### PR TITLE
Session metadata FTS: stable row_id + resumable Unicode external-content index (#25)

### DIFF
--- a/docs/design/session-metadata-fts.md
+++ b/docs/design/session-metadata-fts.md
@@ -91,8 +91,9 @@ decompose + drop combining marks + casefold) instead of SQLite's ASCII-only
 (`_fts_query_positive_terms` — multi-token implicit AND, `OR`, quoted phrases,
 prefix `*`), so `MATCH 'ecole'` finds `École` in the gap and `MATCH 'Alpha
 Project'` finds a gap row titled `Alpha middle Project` exactly as the indexed
-lane would. Terms split on unicode61's token-character set (Unicode letters
-and digits only), so the sanitizer-quoted `[._-]` punctuation is a separator
+lane would. Terms split on unicode61's token-character set — Unicode letters,
+digits, and Private-Use codepoints (categories `L*`, `N*`, `Co`) — so the
+sanitizer-quoted `[._-]` punctuation is a separator
 too: `foo_bar` / `foo-bar` / `foo.bar` all yield the terms (`foo`, `bar`)
 exactly as the index tokenizes a `foo bar` document — a term that kept `_` as
 a literal would MISS a session the FTS lane finds. Boolean operator words

--- a/docs/design/session-metadata-fts.md
+++ b/docs/design/session-metadata-fts.md
@@ -21,6 +21,13 @@ Research context: [`docs/research/issue-32-stable-row-id-unicode-session-fts.md`
    the historical rows are backfilled by the resumable chunk engine, sharing
    the message rebuild's crash-safe claim/repair/finish rules and its single
    monkeypatchable pause helper.
+4. The sessions_fts upgrade is **decoupled from the message-FTS layout**: it
+   runs on BOTH the legacy v22-inline-messages path and the v23 path.
+   `_migrate_sessions_row_id()` rebuilds `sessions` via `DROP TABLE`, which
+   carries away any pre-#25 `sessions_fts_*` triggers with it — so the
+   sessions ensure must not live inside the message `else` branch, or a
+   legacy-message DB would strand the old internal title-only `sessions_fts`
+   with no triggers and no H/P claim.
 
 ## Ownership model
 
@@ -72,13 +79,18 @@ it for non-CJK titles), and `list_sessions_rich(search_query=...)` now also
 matches the raw `display_name` dimension. The existing normalized / infix
 `%LIKE%` fallback is preserved until #30 deliberately replaces it.
 
-Gap semantics match the index: the supplement folds both sides with
-`_fts_unicode61_fold` (Unicode case-fold + diacritic removal, mirroring
-unicode61) instead of SQLite's ASCII-only `LOWER()`, so `MATCH 'ecole'` finds
-`École` in the gap exactly as it does in the index. The merged FTS+gap result
-is sorted globally by `started_at DESC` (never lane-then-gap), which is what
-`resolve_session_by_title` relies on to resume the latest continuation. The
-helper returns `(fts_ok, candidates)`: when the `sessions_fts` MATCH lane
+Gap semantics approximate the index conservatively: the supplement folds both
+sides with `_fts_unicode61_fold` (NFKD decompose + drop combining marks +
+casefold) instead of SQLite's ASCII-only `LOWER()`, so `MATCH 'ecole'` finds
+`École` in the gap as it does in the index. This is deliberately a
+conservative Unicode approximation, NOT exact unicode61 parity (the real
+tokenizer folds per Unicode 6.1, strips Latin-script diacritics, and preserves
+single-codepoint multi-diacritic characters such as `ộ`), so the gap lane can
+produce a temporary false positive that disappears after backfill — accepted,
+because #25's core risk is migration MISSING a result. The merged FTS+gap
+result is sorted globally by `started_at DESC` (never lane-then-gap), which is
+what `resolve_session_by_title` relies on to resume the latest continuation.
+The helper returns `(fts_ok, candidates)`: when the `sessions_fts` MATCH lane
 itself fails, `fts_ok` is False so title resolution falls back to the LIKE
 lane instead of trusting a partial result.
 
@@ -93,8 +105,10 @@ lane instead of trusting a partial result.
   `_session_fts_rebuild_gap`, `_fts_unicode61_fold`, `_fts_metadata_candidates`
   (returns `(fts_ok, candidates)` sorted globally), updated
   `_fts_numbered_variants`.
-- `hermes_state_schema.py` — `_init_schema` wiring (the `fts_storage_version`
-  stamp stays message-scoped; unified storage-version settlement is #27).
+- `hermes_state_schema.py` — `_init_schema` wiring: the sessions-FTS block is
+  placed OUTSIDE the message legacy/`else` branch so it runs for every message
+  layout (the `fts_storage_version` stamp stays message-scoped; unified
+  storage-version settlement is #27).
 - `hermes_state_search.py` — shared `_FTS_MESSAGE_SPEC` / `_FTS_SESSION_SPEC`,
   parameterized `fts_rebuild_status/step`, `_fts_rebuild_finish`,
   `_seed_fts_rebuild_markers`, `_repair_missing_progress` (the shared crash-safe
@@ -105,7 +119,9 @@ lane instead of trusting a partial result.
   pending in offline recovery.
 - `tests/test_session_metadata_fts.py` — rowid-hole migration (incl. legacy
   duplicate-title upgrade), raw Unicode external-content, H/P ownership
-  regions, crash/restart, bounded-gap search (incl. Unicode-fold parity and
-  cross-lane ordering), finish, delete probes that read the index directly and
-  a `rank=1` consistency check on completed indexes, two real concurrent
-  runners (thread + barrier), shared throttle.
+  regions, crash/restart, bounded-gap search (incl. conservative Unicode-fold
+  supplement and its explicit non-parity edge, cross-lane ordering), finish,
+  delete probes that read the index directly and a `rank=1` consistency check
+  on completed indexes, two real concurrent runners (thread + barrier), shared
+  throttle, and a legacy-message × old-session-FTS cross-layout upgrade path
+  (one optimize settles both).

--- a/docs/design/session-metadata-fts.md
+++ b/docs/design/session-metadata-fts.md
@@ -1,0 +1,93 @@
+# Session metadata FTS (#25) — stable `row_id` + resumable Unicode external-content index
+
+Status: **implemented on `fts/session-row-id-unicode-migration`** (fork #25).
+
+This documents the architecture shipped by #25 and the invariants later tickets
+(#26 CJK, #27 unified lifecycle/storage settlement, #30 normalized trigram) build on.
+Research context: [`docs/research/issue-32-stable-row-id-unicode-session-fts.md`](../research/issue-32-stable-row-id-unicode-session-fts.md).
+
+## What changed
+
+1. `sessions` gained a named `row_id INTEGER PRIMARY KEY AUTOINCREMENT` while
+   `id TEXT NOT NULL UNIQUE` stays the logical/public identity. Legacy hidden
+   `rowid` values are copied verbatim into `row_id` (deleted-row holes
+   preserved), in one `BEGIN IMMEDIATE` transaction.
+2. `sessions_fts` is now **external-content** over the raw canonical
+   `(title, id, display_name)` tuple, keyed by `content_rowid='row_id'`,
+   `tokenize='unicode61'`. No normalization or synthetic concatenation
+   (that is #30's scope).
+3. Startup no longer runs a blocking one-shot Unicode backfill. It stages a
+   durable H/P claim (`fts_session_rebuild_high_water` / `..._progress`) and
+   the historical rows are backfilled by the resumable chunk engine, sharing
+   the message rebuild's crash-safe claim/repair/finish rules and its single
+   monkeypatchable pause helper.
+
+## Ownership model
+
+A session's `row_id` determines who may touch its FTS document while a rebuild
+is pending:
+
+```mermaid
+flowchart LR
+    subgraph regions["row_id regions during rebuild (H = high water, P = progress)"]
+        L["row_id <= P<br/>already backfilled<br/>triggers maintain FTS"]
+        G["(P, H]<br/>historical worker owns it<br/>triggers leave it alone<br/>search supplements it"]
+        R["row_id > H<br/>live row<br/>inserted after capture<br/>trigger indexes immediately"]
+    end
+```
+
+The live triggers gate on `row_id > H OR row_id <= P`; when no rebuild is
+pending both markers are absent and `COALESCE(..., -1)` makes the gate a
+tautology (normal operation). This makes every existing canonical
+session-delete path correct without a second manual FTS delete path:
+
+- deleting `<= P` removes the already-indexed document;
+- deleting `(P, H]` issues no external-content delete (the document was never
+  indexed) and the later range backfill simply finds no canonical row;
+- deleting `> H` removes the live-indexed document.
+
+## Crash-safe H/P rebuild
+
+Reuses the accepted message-FTS seam (upstream #76832):
+
+- durable claim is committed **before** an empty external index can look
+  complete;
+- `H` present / `P` missing never replays from zero over a maybe-partial index:
+  either a proven boundary is recovered or the index is reset known-empty
+  (`'delete-all'`) first;
+- each chunk claims `(P, min(P + _FTS_REBUILD_CHUNK_ROWS, H)]` and publishes
+  progress in the same `BEGIN IMMEDIATE` transaction (crash-atomic, and two
+  concurrent runners interleave disjoint chunks);
+- finish runs a narrow docsize anti-join boundary sweep before clearing the
+  markers.
+
+## Search during migration
+
+`_fts_metadata_candidates(raw_query)` is the raw Unicode lane over
+`(title, id, display_name)`. While the backfill is pending it supplements only
+the bounded gap `(P, H]` from canonical rows and deduplicates by `row_id`, so
+migration never silently hides a matching session. The existing normalized /
+infix `%LIKE%` fallback in `list_sessions_rich(search_query=...)` is preserved
+unchanged until #30 deliberately replaces it.
+
+## Files
+
+- `hermes_state_common.py` — `SESSIONS_FTS_SQL` (external DDL + gated narrow
+  triggers), `SESSION_TABLE_REBUILD_SQL` / `SESSION_INDEX_SQL_STATEMENTS`,
+  `FTS_STORAGE_VERSION = 2`.
+- `hermes_state.py` — `_migrate_sessions_row_id`, `_ensure_sessions_fts_schema`,
+  `_db_has_internal_content_sessions_fts`, `_backfill_sessions_fts_cjk`,
+  `_session_fts_rebuild_gap`, `_fts_metadata_candidates`, updated
+  `_fts_numbered_variants`.
+- `hermes_state_schema.py` — `_init_schema` wiring, `fts_storage_version`
+  stamp requires session-settled.
+- `hermes_state_search.py` — shared `_FTS_MESSAGE_SPEC` / `_FTS_SESSION_SPEC`,
+  parameterized `fts_rebuild_status/step`, `_fts_rebuild_finish`,
+  `_seed_fts_rebuild_markers`, `_repair_optimize_bookkeeping`,
+  `_fts_rebuild_pause`, session wrappers + `_repair_session_fts_bookkeeping`,
+  `fts_optimize_available` / `optimize_fts_storage` session phase.
+- `hermes_cli/session_recovery.py` — session markers treated as generated /
+  pending in offline recovery.
+- `tests/test_session_metadata_fts.py` — rowid-hole migration, raw Unicode
+  external-content, H/P ownership regions, crash/restart, bounded-gap search +
+  finish, concurrency + shared throttle.

--- a/docs/design/session-metadata-fts.md
+++ b/docs/design/session-metadata-fts.md
@@ -66,26 +66,28 @@ Reuses the accepted message-FTS seam (upstream #76832):
 `_fts_metadata_candidates(raw_query)` is the raw Unicode lane over
 `(title, id, display_name)`. While the backfill is pending it supplements only
 the bounded gap `(P, H]` from canonical rows and deduplicates by `row_id`, so
-migration never silently hides a matching session. The existing normalized /
-infix `%LIKE%` fallback in `list_sessions_rich(search_query=...)` is preserved
-unchanged until #30 deliberately replaces it.
+migration never silently hides a matching session. It is wired into the
+production title-lineage resolution path (`_fts_numbered_variants` delegates to
+it for non-CJK titles), and `list_sessions_rich(search_query=...)` now also
+matches the raw `display_name` dimension. The existing normalized / infix
+`%LIKE%` fallback is preserved until #30 deliberately replaces it.
 
 ## Files
 
 - `hermes_state_common.py` — `SESSIONS_FTS_SQL` (external DDL + gated narrow
-  triggers), `SESSION_TABLE_REBUILD_SQL` / `SESSION_INDEX_SQL_STATEMENTS`,
-  `FTS_STORAGE_VERSION = 2`.
+  triggers), `SESSION_TABLE_REBUILD_SQL` / `SESSION_INDEX_SQL_STATEMENTS`.
 - `hermes_state.py` — `_migrate_sessions_row_id`, `_ensure_sessions_fts_schema`,
   `_db_has_internal_content_sessions_fts`, `_backfill_sessions_fts_cjk`,
   `_session_fts_rebuild_gap`, `_fts_metadata_candidates`, updated
   `_fts_numbered_variants`.
-- `hermes_state_schema.py` — `_init_schema` wiring, `fts_storage_version`
-  stamp requires session-settled.
+- `hermes_state_schema.py` — `_init_schema` wiring (the `fts_storage_version`
+  stamp stays message-scoped; unified storage-version settlement is #27).
 - `hermes_state_search.py` — shared `_FTS_MESSAGE_SPEC` / `_FTS_SESSION_SPEC`,
   parameterized `fts_rebuild_status/step`, `_fts_rebuild_finish`,
-  `_seed_fts_rebuild_markers`, `_repair_optimize_bookkeeping`,
-  `_fts_rebuild_pause`, session wrappers + `_repair_session_fts_bookkeeping`,
-  `fts_optimize_available` / `optimize_fts_storage` session phase.
+  `_seed_fts_rebuild_markers`, `_repair_missing_progress` (the shared crash-safe
+  repair), `_repair_optimize_bookkeeping` / `_repair_session_fts_bookkeeping`,
+  `_fts_rebuild_pause`, `fts_optimize_available` / `optimize_fts_storage`
+  session phase.
 - `hermes_cli/session_recovery.py` — session markers treated as generated /
   pending in offline recovery.
 - `tests/test_session_metadata_fts.py` — rowid-hole migration, raw Unicode

--- a/docs/design/session-metadata-fts.md
+++ b/docs/design/session-metadata-fts.md
@@ -64,14 +64,19 @@ Reuses the accepted message-FTS seam (upstream #76832):
   construction, and an `H=0/P=0` pair would never enter the rebuild (status
   total ≤ 0) yet would leave `optimize_fts_storage` permanently pending as
   `backfill_incomplete`;
-- after the new external table + gated triggers are ensured, a **transition
-  catch-up** runs in its own `BEGIN IMMEDIATE` (a `>H OR <=P` insert with a
-  docsize anti-join): a concurrent writer can commit a `>H` row in the window
-  between the stage transaction's COMMIT and the trigger install, and that
-  row is neither trigger-indexed nor in the `(P,H]` gap supplement — the
-  catch-up closes the window (idempotent; rows committing after it are
-  trigger-indexed). Applies to both the internal→external conversion and the
-  fresh-create-over-populated path;
+- when the external table is created, the schema install (CREATE VIRTUAL
+  TABLE + the three gated triggers) AND the **transition catch-up** land in
+  ONE crash-atomic `BEGIN IMMEDIATE` (DDL executed statement-by-statement —
+  `executescript`'s implicit COMMIT would break the transaction). The
+  catch-up is a `>H OR <=P` insert with a docsize anti-join whose predicate
+  uses `COALESCE(H, -1)` / `COALESCE(P, -1)`, so it also covers the
+  no-marker (empty / complete) case: with no markers every `row_id > -1` is
+  trigger-owned, catching an empty DB's first window row too. This closes the
+  trigger-free window (a concurrent writer committed after the stage
+  transaction released the lock but before the triggers existed is caught
+  up; a crash mid-transition rolls back schema + catch-up together and the
+  reopen re-runs it). Applies to both the internal→external conversion and
+  the fresh-create-over-populated path;
 - `H` present / `P` missing never replays from zero over a maybe-partial index:
   either a proven boundary is recovered or the index is reset known-empty
   (`'delete-all'`) first;
@@ -153,8 +158,9 @@ lane instead of trusting a partial result.
 - `tests/test_session_metadata_fts.py` — rowid-hole migration (incl. legacy
   duplicate-title upgrade), raw Unicode external-content, H/P ownership
   regions, crash/restart (incl. the partial-index H-without-P orphan
-  reset/replay regression), the trigger-install window race (two-connection
-  catch-up regressions for both the internal→external and fresh-create paths),
+  reset/replay regression), the crash-atomic schema+catch-up transition
+  (two-connection window regressions for the internal→external, fresh-create,
+  empty-first-row, and populated crash-reopen paths),
   bounded-gap search (conservative Unicode-fold supplement + its explicit
   non-parity edge, multi-token implicit-AND and OR no-hide regressions,
   sanitizer-quoted `[._-]` punctuation + quoted-boolean + PUA/U+1018C

--- a/docs/design/session-metadata-fts.md
+++ b/docs/design/session-metadata-fts.md
@@ -64,6 +64,14 @@ Reuses the accepted message-FTS seam (upstream #76832):
   construction, and an `H=0/P=0` pair would never enter the rebuild (status
   total ≤ 0) yet would leave `optimize_fts_storage` permanently pending as
   `backfill_incomplete`;
+- after the new external table + gated triggers are ensured, a **transition
+  catch-up** runs in its own `BEGIN IMMEDIATE` (a `>H OR <=P` insert with a
+  docsize anti-join): a concurrent writer can commit a `>H` row in the window
+  between the stage transaction's COMMIT and the trigger install, and that
+  row is neither trigger-indexed nor in the `(P,H]` gap supplement — the
+  catch-up closes the window (idempotent; rows committing after it are
+  trigger-indexed). Applies to both the internal→external conversion and the
+  fresh-create-over-populated path;
 - `H` present / `P` missing never replays from zero over a maybe-partial index:
   either a proven boundary is recovered or the index is reset known-empty
   (`'delete-all'`) first;
@@ -91,9 +99,14 @@ decompose + drop combining marks + casefold) instead of SQLite's ASCII-only
 (`_fts_query_positive_terms` — multi-token implicit AND, `OR`, quoted phrases,
 prefix `*`), so `MATCH 'ecole'` finds `École` in the gap and `MATCH 'Alpha
 Project'` finds a gap row titled `Alpha middle Project` exactly as the indexed
-lane would. Terms split on unicode61's token-character set — Unicode letters,
-digits, and Private-Use codepoints (categories `L*`, `N*`, `Co`) — so the
-sanitizer-quoted `[._-]` punctuation is a separator
+lane would. Terms split on an ASCII-only separator boundary (unicode61 always
+treats ASCII non-alphanumerics — whitespace, punctuation, notably `_` — as
+separators); every non-ASCII character is kept inside terms, because Python's
+`unicodedata` cannot mirror SQLite's unicode61 (Unicode 6.1) — e.g. U+1018C
+is a token char in unicode61 but category `So` in Python, so excluding by
+category would risk a miss. Non-ASCII runs also emit each ASCII sub-run and
+each non-ASCII codepoint, so a query unicode61 tokenizes more finely cannot
+miss either. The sanitizer-quoted `[._-]` punctuation is a separator
 too: `foo_bar` / `foo-bar` / `foo.bar` all yield the terms (`foo`, `bar`)
 exactly as the index tokenizes a `foo bar` document — a term that kept `_` as
 a literal would MISS a session the FTS lane finds. Boolean operator words
@@ -139,11 +152,15 @@ lane instead of trusting a partial result.
   pending in offline recovery.
 - `tests/test_session_metadata_fts.py` — rowid-hole migration (incl. legacy
   duplicate-title upgrade), raw Unicode external-content, H/P ownership
-  regions, crash/restart, bounded-gap search (conservative Unicode-fold
-  supplement + its explicit non-parity edge, multi-token implicit-AND and OR
-  no-hide regressions, sanitizer-quoted `[._-]` punctuation no-hide
-  regression, cross-lane ordering), finish, delete probes that read the index
-  directly and a `rank=1` consistency check on completed indexes, two real
-  concurrent runners (thread + barrier), shared throttle, and a
-  legacy-message × old-session-FTS cross-layout upgrade path (one optimize
-  settles both) plus the empty-legacy-DB no-zombie-marker path.
+  regions, crash/restart (incl. the partial-index H-without-P orphan
+  reset/replay regression), the trigger-install window race (two-connection
+  catch-up regressions for both the internal→external and fresh-create paths),
+  bounded-gap search (conservative Unicode-fold supplement + its explicit
+  non-parity edge, multi-token implicit-AND and OR no-hide regressions,
+  sanitizer-quoted `[._-]` punctuation + quoted-boolean + PUA/U+1018C
+  no-hide regressions, cross-lane ordering), finish, delete probes that read
+  the index directly plus an ordinary internal integrity-check mid-migration
+  and a `rank=1` consistency check on completed indexes, two real concurrent
+  runners (thread + barrier), shared throttle, and a legacy-message ×
+  old-session-FTS cross-layout upgrade path (one optimize settles both) plus
+  the empty-legacy-DB no-zombie-marker path.

--- a/docs/design/session-metadata-fts.md
+++ b/docs/design/session-metadata-fts.md
@@ -72,13 +72,26 @@ it for non-CJK titles), and `list_sessions_rich(search_query=...)` now also
 matches the raw `display_name` dimension. The existing normalized / infix
 `%LIKE%` fallback is preserved until #30 deliberately replaces it.
 
+Gap semantics match the index: the supplement folds both sides with
+`_fts_unicode61_fold` (Unicode case-fold + diacritic removal, mirroring
+unicode61) instead of SQLite's ASCII-only `LOWER()`, so `MATCH 'ecole'` finds
+`École` in the gap exactly as it does in the index. The merged FTS+gap result
+is sorted globally by `started_at DESC` (never lane-then-gap), which is what
+`resolve_session_by_title` relies on to resume the latest continuation. The
+helper returns `(fts_ok, candidates)`: when the `sessions_fts` MATCH lane
+itself fails, `fts_ok` is False so title resolution falls back to the LIKE
+lane instead of trusting a partial result.
+
 ## Files
 
 - `hermes_state_common.py` — `SESSIONS_FTS_SQL` (external DDL + gated narrow
-  triggers), `SESSION_TABLE_REBUILD_SQL` / `SESSION_INDEX_SQL_STATEMENTS`.
+  triggers), `SESSION_TABLE_REBUILD_SQL` / `SESSION_INDEX_SQL_STATEMENTS`
+  (the unique title index is deliberately excluded: the existing post-migration
+  duplicate-title repair owns it).
 - `hermes_state.py` — `_migrate_sessions_row_id`, `_ensure_sessions_fts_schema`,
   `_db_has_internal_content_sessions_fts`, `_backfill_sessions_fts_cjk`,
-  `_session_fts_rebuild_gap`, `_fts_metadata_candidates`, updated
+  `_session_fts_rebuild_gap`, `_fts_unicode61_fold`, `_fts_metadata_candidates`
+  (returns `(fts_ok, candidates)` sorted globally), updated
   `_fts_numbered_variants`.
 - `hermes_state_schema.py` — `_init_schema` wiring (the `fts_storage_version`
   stamp stays message-scoped; unified storage-version settlement is #27).
@@ -90,6 +103,9 @@ matches the raw `display_name` dimension. The existing normalized / infix
   session phase.
 - `hermes_cli/session_recovery.py` — session markers treated as generated /
   pending in offline recovery.
-- `tests/test_session_metadata_fts.py` — rowid-hole migration, raw Unicode
-  external-content, H/P ownership regions, crash/restart, bounded-gap search +
-  finish, concurrency + shared throttle.
+- `tests/test_session_metadata_fts.py` — rowid-hole migration (incl. legacy
+  duplicate-title upgrade), raw Unicode external-content, H/P ownership
+  regions, crash/restart, bounded-gap search (incl. Unicode-fold parity and
+  cross-lane ordering), finish, delete probes that read the index directly and
+  a `rank=1` consistency check on completed indexes, two real concurrent
+  runners (thread + barrier), shared throttle.

--- a/docs/design/session-metadata-fts.md
+++ b/docs/design/session-metadata-fts.md
@@ -91,8 +91,12 @@ decompose + drop combining marks + casefold) instead of SQLite's ASCII-only
 (`_fts_query_positive_terms` — multi-token implicit AND, `OR`, quoted phrases,
 prefix `*`), so `MATCH 'ecole'` finds `École` in the gap and `MATCH 'Alpha
 Project'` finds a gap row titled `Alpha middle Project` exactly as the indexed
-lane would. Over-matching is accepted (the backfilled index restores exact
-semantics); a MISS is not. The fold is deliberately a conservative Unicode
+lane would. Terms split on unicode61's token-character set (Unicode letters
+and digits only), so the sanitizer-quoted `[._-]` punctuation is a separator
+too: `foo_bar` / `foo-bar` / `foo.bar` all yield the terms (`foo`, `bar`)
+exactly as the index tokenizes a `foo bar` document — a term that kept `_` as
+a literal would MISS a session the FTS lane finds. Over-matching is accepted
+(the backfilled index restores exact semantics); a MISS is not. The fold is deliberately a conservative Unicode
 approximation, NOT exact unicode61 parity (the real tokenizer folds per
 Unicode 6.1, strips Latin-script diacritics, and preserves single-codepoint
 multi-diacritic characters such as `ộ`), so the gap lane can produce a
@@ -132,8 +136,9 @@ lane instead of trusting a partial result.
   duplicate-title upgrade), raw Unicode external-content, H/P ownership
   regions, crash/restart, bounded-gap search (conservative Unicode-fold
   supplement + its explicit non-parity edge, multi-token implicit-AND and OR
-  no-hide regressions, cross-lane ordering), finish, delete probes that read
-  the index directly and a `rank=1` consistency check on completed indexes,
-  two real concurrent runners (thread + barrier), shared throttle, and a
+  no-hide regressions, sanitizer-quoted `[._-]` punctuation no-hide
+  regression, cross-lane ordering), finish, delete probes that read the index
+  directly and a `rank=1` consistency check on completed indexes, two real
+  concurrent runners (thread + barrier), shared throttle, and a
   legacy-message × old-session-FTS cross-layout upgrade path (one optimize
   settles both) plus the empty-legacy-DB no-zombie-marker path.

--- a/docs/design/session-metadata-fts.md
+++ b/docs/design/session-metadata-fts.md
@@ -95,7 +95,11 @@ lane would. Terms split on unicode61's token-character set (Unicode letters
 and digits only), so the sanitizer-quoted `[._-]` punctuation is a separator
 too: `foo_bar` / `foo-bar` / `foo.bar` all yield the terms (`foo`, `bar`)
 exactly as the index tokenizes a `foo bar` document — a term that kept `_` as
-a literal would MISS a session the FTS lane finds. Over-matching is accepted
+a literal would MISS a session the FTS lane finds. Boolean operator words
+(`and`/`or`/`not`/`near`) are deliberately kept as terms too: a quoted
+`"AND"` is a literal FTS phrase (the sanitizer protects balanced quotes), so
+stripping them would empty the terms for that query and hide a matched row —
+keeping them can only over-match, never miss. Over-matching is accepted
 (the backfilled index restores exact semantics); a MISS is not. The fold is deliberately a conservative Unicode
 approximation, NOT exact unicode61 parity (the real tokenizer folds per
 Unicode 6.1, strips Latin-script diacritics, and preserves single-codepoint

--- a/docs/design/session-metadata-fts.md
+++ b/docs/design/session-metadata-fts.md
@@ -59,6 +59,11 @@ Reuses the accepted message-FTS seam (upstream #76832):
 
 - durable claim is committed **before** an empty external index can look
   complete;
+- an internal→external conversion over a DB with **zero sessions** stages no
+  claim at all (and clears any stale one): the index is complete by
+  construction, and an `H=0/P=0` pair would never enter the rebuild (status
+  total ≤ 0) yet would leave `optimize_fts_storage` permanently pending as
+  `backfill_incomplete`;
 - `H` present / `P` missing never replays from zero over a maybe-partial index:
   either a proven boundary is recovered or the index is reset known-empty
   (`'delete-all'`) first;
@@ -79,18 +84,23 @@ it for non-CJK titles), and `list_sessions_rich(search_query=...)` now also
 matches the raw `display_name` dimension. The existing normalized / infix
 `%LIKE%` fallback is preserved until #30 deliberately replaces it.
 
-Gap semantics approximate the index conservatively: the supplement folds both
-sides with `_fts_unicode61_fold` (NFKD decompose + drop combining marks +
-casefold) instead of SQLite's ASCII-only `LOWER()`, so `MATCH 'ecole'` finds
-`École` in the gap as it does in the index. This is deliberately a
-conservative Unicode approximation, NOT exact unicode61 parity (the real
-tokenizer folds per Unicode 6.1, strips Latin-script diacritics, and preserves
-single-codepoint multi-diacritic characters such as `ộ`), so the gap lane can
-produce a temporary false positive that disappears after backfill — accepted,
-because #25's core risk is migration MISSING a result. The merged FTS+gap
-result is sorted globally by `started_at DESC` (never lane-then-gap), which is
-what `resolve_session_by_title` relies on to resume the latest continuation.
-The helper returns `(fts_ok, candidates)`: when the `sessions_fts` MATCH lane
+Gap semantics approximate the index conservatively as a **superset of the FTS
+predicate**: the supplement folds both sides with `_fts_unicode61_fold` (NFKD
+decompose + drop combining marks + casefold) instead of SQLite's ASCII-only
+`LOWER()`, and matches on ANY positive term extracted from the query
+(`_fts_query_positive_terms` — multi-token implicit AND, `OR`, quoted phrases,
+prefix `*`), so `MATCH 'ecole'` finds `École` in the gap and `MATCH 'Alpha
+Project'` finds a gap row titled `Alpha middle Project` exactly as the indexed
+lane would. Over-matching is accepted (the backfilled index restores exact
+semantics); a MISS is not. The fold is deliberately a conservative Unicode
+approximation, NOT exact unicode61 parity (the real tokenizer folds per
+Unicode 6.1, strips Latin-script diacritics, and preserves single-codepoint
+multi-diacritic characters such as `ộ`), so the gap lane can produce a
+temporary false positive that disappears after backfill — accepted, because
+#25's core risk is migration MISSING a result. The merged FTS+gap result is
+sorted globally by `started_at DESC` (never lane-then-gap), which is what
+`resolve_session_by_title` relies on to resume the latest continuation. The
+helper returns `(fts_ok, candidates)`: when the `sessions_fts` MATCH lane
 itself fails, `fts_ok` is False so title resolution falls back to the LIKE
 lane instead of trusting a partial result.
 
@@ -102,8 +112,9 @@ lane instead of trusting a partial result.
   duplicate-title repair owns it).
 - `hermes_state.py` — `_migrate_sessions_row_id`, `_ensure_sessions_fts_schema`,
   `_db_has_internal_content_sessions_fts`, `_backfill_sessions_fts_cjk`,
-  `_session_fts_rebuild_gap`, `_fts_unicode61_fold`, `_fts_metadata_candidates`
-  (returns `(fts_ok, candidates)` sorted globally), updated
+  `_session_fts_rebuild_gap`, `_fts_unicode61_fold`, `_fts_query_positive_terms`,
+  `_fts_metadata_candidates` (returns `(fts_ok, candidates)` sorted globally;
+  the gap supplement is a term-superset of the FTS predicate), updated
   `_fts_numbered_variants`.
 - `hermes_state_schema.py` — `_init_schema` wiring: the sessions-FTS block is
   placed OUTSIDE the message legacy/`else` branch so it runs for every message
@@ -119,9 +130,10 @@ lane instead of trusting a partial result.
   pending in offline recovery.
 - `tests/test_session_metadata_fts.py` — rowid-hole migration (incl. legacy
   duplicate-title upgrade), raw Unicode external-content, H/P ownership
-  regions, crash/restart, bounded-gap search (incl. conservative Unicode-fold
-  supplement and its explicit non-parity edge, cross-lane ordering), finish,
-  delete probes that read the index directly and a `rank=1` consistency check
-  on completed indexes, two real concurrent runners (thread + barrier), shared
-  throttle, and a legacy-message × old-session-FTS cross-layout upgrade path
-  (one optimize settles both).
+  regions, crash/restart, bounded-gap search (conservative Unicode-fold
+  supplement + its explicit non-parity edge, multi-token implicit-AND and OR
+  no-hide regressions, cross-lane ordering), finish, delete probes that read
+  the index directly and a `rank=1` consistency check on completed indexes,
+  two real concurrent runners (thread + barrier), shared throttle, and a
+  legacy-message × old-session-FTS cross-layout upgrade path (one optimize
+  settles both) plus the empty-legacy-DB no-zombie-marker path.

--- a/hermes_cli/session_recovery.py
+++ b/hermes_cli/session_recovery.py
@@ -55,6 +55,10 @@ _GENERATED_META_KEYS = frozenset({
     "fts_cjk_stale",
     "fts_cjk_rebuild_high_water",
     "fts_cjk_rebuild_progress",
+    # Session Unicode metadata rebuild markers (issue #25) - generated from
+    # the current schema on a fresh destination, never copied.
+    "fts_session_rebuild_high_water",
+    "fts_session_rebuild_progress",
     "telegram_dm_topic_schema_version",
 })
 
@@ -1104,6 +1108,8 @@ def _verify_recovered_database(
                 "fts_cjk_stale",
                 "fts_cjk_rebuild_high_water",
                 "fts_cjk_rebuild_progress",
+                "fts_session_rebuild_high_water",
+                "fts_session_rebuild_progress",
             )
             if key in meta
         )

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -27,6 +27,7 @@ import sqlite3
 import sys
 import threading
 import time
+import unicodedata
 from collections import deque
 from contextlib import contextmanager
 from pathlib import Path
@@ -137,6 +138,28 @@ def _compression_lock_holder_process_is_dead(holder: str) -> bool:
     except (PermissionError, OSError, OverflowError):
         return False
     return False
+
+
+def _fts_unicode61_fold(text: Optional[str]) -> str:
+    """Fold ``text`` the way FTS5's unicode61 tokenizer folds before indexing.
+
+    unicode61 applies Unicode case folding and, by default, removes diacritics
+    from Latin scripts, so ``École`` indexes as ``ecole`` and matches both
+    ``MATCH 'école'`` and ``MATCH 'ecole'``. The #25 bounded-gap supplement
+    must match the same queries the index does (otherwise a session searchable
+    at ``<= P`` silently vanishes while it sits in ``(P, H]``), so it folds
+    with the same rules instead of SQLite's ASCII-only ``LOWER()``.
+
+    This is a close approximation of SQLite's internal folding for Latin
+    scripts (NFKD-decompose, drop combining marks, casefold) — the gap lane is
+    a temporary migration fallback, not the authoritative index.
+    """
+    text = text or ""
+    decomposed = unicodedata.normalize("NFKD", text)
+    stripped = "".join(
+        ch for ch in decomposed if unicodedata.category(ch) != "Mn"
+    )
+    return stripped.casefold()
 
 
 def _scrub_surrogates(value: Any) -> Any:
@@ -5656,35 +5679,50 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             return None
         return progress, high_water
 
-    def _fts_metadata_candidates(self, raw_query: str) -> List[Dict[str, Any]]:
+    def _fts_metadata_candidates(
+        self, raw_query: str
+    ) -> Tuple[bool, List[Dict[str, Any]]]:
         """Raw Unicode session-metadata candidates matching ``raw_query``.
 
         Covers title, logical session id, and display_name (issue #25) via the
         external-content ``sessions_fts``. While the #25 backfill is pending,
         the bounded historical gap ``(P, H]`` is supplemented from canonical
-        rows over the same raw-substring dimensions and deduplicated by
-        ``row_id``, so migration never silently hides matching sessions:
-        rows ``<= P`` are already indexed, rows ``> H`` are live-indexed, and
-        only ``(P, H]`` is supplemented.
+        rows and deduplicated by ``row_id``, so migration never silently hides
+        matching sessions: rows ``<= P`` are already indexed, rows ``> H`` are
+        live-indexed, and only ``(P, H]`` is supplemented.
 
-        Returns a list of dicts (``id``, ``title``, ``display_name``,
-        ``started_at``, ``row_id``). Raw Unicode only — no normalization
-        policy (normalized arbitrary infix is owned by #30).
+        Returns ``(fts_ok, candidates)`` — ``fts_ok`` is False when the
+        ``sessions_fts`` MATCH lane itself failed (table unavailable /
+        corrupt), so callers can fall back to the LIKE lane instead of
+        trusting a partial result; candidates is a list of dicts (``id``,
+        ``title``, ``display_name``, ``started_at``, ``row_id``) merged from
+        both lanes and sorted ``started_at DESC`` (the resume-ordering that
+        ``resolve_session_by_title`` relies on — never a lane-then-gap
+        concatenation). Raw Unicode only — no normalization policy
+        (normalized arbitrary infix is owned by #30).
+
+        The gap supplement folds values with ``_fts_unicode61_fold`` — the
+        same case-fold + diacritic-removal the unicode61 tokenizer applies —
+        so ``MATCH 'ecole'`` finds ``École`` in the gap exactly as it does in
+        the index. SQLite's ``LOWER()`` only folds ASCII and would make a gap
+        row vanish/reappear across the backfill boundary.
         """
         sanitized = self._sanitize_fts5_query(raw_query)
         if not sanitized:
-            return []
-        # The gap supplement folds columns with LOWER(...) LIKE, so the needle
-        # must be lowercased too (SQLite's LIKE is case-insensitive for ASCII
-        # only, so folding both sides is required for non-ASCII match parity
-        # with the case-insensitive unicode61 FTS lane).
-        escaped = (
-            raw_query.lower()
-            .replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
-        )
-        needle = f"%{escaped}%"
+            return True, []
+        needle = _fts_unicode61_fold(raw_query)
         gap = self._session_fts_rebuild_gap()
+        fts_ok = True
         by_row_id: Dict[int, Dict[str, Any]] = {}
+
+        def _candidate(c) -> Dict[str, Any]:
+            return {
+                "id": c["id"],
+                "title": c["title"],
+                "display_name": c["display_name"],
+                "started_at": c["started_at"],
+                "row_id": c["row_id"],
+            }
 
         with self._read_ctx() as conn:
             try:
@@ -5693,22 +5731,16 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     "       s.started_at, s.row_id AS row_id "
                     "FROM sessions_fts f "
                     "JOIN sessions s ON s.row_id = f.rowid "
-                    "WHERE sessions_fts MATCH ? "
-                    "ORDER BY s.started_at DESC",
+                    "WHERE sessions_fts MATCH ? ",
                     (sanitized,),
                 )
                 for c in cursor:
-                    by_row_id[c["row_id"]] = {
-                        "id": c["id"],
-                        "title": c["title"],
-                        "display_name": c["display_name"],
-                        "started_at": c["started_at"],
-                        "row_id": c["row_id"],
-                    }
+                    by_row_id[c["row_id"]] = _candidate(c)
             except sqlite3.OperationalError:
-                # FTS lane unavailable for this query — the gap supplement
-                # below still runs; the rest falls back to the legacy LIKE
-                # lane where the caller provides one.
+                # FTS lane unavailable/corrupt: signal failure so callers can
+                # fall back to the LIKE lane instead of trusting a partial
+                # result; the gap supplement below still runs.
+                fts_ok = False
                 logging.debug(
                     "sessions_fts MATCH failed for %r", sanitized, exc_info=True,
                 )
@@ -5717,22 +5749,22 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 gap_rows = conn.execute(
                     "SELECT id, title, display_name, started_at, row_id "
                     "FROM sessions "
-                    "WHERE row_id > ? AND row_id <= ? "
-                    "AND (LOWER(COALESCE(title, '')) LIKE ? ESCAPE '\\' "
-                    "  OR LOWER(COALESCE(id, '')) LIKE ? ESCAPE '\\' "
-                    "  OR LOWER(COALESCE(display_name, '')) LIKE ? ESCAPE '\\') "
-                    "ORDER BY started_at DESC",
-                    (progress, high_water, needle, needle, needle),
+                    "WHERE row_id > ? AND row_id <= ? ",
+                    (progress, high_water),
                 ).fetchall()
                 for c in gap_rows:
-                    by_row_id.setdefault(c["row_id"], {
-                        "id": c["id"],
-                        "title": c["title"],
-                        "display_name": c["display_name"],
-                        "started_at": c["started_at"],
-                        "row_id": c["row_id"],
-                    })
-        return list(by_row_id.values())
+                    if (
+                        needle in _fts_unicode61_fold(c["title"])
+                        or needle in _fts_unicode61_fold(c["id"])
+                        or needle in _fts_unicode61_fold(c["display_name"])
+                    ):
+                        by_row_id.setdefault(c["row_id"], _candidate(c))
+        # Global merge ordering, not lane-then-gap: resolve_session_by_title
+        # takes candidates[0] and must resume the LATEST continuation even
+        # when the newer one is still in the gap.
+        return fts_ok, sorted(
+            by_row_id.values(), key=lambda c: c["started_at"], reverse=True
+        )
 
     def _fts_numbered_variants(
         self, title: str
@@ -5812,8 +5844,13 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             return filtered
 
         # Non-CJK: the shared raw Unicode lane already merges the FTS
-        # candidates with the bounded (P, H] gap and dedupes by row_id.
-        candidates = self._fts_metadata_candidates(title)
+        # candidates with the bounded (P, H] gap, dedupes by row_id, and sorts
+        # globally by started_at DESC. When the sessions_fts lane itself
+        # failed, signal fallback to LIKE (None) rather than trusting a
+        # partial result.
+        fts_ok, candidates = self._fts_metadata_candidates(title)
+        if not fts_ok:
+            return None
         if not candidates:
             return candidates
         return [

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -141,18 +141,22 @@ def _compression_lock_holder_process_is_dead(holder: str) -> bool:
 
 
 def _fts_unicode61_fold(text: Optional[str]) -> str:
-    """Fold ``text`` the way FTS5's unicode61 tokenizer folds before indexing.
+    """Fold ``text`` for the #25 bounded-gap search supplement.
 
-    unicode61 applies Unicode case folding and, by default, removes diacritics
-    from Latin scripts, so ``École`` indexes as ``ecole`` and matches both
-    ``MATCH 'école'`` and ``MATCH 'ecole'``. The #25 bounded-gap supplement
-    must match the same queries the index does (otherwise a session searchable
-    at ``<= P`` silently vanishes while it sits in ``(P, H]``), so it folds
-    with the same rules instead of SQLite's ASCII-only ``LOWER()``.
+    The gap lane must match the same query forms the index does, otherwise a
+    session searchable at ``<= P`` silently vanishes while it sits in
+    ``(P, H]`` (SQLite's ASCII-only ``LOWER()`` would hide non-ASCII titles
+    such as ``École``).
 
-    This is a close approximation of SQLite's internal folding for Latin
-    scripts (NFKD-decompose, drop combining marks, casefold) — the gap lane is
-    a temporary migration fallback, not the authoritative index.
+    This is a CONSERVATIVE Unicode normalization APPROXIMATION of FTS5's
+    unicode61 tokenizer (NFKD-decompose, drop all combining marks, casefold),
+    deliberately more permissive than the real tokenizer — which folds per
+    Unicode 6.1, removes diacritics from Latin scripts only, and preserves
+    single-codepoint multi-diacritic characters such as ``ộ``. It is NOT a
+    parity mirror: it can produce a temporary false positive while a row sits
+    in the gap (found here, not matched after backfill). #25's core risk is
+    migration MISSING a result, so a looser gap lane is the safe direction;
+    the authoritative tokenizer governs once the row is backfilled.
     """
     text = text or ""
     decomposed = unicodedata.normalize("NFKD", text)
@@ -5701,11 +5705,13 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         concatenation). Raw Unicode only — no normalization policy
         (normalized arbitrary infix is owned by #30).
 
-        The gap supplement folds values with ``_fts_unicode61_fold`` — the
-        same case-fold + diacritic-removal the unicode61 tokenizer applies —
-        so ``MATCH 'ecole'`` finds ``École`` in the gap exactly as it does in
-        the index. SQLite's ``LOWER()`` only folds ASCII and would make a gap
-        row vanish/reappear across the backfill boundary.
+        The gap supplement folds values with ``_fts_unicode61_fold`` — a
+        conservative Unicode approximation of the unicode61 rules (case fold
+        + diacritic removal, NOT exact parity) — so ``MATCH 'ecole'`` finds
+        ``École`` in the gap as it does in the index, while accepting the
+        loose side (a temporary extra candidate) for multi-diacritic
+        codepoints. SQLite's ``LOWER()`` only folds ASCII and would make a
+        gap row vanish/reappear across the backfill boundary.
         """
         sanitized = self._sanitize_fts5_query(raw_query)
         if not sanitized:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -189,14 +189,18 @@ def _fts_query_positive_terms(raw_query: str) -> List[str]:
     that kept the separator literal (``"foo_bar"``) would MISS a session the
     indexed lane finds. (CJK runs are deliberately left as whole terms here;
     per-codepoint CJK tokenization belongs to the #26 CJK lane.)
+
+    Boolean operator WORDS are deliberately kept as terms. A quoted
+    ``"AND"`` is a literal FTS phrase — the sanitizer protects balanced
+    quotes — so stripping ``AND|OR|NOT|NEAR`` would empty the terms for that
+    query and hide an indexed-matched row from the gap. Because the predicate
+    is ANY-term, keeping them can only add false positives, never a false
+    negative.
     """
-    # Drop FTS5 boolean operators, then map every non-token character —
-    # anything that is not a Unicode letter or digit, including '_' — to a
-    # space (mirrors unicode61's token-character set exactly).
-    cleaned = re.sub(
-        r"\b(?:AND|OR|NOT|NEAR)\b", " ", raw_query, flags=re.IGNORECASE
-    )
-    cleaned = "".join(ch if ch.isalnum() else " " for ch in cleaned)
+    # Map every non-token character — anything that is not a Unicode letter
+    # or digit, including '_' — to a space (mirrors unicode61's
+    # token-character set exactly).
+    cleaned = "".join(ch if ch.isalnum() else " " for ch in raw_query)
     terms: List[str] = []
     for token in cleaned.split():
         folded = _fts_unicode61_fold(token.rstrip("*"))

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -166,6 +166,33 @@ def _fts_unicode61_fold(text: Optional[str]) -> str:
     return stripped.casefold()
 
 
+def _fts_query_positive_terms(raw_query: str) -> List[str]:
+    """Conservative lexical terms for the #25 gap supplement's FTS-superset test.
+
+    The gap lane cannot parse FTS5's full query syntax (implicit AND,
+    OR/NOT, quoted phrases, prefix ``*``). Instead it extracts the words any
+    positive FTS5 match would have to contain and treats each as an
+    independent candidate trigger: ANY term in ANY metadata field → include.
+    This is deliberately a SUPERSET of the FTS predicate — over-matching is
+    accepted (the backfilled index restores exact semantics), but a MISS is
+    not: a session that MATCHes once backfilled must never be hidden while
+    it sits in the ``(P, H]`` gap.
+    """
+    # Drop FTS5 boolean operators, then split on anything that is not a
+    # letter/digit (close enough to unicode61 tokenization for a conservative
+    # superset). Trailing '*' prefix markers fold into the term itself
+    # (substring containment covers prefix matching).
+    cleaned = re.sub(
+        r"\b(?:AND|OR|NOT|NEAR)\b", " ", raw_query, flags=re.IGNORECASE
+    )
+    terms: List[str] = []
+    for token in re.split(r"[^\w]+", cleaned, flags=re.UNICODE):
+        folded = _fts_unicode61_fold(token.rstrip("*"))
+        if folded:
+            terms.append(folded)
+    return terms
+
+
 def _scrub_surrogates(value: Any) -> Any:
     """Replace lone surrogates when *value* is text; pass anything else through.
 
@@ -2459,17 +2486,33 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             # ONE write transaction; the external schema ensure runs after
             # (it uses executescript, which issues an implicit COMMIT).
             def _stage(conn):
-                hw = conn.execute(
+                hw = int(conn.execute(
                     "SELECT COALESCE(MAX(row_id), 0) FROM sessions"
-                ).fetchone()[0]
-                for k, v in (
-                    ("fts_session_rebuild_high_water", str(hw)),
-                    ("fts_session_rebuild_progress", "0"),
-                ):
+                ).fetchone()[0])
+                if hw > 0:
+                    # Historical rows to backfill: stage the durable H/P
+                    # claim (an empty external index is never served as
+                    # complete — the #76832 invariant).
+                    for k, v in (
+                        ("fts_session_rebuild_high_water", str(hw)),
+                        ("fts_session_rebuild_progress", "0"),
+                    ):
+                        conn.execute(
+                            "INSERT INTO state_meta (key, value) VALUES (?, ?) "
+                            "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                            (k, v),
+                        )
+                else:
+                    # Zero sessions: the index is complete by construction, so
+                    # no claim is needed. Also clear any stale markers left by
+                    # an earlier interrupted open — an H=0/P=0 pair would
+                    # never enter the rebuild (status total <= 0 → None) and
+                    # would leave optimize permanently pending as
+                    # ``backfill_incomplete``.
                     conn.execute(
-                        "INSERT INTO state_meta (key, value) VALUES (?, ?) "
-                        "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
-                        (k, v),
+                        "DELETE FROM state_meta WHERE key IN "
+                        "('fts_session_rebuild_high_water', "
+                        "'fts_session_rebuild_progress')"
                     )
                 for trig in (
                     "sessions_fts_insert",
@@ -5707,17 +5750,26 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
         The gap supplement folds values with ``_fts_unicode61_fold`` — a
         conservative Unicode approximation of the unicode61 rules (case fold
-        + diacritic removal, NOT exact parity) — so ``MATCH 'ecole'`` finds
-        ``École`` in the gap as it does in the index, while accepting the
-        loose side (a temporary extra candidate) for multi-diacritic
-        codepoints. SQLite's ``LOWER()`` only folds ASCII and would make a
-        gap row vanish/reappear across the backfill boundary.
+        + diacritic removal, NOT exact parity) — and matches on ANY positive
+        FTS term extracted from the query (see ``_fts_query_positive_terms``),
+        so both ``MATCH 'ecole'`` and a multi-token query such as
+        ``MATCH 'Alpha Project'`` (implicit AND) or ``alpha OR beta`` find
+        their gap rows exactly as the indexed lane would. The predicate is
+        deliberately a SUPERSET of the FTS semantics: it can over-match
+        (accepted — the backfilled index restores exact semantics) but never
+        misses a session the index would match, so a gap row cannot
+        vanish/reappear across the backfill boundary. SQLite's ``LOWER()``
+        only folds ASCII and would make a gap row disappear.
         """
         sanitized = self._sanitize_fts5_query(raw_query)
         if not sanitized:
             return True, []
-        needle = _fts_unicode61_fold(raw_query)
         gap = self._session_fts_rebuild_gap()
+        # Conservative FTS-superset terms for the gap supplement: the gap
+        # cannot parse FTS5's query syntax, so it matches ANY positive term
+        # in ANY field (over-match is accepted; a miss is not — a session
+        # the indexed lane matches must never hide while in (P, H]).
+        terms = _fts_query_positive_terms(raw_query)
         fts_ok = True
         by_row_id: Dict[int, Dict[str, Any]] = {}
 
@@ -5750,7 +5802,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 logging.debug(
                     "sessions_fts MATCH failed for %r", sanitized, exc_info=True,
                 )
-            if gap is not None:
+            if gap is not None and terms:
                 progress, high_water = gap
                 gap_rows = conn.execute(
                     "SELECT id, title, display_name, started_at, row_id "
@@ -5759,10 +5811,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     (progress, high_water),
                 ).fetchall()
                 for c in gap_rows:
-                    if (
-                        needle in _fts_unicode61_fold(c["title"])
-                        or needle in _fts_unicode61_fold(c["id"])
-                        or needle in _fts_unicode61_fold(c["display_name"])
+                    if any(
+                        term in _fts_unicode61_fold(field)
+                        for term in terms
+                        for field in (c["title"], c["id"], c["display_name"])
                     ):
                         by_row_id.setdefault(c["row_id"], _candidate(c))
         # Global merge ordering, not lane-then-gap: resolve_session_by_title

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -177,16 +177,28 @@ def _fts_query_positive_terms(raw_query: str) -> List[str]:
     accepted (the backfilled index restores exact semantics), but a MISS is
     not: a session that MATCHes once backfilled must never be hidden while
     it sits in the ``(P, H]`` gap.
+
+    Tokenization follows unicode61's token-character set, splitting MORE
+    aggressively rather than less: unicode61's token characters are Unicode
+    letters and digits, and EVERYTHING else — whitespace, punctuation, and
+    notably ``_`` (which Python's ``\\w`` wrongly keeps) — is a separator.
+    The query sanitizer quotes ``[._-]`` terms as FTS phrases, but the index
+    still tokenizes them the same way (``"foo_bar"`` → phrase ``foo bar``
+    against a ``foo bar`` document), so the gap must too: ``foo_bar`` /
+    ``foo-bar`` / ``foo.bar`` all yield the terms (``foo``, ``bar``). A term
+    that kept the separator literal (``"foo_bar"``) would MISS a session the
+    indexed lane finds. (CJK runs are deliberately left as whole terms here;
+    per-codepoint CJK tokenization belongs to the #26 CJK lane.)
     """
-    # Drop FTS5 boolean operators, then split on anything that is not a
-    # letter/digit (close enough to unicode61 tokenization for a conservative
-    # superset). Trailing '*' prefix markers fold into the term itself
-    # (substring containment covers prefix matching).
+    # Drop FTS5 boolean operators, then map every non-token character —
+    # anything that is not a Unicode letter or digit, including '_' — to a
+    # space (mirrors unicode61's token-character set exactly).
     cleaned = re.sub(
         r"\b(?:AND|OR|NOT|NEAR)\b", " ", raw_query, flags=re.IGNORECASE
     )
+    cleaned = "".join(ch if ch.isalnum() else " " for ch in cleaned)
     terms: List[str] = []
-    for token in re.split(r"[^\w]+", cleaned, flags=re.UNICODE):
+    for token in cleaned.split():
         folded = _fts_unicode61_fold(token.rstrip("*"))
         if folded:
             terms.append(folded)

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -166,6 +166,17 @@ def _fts_unicode61_fold(text: Optional[str]) -> str:
     return stripped.casefold()
 
 
+def _is_unicode61_token_char(ch: str) -> bool:
+    """True when unicode61 treats *ch* as a token character.
+
+    unicode61's default token categories are L* (letters), N* (numbers) and
+    Co (Private Use). ``str.isalnum()`` covers L*/N* but MISSES Co, so it is
+    not a faithful boundary: a PUA codepoint such as U+E000 is indexable and
+    MATCH-able, yet isalnum() would drop it and cause a gap miss.
+    """
+    return ch.isalnum() or unicodedata.category(ch) == "Co"
+
+
 def _fts_query_positive_terms(raw_query: str) -> List[str]:
     """Conservative lexical terms for the #25 gap supplement's FTS-superset test.
 
@@ -180,8 +191,10 @@ def _fts_query_positive_terms(raw_query: str) -> List[str]:
 
     Tokenization follows unicode61's token-character set, splitting MORE
     aggressively rather than less: unicode61's token characters are Unicode
-    letters and digits, and EVERYTHING else — whitespace, punctuation, and
-    notably ``_`` (which Python's ``\\w`` wrongly keeps) — is a separator.
+    letters, digits, and Private-Use codepoints (categories L*, N*, Co — see
+    ``_is_unicode61_token_char``), and EVERYTHING else — whitespace,
+    punctuation, and notably ``_`` (which Python's ``\\w`` wrongly keeps) —
+    is a separator.
     The query sanitizer quotes ``[._-]`` terms as FTS phrases, but the index
     still tokenizes them the same way (``"foo_bar"`` → phrase ``foo bar``
     against a ``foo bar`` document), so the gap must too: ``foo_bar`` /
@@ -197,10 +210,13 @@ def _fts_query_positive_terms(raw_query: str) -> List[str]:
     is ANY-term, keeping them can only add false positives, never a false
     negative.
     """
-    # Map every non-token character — anything that is not a Unicode letter
-    # or digit, including '_' — to a space (mirrors unicode61's
-    # token-character set exactly).
-    cleaned = "".join(ch if ch.isalnum() else " " for ch in raw_query)
+    # Map every non-token character — anything that is not a unicode61 token
+    # character (letters, digits, Private-Use; see _is_unicode61_token_char),
+    # including '_' — to a space (mirrors unicode61's token-character set
+    # exactly).
+    cleaned = "".join(
+        ch if _is_unicode61_token_char(ch) else " " for ch in raw_query
+    )
     terms: List[str] = []
     for token in cleaned.split():
         folded = _fts_unicode61_fold(token.rstrip("*"))

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -234,6 +234,23 @@ def _fts_query_positive_terms(raw_query: str) -> List[str]:
     return terms
 
 
+def _split_fts_sql_statements(ddl: str) -> List[str]:
+    """Split a fixed FTS DDL constant into individual statements.
+
+    Statements are separated by blank lines; trigger bodies contain
+    semicolons but no blank lines, so ``split("\n\n")`` is a safe boundary
+    for the module's fixed DDL constants (used by the crash-atomic transition,
+    which cannot use executescript's implicit COMMIT).
+    """
+    return [s.strip() for s in ddl.split("\n\n") if s.strip()]
+
+
+# The #25 sessions_fts DDL split into its four statements (external table +
+# three gated triggers), executed individually inside the crash-atomic
+# transition's BEGIN IMMEDIATE.
+_SESSIONS_FTS_STATEMENTS = _split_fts_sql_statements(SESSIONS_FTS_SQL)
+
+
 def _scrub_surrogates(value: Any) -> Any:
     """Replace lone surrogates when *value* is text; pass anything else through.
 
@@ -2593,67 +2610,77 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         if not existing and self.get_meta("fts_session_rebuild_high_water") is None:
             self._seed_session_fts_rebuild_markers(cursor)
 
-        ok = self._ensure_fts_schema(cursor, "sessions_fts", SESSIONS_FTS_SQL)
+        # ── Crash-atomic schema + catch-up transition (#25) ────────
+        # The durable H capture + old-table teardown committed in the stage
+        # transaction above, so a concurrent writer can commit a session in
+        # the trigger-free window that follows. When the external table is
+        # being created NOW (internal→external conversion or fresh-create over
+        # a populated DB), schema install AND the trigger-owned-region catch-up
+        # must land in ONE BEGIN IMMEDIATE: a window row is caught up, a crash
+        # mid-transition rolls back schema + catch-up together (reopen re-runs
+        # it), and rows committing after the commit are trigger-indexed. When
+        # the table already exists (reopen), the plain IF NOT EXISTS ensure
+        # suffices — triggers are already durable, so no window.
+        if not existing:
+            ok = self._fts_session_schema_transition(cursor)
+        else:
+            ok = self._ensure_fts_schema(cursor, "sessions_fts", SESSIONS_FTS_SQL)
         if not ok:
             self._sessions_fts_available = False
             return False
-        # ── Transition catch-up (#25) ──────────────────────────────
-        # The durable H capture + old-table teardown commit in one write
-        # transaction, but the new external table + gated triggers are ensured
-        # afterwards (executescript issues its own COMMIT). A concurrent
-        # writer can therefore commit a session with row_id > H in the window
-        # where NO trigger exists yet — it is neither trigger-indexed nor in
-        # the (P,H] gap supplement, so it would be invisible until a full
-        # rebuild. Catch it up in a fresh BEGIN IMMEDIATE now that the
-        # triggers exist: the NOT EXISTS docsize anti-join makes it
-        # idempotent, and any row committing after this transaction is
-        # trigger-indexed. Covers both the internal→external conversion and
-        # the fresh-create-over-populated path (existing == False either way).
-        if not existing:
-            self._fts_session_transition_catchup(cursor)
         return True
 
-    def _fts_session_transition_catchup(self, cursor) -> None:
-        """Backfill rows that slipped into the trigger-owned region while the
-        #25 external schema was being created (see ``_ensure_sessions_fts_schema``).
+    def _fts_session_schema_transition(self, cursor) -> bool:
+        """Crash-atomic install of the #25 external sessions_fts schema AND
+        the trigger-owned-region catch-up, in one ``BEGIN IMMEDIATE``.
 
-        Rows in the trigger's ownership (``row_id > H OR row_id <= P``) that
-        are not yet in the index are inserted directly; the docsize anti-join
-        dedupes any already-indexed row. Runs in its own write transaction
-        AFTER the triggers exist, so the window is closed: anything committing
-        after this transaction is indexed by the live trigger. A DB with no
-        markers (empty / complete index) has nothing to catch up, so no write
-        is issued. The write is schema-init bookkeeping and must NOT advance
-        the routine-write merge cadence, so ``_write_count`` is restored.
+        Executes the DDL statement-by-statement (CREATE VIRTUAL TABLE + the
+        three gated triggers) and then the catch-up INSERT inside a single
+        write transaction, so the whole transition is atomic: a writer that
+        committed in the trigger-free window (after the stage transaction
+        released the lock but before the triggers existed) is caught up; a
+        writer mid-transaction is blocked; a writer after COMMIT is
+        trigger-indexed; a crash mid-transition rolls everything back, and the
+        reopen re-runs the transition. The catch-up predicate uses
+        ``COALESCE(H, -1)`` / ``COALESCE(P, -1)`` so the no-marker (empty /
+        complete) case is covered too — with no markers every ``row_id > -1``
+        is trigger-owned, which also catches an empty DB's first window row.
+        DDL runs via individual ``execute`` (not ``executescript``, whose
+        implicit COMMIT would break the transaction).
         """
         def _do(conn):
-            hw_row = conn.execute(
-                "SELECT CAST(value AS INTEGER) FROM state_meta "
-                "WHERE key = 'fts_session_rebuild_high_water'"
-            ).fetchone()
-            if hw_row is None:
-                return
-            hw = int(hw_row[0])
-            p_row = conn.execute(
-                "SELECT CAST(value AS INTEGER) FROM state_meta "
-                "WHERE key = 'fts_session_rebuild_progress'"
-            ).fetchone()
-            progress = int(p_row[0]) if p_row is not None else 0
+            for stmt in _SESSIONS_FTS_STATEMENTS:
+                conn.execute(stmt)
             conn.execute(
                 "INSERT INTO sessions_fts(rowid, title, id, display_name) "
                 "SELECT s.row_id, s.title, s.id, s.display_name "
                 "FROM sessions s "
-                "WHERE (s.row_id > ? OR s.row_id <= ?) "
+                "WHERE (s.row_id > COALESCE("
+                "    (SELECT CAST(value AS INTEGER) FROM state_meta "
+                "     WHERE key = 'fts_session_rebuild_high_water'), -1)"
+                "   OR s.row_id <= COALESCE("
+                "    (SELECT CAST(value AS INTEGER) FROM state_meta "
+                "     WHERE key = 'fts_session_rebuild_progress'), -1))"
                 "  AND NOT EXISTS ("
                 "    SELECT 1 FROM sessions_fts_docsize d WHERE d.id = s.row_id"
-                "  )",
-                (hw, progress),
+                "  )"
             )
+        # Schema-init bookkeeping must not advance the routine-write merge
+        # cadence (the write-path cadence test asserts exact boundaries).
         before = self._write_count
         try:
             self._execute_write(_do)
+        except sqlite3.OperationalError as exc:
+            if self._is_fts5_unavailable_error(exc):
+                self._warn_fts5_unavailable(exc)
+                return False
+            if self._is_trigram_unavailable_error(exc):
+                self._warn_trigram_unavailable(exc)
+                return False
+            raise
         finally:
             self._write_count = before
+        return True
 
     def _ensure_fts_cjk_schema(self, cursor) -> None:
         """Create / repair / self-heal the CJK-bigram index surface.

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2473,15 +2473,19 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             "SELECT 1 FROM sqlite_master "
             "WHERE type = 'table' AND name = 'sessions_fts'"
         ).fetchone())
+
+        # Fresh-create path: stage the durable claim BEFORE the empty external
+        # table can exist (the #76832 invariant). A crash between the claim
+        # commit and the schema ensure leaves markers without a table; reopen
+        # re-ensures the schema and finds the claim already durable — never an
+        # empty index + populated sessions + no claim orphan.
+        if not existing and self.get_meta("fts_session_rebuild_high_water") is None:
+            self._seed_session_fts_rebuild_markers(cursor)
+
         ok = self._ensure_fts_schema(cursor, "sessions_fts", SESSIONS_FTS_SQL)
         if not ok:
             self._sessions_fts_available = False
             return False
-        # Seed the durable claim only when the external table was just
-        # created on a populated DB with no existing claim (a staged claim
-        # from a crash before schema ensure must survive untouched).
-        if not existing and self.get_meta("fts_session_rebuild_high_water") is None:
-            self._seed_session_fts_rebuild_markers(cursor)
         return True
 
     def _ensure_fts_cjk_schema(self, cursor) -> None:
@@ -5670,8 +5674,13 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         sanitized = self._sanitize_fts5_query(raw_query)
         if not sanitized:
             return []
+        # The gap supplement folds columns with LOWER(...) LIKE, so the needle
+        # must be lowercased too (SQLite's LIKE is case-insensitive for ASCII
+        # only, so folding both sides is required for non-ASCII match parity
+        # with the case-insensitive unicode61 FTS lane).
         escaped = (
-            raw_query.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+            raw_query.lower()
+            .replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
         )
         needle = f"%{escaped}%"
         gap = self._session_fts_rebuild_gap()
@@ -5725,12 +5734,18 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     })
         return list(by_row_id.values())
 
-    def _fts_numbered_variants(self, title: str) -> Optional[List[sqlite3.Row]]:
+    def _fts_numbered_variants(
+        self, title: str
+    ) -> Optional[List[Dict[str, Any]]]:
         """Find numbered continuation variants via FTS5 MATCH with CJK dispatch.
 
-        During a #25 session metadata rebuild the bounded ``(P, H]`` gap is
-        supplemented with a LIKE scan and merged with the FTS candidates, so
-        title resolution never returns incomplete results mid-backfill.
+        Non-CJK titles delegate to the shared raw Unicode metadata lane
+        (``_fts_metadata_candidates``), which already covers title / logical
+        id / display_name and supplements the bounded ``(P, H]`` rebuild gap —
+        title resolution therefore never returns incomplete results
+        mid-backfill and the gap logic lives in exactly one place. CJK titles
+        keep their dedicated ``sessions_fts_cjk`` lane + gap supplement (the
+        CJK lifecycle is owned by #26).
 
         Returns None to signal fallback to LIKE (e.g. FTS5 runtime error or
         the target table unavailable). Returns empty list when no matches.
@@ -5738,64 +5753,73 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         is_cjk = self._contains_cjk(title)
         if is_cjk and not getattr(self, "_sessions_cjk_available", False):
             return None
-        fts_table = "sessions_fts_cjk" if is_cjk else "sessions_fts"
-        sanitized = self._sanitize_fts5_query(title)
-
-        if not sanitized:
-            return None
-
         escaped = title.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
 
-        with self._lock:
-            try:
-                cursor = self._conn.execute(
-                    f"SELECT s.id AS id, s.title, s.started_at "
-                    f"FROM {fts_table} f "
-                    f"JOIN sessions s ON s.row_id = f.rowid "
-                    f"WHERE {fts_table} MATCH ? "
-                    f"ORDER BY s.started_at DESC",
-                    (sanitized,),
-                )
-                candidates = list(cursor)
-            except sqlite3.OperationalError:
-                logging.debug(
-                    "%s MATCH failed for %r, falling back to LIKE",
-                    fts_table, sanitized, exc_info=True,
-                )
-                return None
+        # An unsanitizable query must signal "use the LIKE fallback" (None),
+        # not "no matches" ([]), for both lanes.
+        if not self._sanitize_fts5_query(title):
+            return None
 
-        # Post-filter: only keep sessions whose title starts with "{title} #N"
-        filtered = [
+        if is_cjk:
+            fts_table = "sessions_fts_cjk"
+            sanitized = self._sanitize_fts5_query(title)
+            if not sanitized:
+                return None
+            with self._lock:
+                try:
+                    cursor = self._conn.execute(
+                        f"SELECT s.id AS id, s.title, s.started_at "
+                        f"FROM {fts_table} f "
+                        f"JOIN sessions s ON s.row_id = f.rowid "
+                        f"WHERE {fts_table} MATCH ? "
+                        f"ORDER BY s.started_at DESC",
+                        (sanitized,),
+                    )
+                    candidates = list(cursor)
+                except sqlite3.OperationalError:
+                    logging.debug(
+                        "%s MATCH failed for %r, falling back to LIKE",
+                        fts_table, sanitized, exc_info=True,
+                    )
+                    return None
+            filtered = [
+                c for c in candidates
+                if c["title"] and c["title"].startswith(f"{escaped} #")
+            ]
+            # Bounded-gap supplement (same rule as the Unicode lane, kept local
+            # for the CJK table which #26 will take over).
+            gap = self._session_fts_rebuild_gap()
+            if gap is not None:
+                progress, high_water = gap
+                with self._read_ctx() as conn:
+                    gap_rows = conn.execute(
+                        "SELECT id, title, started_at FROM sessions "
+                        "WHERE title LIKE ? ESCAPE '\\' "
+                        "AND row_id > ? AND row_id <= ? "
+                        "ORDER BY started_at DESC",
+                        (f"{escaped} #%", progress, high_water),
+                    ).fetchall()
+                gap_filtered = [
+                    c for c in gap_rows
+                    if c["title"] and c["title"].startswith(f"{escaped} #")
+                ]
+                by_id = {c["id"]: c for c in filtered}
+                for c in gap_filtered:
+                    by_id.setdefault(c["id"], c)
+                filtered = sorted(
+                    by_id.values(), key=lambda c: c["started_at"], reverse=True
+                )
+            return filtered
+
+        # Non-CJK: the shared raw Unicode lane already merges the FTS
+        # candidates with the bounded (P, H] gap and dedupes by row_id.
+        candidates = self._fts_metadata_candidates(title)
+        if not candidates:
+            return candidates
+        return [
             c for c in candidates
             if c["title"] and c["title"].startswith(f"{escaped} #")
         ]
-
-        # Bounded-gap supplement: rows in (P, H] are not in the index yet.
-        gap = self._session_fts_rebuild_gap()
-        if gap is not None:
-            progress, high_water = gap
-            with self._read_ctx() as conn:
-                gap_rows = conn.execute(
-                    "SELECT id, title, started_at FROM sessions "
-                    "WHERE title LIKE ? ESCAPE '\\' "
-                    "AND row_id > ? AND row_id <= ? "
-                    "ORDER BY started_at DESC",
-                    (f"{escaped} #%", progress, high_water),
-                ).fetchall()
-            gap_filtered = [
-                c for c in gap_rows
-                if c["title"] and c["title"].startswith(f"{escaped} #")
-            ]
-            by_id = {c["id"]: c for c in filtered}
-            for c in gap_filtered:
-                by_id.setdefault(c["id"], c)
-            # Re-sort the merged candidates so the latest continuation is
-            # first even when the gap rows joined after the FTS hits.
-            filtered = sorted(
-                by_id.values(), key=lambda c: c["started_at"], reverse=True
-            )
-
-        return filtered
 
     def get_next_title_in_lineage(self, base_title: str) -> str:
         """Generate the next title in a lineage (e.g., "my session" → "my session #2").
@@ -6083,9 +6107,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 )
                 id_params.append(_like_pattern(id_needle))
             if search_needle:
-                # Same chain-membership trick as id_query, but matching either
-                # the title or the id of any session in the chain. The compact
-                # (punctuation-stripped) variant lets `an94` match `AN-94`.
+                # Same chain-membership trick as id_query, but matching the
+                # title, logical id, or display_name of any session in the
+                # chain (issue #25 covers display_name in the raw metadata
+                # search). The compact (punctuation-stripped) variant lets
+                # `an94` match `AN-94`.
                 compact_needle = re.sub(r"[\W_]+", "", search_needle)
                 compact_sql = (
                     "REPLACE(REPLACE(REPLACE(REPLACE(LOWER(COALESCE({0}, '')),"
@@ -6097,8 +6123,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     " WHERE cq.root_id = s.id"
                     " AND (LOWER(COALESCE(cs.title, '')) LIKE ? ESCAPE '\\'"
                     " OR LOWER(cq.cur_id) LIKE ? ESCAPE '\\'"
+                    " OR LOWER(COALESCE(cs.display_name, '')) LIKE ? ESCAPE '\\'"
                 )
-                id_params.extend([_like_pattern(search_needle)] * 2)
+                id_params.extend([_like_pattern(search_needle)] * 3)
                 if compact_needle:
                     search_clause += (
                         f" OR {compact_sql.format('cs.title')} LIKE ? ESCAPE '\\'"

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -66,6 +66,7 @@ from hermes_state_common import (  # noqa: F401  (re-exported for back-compat)
     MAX_FTS5_QUERY_CHARS,
     SCHEMA_SQL,
     SCHEMA_VERSION,
+    SESSIONS_FTS_SQL,
     _PREVIEW_CONTENT_SQL,
     _PREVIEW_HEAD_CHARS,
     _PREVIEW_MAX_CHARS,
@@ -2326,6 +2327,25 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         # means a legacy shape that doesn't index tool metadata → optimize.
         return "tool_name" not in sql
 
+    @staticmethod
+    def _db_has_internal_content_sessions_fts(cursor: sqlite3.Cursor) -> bool:
+        """True when sessions_fts is the pre-#25 internal-content shape.
+
+        #25's sessions_fts is external-content over raw (title, id,
+        display_name). The pre-#25 shape stores its own copy (title-only).
+        Detected by the absence of ``content=`` in the stored CREATE.
+        Returns False when sessions_fts doesn't exist yet (fresh DB mid-init):
+        the ensure path creates the external shape directly.
+        """
+        row = cursor.execute(
+            "SELECT sql FROM sqlite_master "
+            "WHERE type = 'table' AND name = 'sessions_fts'"
+        ).fetchone()
+        if row is None:
+            return False
+        sql = (row[0] if not isinstance(row, sqlite3.Row) else row["sql"]) or ""
+        return "content=" not in sql
+
     def _warn_trigram_unavailable(self, exc: sqlite3.OperationalError) -> None:
         """Log once that the trigram tokenizer is missing; base FTS5 stays enabled."""
         if getattr(self, "_trigram_unavailable_warned", False):
@@ -2355,50 +2375,114 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         )
 
     @staticmethod
-    def _backfill_sessions_fts(
-        cursor,
-        *,
-        include_cjk: bool = True,
-    ) -> None:
-        """Backfill existing session titles into the sessions FTS5 tables.
+    def _backfill_sessions_fts_cjk(cursor) -> None:
+        """Backfill existing session titles into the legacy CJK table.
 
         ``cursor`` may be a Cursor or a Connection (both expose ``execute``).
-        The cjk table backfill runs in progressive batches with a short
-        breather so the gateway writer is not starved.
+        The Unicode sessions_fts is no longer backfilled here (issue #25): it
+        is external-content and rebuilt by the resumable H/P chunk engine
+        (``fts_session_rebuild_step``), with search supplementing the bounded
+        gap meanwhile. The cjk table stays internal-content and one-shot
+        backfilled (the CJK lifecycle is owned by #26); it runs in
+        progressive batches with a short breather so the gateway writer is
+        not starved.
         """
         conn = getattr(cursor, "connection", cursor)
-
-        # Main sessions_fts backfill (unicode61 — one shot).
         cursor.execute(
-            "INSERT OR IGNORE INTO sessions_fts(rowid, title) "
-            "SELECT _rowid_, COALESCE(title, '') FROM sessions WHERE title IS NOT NULL"
+            "SELECT _rowid_ FROM sessions WHERE title IS NOT NULL "
+            "AND _rowid_ NOT IN (SELECT rowid FROM sessions_fts_cjk)"
         )
-        conn.commit()
+        missing = [row[0] for row in cursor.fetchall()]
+        if missing:
+            batch_sizes = [500, 200, 100, 50]
+            remaining = list(missing)
+            while remaining:
+                bs = batch_sizes.pop(0) if batch_sizes else 50
+                batch = remaining[:bs]
+                remaining = remaining[bs:]
+                placeholders = ",".join("?" for _ in batch)
+                cursor.execute(
+                    f"INSERT OR IGNORE INTO sessions_fts_cjk(rowid, title) "
+                    f"SELECT _rowid_, COALESCE(title, '') FROM sessions "
+                    f"WHERE _rowid_ IN ({placeholders})",
+                    batch,
+                )
+                conn.commit()
+                if remaining:
+                    time.sleep(0.05)  # 50ms breather for gateway writer
 
-        # CJK sessions_fts_cjk backfill (cjk_unicode61) — progressive batches.
-        if include_cjk:
-            cursor.execute(
-                "SELECT _rowid_ FROM sessions WHERE title IS NOT NULL "
-                "AND _rowid_ NOT IN (SELECT rowid FROM sessions_fts_cjk)"
-            )
-            missing = [row[0] for row in cursor.fetchall()]
-            if missing:
-                batch_sizes = [500, 200, 100, 50]
-                remaining = list(missing)
-                while remaining:
-                    bs = batch_sizes.pop(0) if batch_sizes else 50
-                    batch = remaining[:bs]
-                    remaining = remaining[bs:]
-                    placeholders = ",".join("?" for _ in batch)
-                    cursor.execute(
-                        f"INSERT OR IGNORE INTO sessions_fts_cjk(rowid, title) "
-                        f"SELECT _rowid_, COALESCE(title, '') FROM sessions "
-                        f"WHERE _rowid_ IN ({placeholders})",
-                        batch,
+    def _ensure_sessions_fts_schema(self, cursor: sqlite3.Cursor) -> bool:
+        """Migrate / self-heal the session Unicode metadata FTS surface (#25).
+
+        Converts a pre-#25 internal-content ``sessions_fts`` to the external-
+        content shape over raw ``(title, id, display_name)`` keyed by named
+        ``sessions.row_id``. The durable H/P claim is committed BEFORE the
+        empty external index can look complete (the #76832 invariant), then
+        the external table + gated triggers are ensured. On a fresh external
+        table over a populated DB with no existing claim, seeds H/P so the
+        resumable chunk engine backfills historical rows — an empty external
+        index is never served as complete. On a DB with an existing claim
+        (crash between claim and schema ensure), just re-ensures the schema
+        and leaves progress untouched.
+
+        Returns True when sessions_fts is available for search.
+        """
+        if self._db_has_internal_content_sessions_fts(cursor):
+            # Staged conversion: claim + teardown of the old internal table in
+            # ONE write transaction; the external schema ensure runs after
+            # (it uses executescript, which issues an implicit COMMIT).
+            def _stage(conn):
+                hw = conn.execute(
+                    "SELECT COALESCE(MAX(row_id), 0) FROM sessions"
+                ).fetchone()[0]
+                for k, v in (
+                    ("fts_session_rebuild_high_water", str(hw)),
+                    ("fts_session_rebuild_progress", "0"),
+                ):
+                    conn.execute(
+                        "INSERT INTO state_meta (key, value) VALUES (?, ?) "
+                        "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                        (k, v),
                     )
-                    conn.commit()
-                    if remaining:
-                        time.sleep(0.05)  # 50ms breather for gateway writer
+                for trig in (
+                    "sessions_fts_insert",
+                    "sessions_fts_delete",
+                    "sessions_fts_update",
+                ):
+                    conn.execute(f"DROP TRIGGER IF EXISTS {trig}")
+                for tbl in (
+                    "sessions_fts", "sessions_fts_data", "sessions_fts_idx",
+                    "sessions_fts_content", "sessions_fts_docsize",
+                    "sessions_fts_config",
+                ):
+                    conn.execute(f"DROP TABLE IF EXISTS {tbl}")
+            self._execute_write(_stage)
+            logger.warning(
+                "Migrating sessions_fts to the external-content Unicode "
+                "metadata index (issue #25); historical backfill staged "
+                "with a durable high-water claim"
+            )
+
+        # Track whether the external table is being created NOW (fresh) vs
+        # already present (reopen). A fresh external table over a populated
+        # DB needs a durable H/P claim; an existing table's rows were either
+        # live-indexed by the triggers or are already covered by durable
+        # markers — seeding again would duplicate documents on the next
+        # backfill.
+        existing = bool(cursor.execute(
+            "SELECT 1 FROM sqlite_master "
+            "WHERE type = 'table' AND name = 'sessions_fts'"
+        ).fetchone())
+        ok = self._ensure_fts_schema(cursor, "sessions_fts", SESSIONS_FTS_SQL)
+        if not ok:
+            self._sessions_fts_available = False
+            return False
+        # Seed the durable claim only when the external table was just
+        # created on a populated DB with no existing claim (a staged claim
+        # from a crash before schema ensure must survive untouched).
+        if not existing and self.get_meta("fts_session_rebuild_high_water") is None:
+            self._seed_session_fts_rebuild_markers(cursor)
+        return True
 
     def _ensure_fts_cjk_schema(self, cursor) -> None:
         """Create / repair / self-heal the CJK-bigram index surface.
@@ -5541,8 +5625,112 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 (f"{escaped} #%",),
             ))
 
+    def _session_fts_rebuild_gap(self) -> Optional[Tuple[int, int]]:
+        """Bounded unindexed session-metadata gap ``(progress, high_water]``.
+
+        During a #25 session metadata backfill, rows whose ``row_id`` falls in
+        ``(P, H]`` are not yet in the external-content index. Metadata search
+        must supplement them (raw substring over the gap) and merge with the
+        FTS candidates so no valid session is hidden while the rebuild is
+        pending. Returns ``(progress, high_water)`` or ``None`` when no
+        session rebuild is pending (normal operation).
+        """
+        with self._read_ctx() as conn:
+            row = conn.execute(
+                "SELECT value FROM state_meta "
+                "WHERE key = 'fts_session_rebuild_high_water'"
+            ).fetchone()
+            if row is None:
+                return None
+            high_water = int(row[0])
+            p = conn.execute(
+                "SELECT value FROM state_meta "
+                "WHERE key = 'fts_session_rebuild_progress'"
+            ).fetchone()
+            progress = int(p[0]) if p is not None else 0
+        if progress >= high_water:
+            return None
+        return progress, high_water
+
+    def _fts_metadata_candidates(self, raw_query: str) -> List[Dict[str, Any]]:
+        """Raw Unicode session-metadata candidates matching ``raw_query``.
+
+        Covers title, logical session id, and display_name (issue #25) via the
+        external-content ``sessions_fts``. While the #25 backfill is pending,
+        the bounded historical gap ``(P, H]`` is supplemented from canonical
+        rows over the same raw-substring dimensions and deduplicated by
+        ``row_id``, so migration never silently hides matching sessions:
+        rows ``<= P`` are already indexed, rows ``> H`` are live-indexed, and
+        only ``(P, H]`` is supplemented.
+
+        Returns a list of dicts (``id``, ``title``, ``display_name``,
+        ``started_at``, ``row_id``). Raw Unicode only — no normalization
+        policy (normalized arbitrary infix is owned by #30).
+        """
+        sanitized = self._sanitize_fts5_query(raw_query)
+        if not sanitized:
+            return []
+        escaped = (
+            raw_query.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+        )
+        needle = f"%{escaped}%"
+        gap = self._session_fts_rebuild_gap()
+        by_row_id: Dict[int, Dict[str, Any]] = {}
+
+        with self._read_ctx() as conn:
+            try:
+                cursor = conn.execute(
+                    "SELECT s.id AS id, s.title, s.display_name, "
+                    "       s.started_at, s.row_id AS row_id "
+                    "FROM sessions_fts f "
+                    "JOIN sessions s ON s.row_id = f.rowid "
+                    "WHERE sessions_fts MATCH ? "
+                    "ORDER BY s.started_at DESC",
+                    (sanitized,),
+                )
+                for c in cursor:
+                    by_row_id[c["row_id"]] = {
+                        "id": c["id"],
+                        "title": c["title"],
+                        "display_name": c["display_name"],
+                        "started_at": c["started_at"],
+                        "row_id": c["row_id"],
+                    }
+            except sqlite3.OperationalError:
+                # FTS lane unavailable for this query — the gap supplement
+                # below still runs; the rest falls back to the legacy LIKE
+                # lane where the caller provides one.
+                logging.debug(
+                    "sessions_fts MATCH failed for %r", sanitized, exc_info=True,
+                )
+            if gap is not None:
+                progress, high_water = gap
+                gap_rows = conn.execute(
+                    "SELECT id, title, display_name, started_at, row_id "
+                    "FROM sessions "
+                    "WHERE row_id > ? AND row_id <= ? "
+                    "AND (LOWER(COALESCE(title, '')) LIKE ? ESCAPE '\\' "
+                    "  OR LOWER(COALESCE(id, '')) LIKE ? ESCAPE '\\' "
+                    "  OR LOWER(COALESCE(display_name, '')) LIKE ? ESCAPE '\\') "
+                    "ORDER BY started_at DESC",
+                    (progress, high_water, needle, needle, needle),
+                ).fetchall()
+                for c in gap_rows:
+                    by_row_id.setdefault(c["row_id"], {
+                        "id": c["id"],
+                        "title": c["title"],
+                        "display_name": c["display_name"],
+                        "started_at": c["started_at"],
+                        "row_id": c["row_id"],
+                    })
+        return list(by_row_id.values())
+
     def _fts_numbered_variants(self, title: str) -> Optional[List[sqlite3.Row]]:
         """Find numbered continuation variants via FTS5 MATCH with CJK dispatch.
+
+        During a #25 session metadata rebuild the bounded ``(P, H]`` gap is
+        supplemented with a LIKE scan and merged with the FTS candidates, so
+        title resolution never returns incomplete results mid-backfill.
 
         Returns None to signal fallback to LIKE (e.g. FTS5 runtime error or
         the target table unavailable). Returns empty list when no matches.
@@ -5556,12 +5744,14 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         if not sanitized:
             return None
 
+        escaped = title.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
         with self._lock:
             try:
                 cursor = self._conn.execute(
                     f"SELECT s.id AS id, s.title, s.started_at "
                     f"FROM {fts_table} f "
-                    f"JOIN sessions s ON s._rowid_ = f.rowid "
+                    f"JOIN sessions s ON s.row_id = f.rowid "
                     f"WHERE {fts_table} MATCH ? "
                     f"ORDER BY s.started_at DESC",
                     (sanitized,),
@@ -5575,11 +5765,37 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 return None
 
         # Post-filter: only keep sessions whose title starts with "{title} #N"
-        escaped = title.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
-        return [
+        filtered = [
             c for c in candidates
             if c["title"] and c["title"].startswith(f"{escaped} #")
         ]
+
+        # Bounded-gap supplement: rows in (P, H] are not in the index yet.
+        gap = self._session_fts_rebuild_gap()
+        if gap is not None:
+            progress, high_water = gap
+            with self._read_ctx() as conn:
+                gap_rows = conn.execute(
+                    "SELECT id, title, started_at FROM sessions "
+                    "WHERE title LIKE ? ESCAPE '\\' "
+                    "AND row_id > ? AND row_id <= ? "
+                    "ORDER BY started_at DESC",
+                    (f"{escaped} #%", progress, high_water),
+                ).fetchall()
+            gap_filtered = [
+                c for c in gap_rows
+                if c["title"] and c["title"].startswith(f"{escaped} #")
+            ]
+            by_id = {c["id"]: c for c in filtered}
+            for c in gap_filtered:
+                by_id.setdefault(c["id"], c)
+            # Re-sort the merged candidates so the latest continuation is
+            # first even when the gap rows joined after the FTS hits.
+            filtered = sorted(
+                by_id.values(), key=lambda c: c["started_at"], reverse=True
+            )
+
+        return filtered
 
     def get_next_title_in_lineage(self, base_title: str) -> str:
         """Generate the next title in a lineage (e.g., "my session" → "my session #2").

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -166,17 +166,6 @@ def _fts_unicode61_fold(text: Optional[str]) -> str:
     return stripped.casefold()
 
 
-def _is_unicode61_token_char(ch: str) -> bool:
-    """True when unicode61 treats *ch* as a token character.
-
-    unicode61's default token categories are L* (letters), N* (numbers) and
-    Co (Private Use). ``str.isalnum()`` covers L*/N* but MISSES Co, so it is
-    not a faithful boundary: a PUA codepoint such as U+E000 is indexable and
-    MATCH-able, yet isalnum() would drop it and cause a gap miss.
-    """
-    return ch.isalnum() or unicodedata.category(ch) == "Co"
-
-
 def _fts_query_positive_terms(raw_query: str) -> List[str]:
     """Conservative lexical terms for the #25 gap supplement's FTS-superset test.
 
@@ -189,19 +178,23 @@ def _fts_query_positive_terms(raw_query: str) -> List[str]:
     not: a session that MATCHes once backfilled must never be hidden while
     it sits in the ``(P, H]`` gap.
 
-    Tokenization follows unicode61's token-character set, splitting MORE
-    aggressively rather than less: unicode61's token characters are Unicode
-    letters, digits, and Private-Use codepoints (categories L*, N*, Co — see
-    ``_is_unicode61_token_char``), and EVERYTHING else — whitespace,
-    punctuation, and notably ``_`` (which Python's ``\\w`` wrongly keeps) —
-    is a separator.
-    The query sanitizer quotes ``[._-]`` terms as FTS phrases, but the index
-    still tokenizes them the same way (``"foo_bar"`` → phrase ``foo bar``
-    against a ``foo bar`` document), so the gap must too: ``foo_bar`` /
-    ``foo-bar`` / ``foo.bar`` all yield the terms (``foo``, ``bar``). A term
-    that kept the separator literal (``"foo_bar"``) would MISS a session the
-    indexed lane finds. (CJK runs are deliberately left as whole terms here;
-    per-codepoint CJK tokenization belongs to the #26 CJK lane.)
+    Tokenization deliberately does NOT mirror unicode61 exactly: SQLite's
+    unicode61 classifies characters per Unicode 6.1, while Python's
+    ``unicodedata`` reflects a different (newer) Unicode database — so
+    classifying non-ASCII by category here would risk a gap miss (e.g.
+    U+1018C is a token character in unicode61 but category ``So`` in Python).
+    The safe boundary is ASCII-only: unicode61 always treats ASCII
+    non-alphanumerics (whitespace, punctuation, and notably ``_``, which
+    Python's ``\\w`` wrongly keeps) as separators, and every non-ASCII
+    character is kept inside terms. The query sanitizer quotes ``[._-]``
+    terms as FTS phrases, but the index still tokenizes them the same way
+    (``"foo_bar"`` → phrase ``foo bar`` against a ``foo bar`` document), so
+    the gap must too: ``foo_bar`` / ``foo-bar`` / ``foo.bar`` all yield the
+    terms (``foo``, ``bar``). For a run containing non-ASCII, each ASCII
+    sub-run and each non-ASCII codepoint is additionally emitted, so a query
+    that unicode61 tokenizes more finely (a non-ASCII separator, CJK
+    per-codepoint) can never miss either. This can only over-match, never
+    miss.
 
     Boolean operator WORDS are deliberately kept as terms. A quoted
     ``"AND"`` is a literal FTS phrase — the sanitizer protects balanced
@@ -210,18 +203,34 @@ def _fts_query_positive_terms(raw_query: str) -> List[str]:
     is ANY-term, keeping them can only add false positives, never a false
     negative.
     """
-    # Map every non-token character — anything that is not a unicode61 token
-    # character (letters, digits, Private-Use; see _is_unicode61_token_char),
-    # including '_' — to a space (mirrors unicode61's token-character set
-    # exactly).
+    # Safe separator boundary across Unicode versions: ASCII non-alphanumeric.
+    # Every non-ASCII character is kept — never excluded by Python's Unicode
+    # categories (SQLite's unicode61 uses Unicode 6.1, which differs).
     cleaned = "".join(
-        ch if _is_unicode61_token_char(ch) else " " for ch in raw_query
+        " " if (ch.isascii() and not ch.isalnum()) else ch for ch in raw_query
     )
     terms: List[str] = []
+    seen: set = set()
     for token in cleaned.split():
         folded = _fts_unicode61_fold(token.rstrip("*"))
-        if folded:
+        if folded and folded not in seen:
+            seen.add(folded)
             terms.append(folded)
+        if any(ord(ch) >= 0x80 for ch in token):
+            # unicode61 may tokenize this run more finely (per-codepoint CJK,
+            # a non-ASCII separator, ...): emit the ASCII sub-runs and each
+            # non-ASCII codepoint so a finer tokenization can never miss.
+            for piece in re.split(r"[^\x00-\x7F]+", token):
+                f = _fts_unicode61_fold(piece)
+                if f and f not in seen:
+                    seen.add(f)
+                    terms.append(f)
+            for ch in token:
+                if ord(ch) >= 0x80:
+                    f = _fts_unicode61_fold(ch)
+                    if f and f not in seen:
+                        seen.add(f)
+                        terms.append(f)
     return terms
 
 
@@ -2588,7 +2597,63 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         if not ok:
             self._sessions_fts_available = False
             return False
+        # ── Transition catch-up (#25) ──────────────────────────────
+        # The durable H capture + old-table teardown commit in one write
+        # transaction, but the new external table + gated triggers are ensured
+        # afterwards (executescript issues its own COMMIT). A concurrent
+        # writer can therefore commit a session with row_id > H in the window
+        # where NO trigger exists yet — it is neither trigger-indexed nor in
+        # the (P,H] gap supplement, so it would be invisible until a full
+        # rebuild. Catch it up in a fresh BEGIN IMMEDIATE now that the
+        # triggers exist: the NOT EXISTS docsize anti-join makes it
+        # idempotent, and any row committing after this transaction is
+        # trigger-indexed. Covers both the internal→external conversion and
+        # the fresh-create-over-populated path (existing == False either way).
+        if not existing:
+            self._fts_session_transition_catchup(cursor)
         return True
+
+    def _fts_session_transition_catchup(self, cursor) -> None:
+        """Backfill rows that slipped into the trigger-owned region while the
+        #25 external schema was being created (see ``_ensure_sessions_fts_schema``).
+
+        Rows in the trigger's ownership (``row_id > H OR row_id <= P``) that
+        are not yet in the index are inserted directly; the docsize anti-join
+        dedupes any already-indexed row. Runs in its own write transaction
+        AFTER the triggers exist, so the window is closed: anything committing
+        after this transaction is indexed by the live trigger. A DB with no
+        markers (empty / complete index) has nothing to catch up, so no write
+        is issued. The write is schema-init bookkeeping and must NOT advance
+        the routine-write merge cadence, so ``_write_count`` is restored.
+        """
+        def _do(conn):
+            hw_row = conn.execute(
+                "SELECT CAST(value AS INTEGER) FROM state_meta "
+                "WHERE key = 'fts_session_rebuild_high_water'"
+            ).fetchone()
+            if hw_row is None:
+                return
+            hw = int(hw_row[0])
+            p_row = conn.execute(
+                "SELECT CAST(value AS INTEGER) FROM state_meta "
+                "WHERE key = 'fts_session_rebuild_progress'"
+            ).fetchone()
+            progress = int(p_row[0]) if p_row is not None else 0
+            conn.execute(
+                "INSERT INTO sessions_fts(rowid, title, id, display_name) "
+                "SELECT s.row_id, s.title, s.id, s.display_name "
+                "FROM sessions s "
+                "WHERE (s.row_id > ? OR s.row_id <= ?) "
+                "  AND NOT EXISTS ("
+                "    SELECT 1 FROM sessions_fts_docsize d WHERE d.id = s.row_id"
+                "  )",
+                (hw, progress),
+            )
+        before = self._write_count
+        try:
+            self._execute_write(_do)
+        finally:
+            self._write_count = before
 
     def _ensure_fts_cjk_schema(self, cursor) -> None:
         """Create / repair / self-heal the CJK-bigram index surface.
@@ -5800,8 +5865,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         # Conservative FTS-superset terms for the gap supplement: the gap
         # cannot parse FTS5's query syntax, so it matches ANY positive term
         # in ANY field (over-match is accepted; a miss is not — a session
-        # the indexed lane matches must never hide while in (P, H]).
-        terms = _fts_query_positive_terms(raw_query)
+        # the indexed lane matches must never hide while in (P, H]). Terms
+        # derive from the SANITIZED query (capped at MAX_FTS5_QUERY_CHARS, the
+        # same string the FTS lane MATCHes) so both lanes process the same
+        # bounded input and a huge query cannot blow up gap-row × terms.
+        terms = _fts_query_positive_terms(sanitized)
         fts_ok = True
         by_row_id: Dict[int, Dict[str, Any]] = {}
 

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -457,6 +457,14 @@ CREATE TABLE sessions_new (
 # Indexes on ``sessions`` that DROP TABLE removes during the row_id swap and
 # the migration must recreate inside the same transaction (all IF NOT EXISTS
 # so the later SCHEMA_SQL / DEFERRED_INDEX_SQL passes no-op on them).
+#
+# ``idx_sessions_title_unique`` is deliberately NOT here: it is a UNIQUE index
+# and legacy DBs can carry duplicate titles (the existing post-migration
+# repair in ``_init_schema`` clears the older duplicates before creating it).
+# Rebuilding it inside the migration's transaction would raise
+# ``UNIQUE constraint failed`` and roll back the whole open for exactly the
+# legacy DBs the migration exists to upgrade — the migration must stay
+# reachable until that repair runs.
 SESSION_INDEX_SQL_STATEMENTS = (
     "CREATE INDEX IF NOT EXISTS idx_sessions_source ON sessions(source)",
     "CREATE INDEX IF NOT EXISTS idx_sessions_source_id ON sessions(source, id)",
@@ -470,8 +478,6 @@ SESSION_INDEX_SQL_STATEMENTS = (
     "ON sessions(handoff_state, started_at)",
     "CREATE INDEX IF NOT EXISTS idx_sessions_system_prompt_hash "
     "ON sessions(system_prompt_hash)",
-    "CREATE UNIQUE INDEX IF NOT EXISTS idx_sessions_title_unique "
-    "ON sessions(title) WHERE title IS NOT NULL",
 )
 
 

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -163,9 +163,7 @@ SCHEMA_VERSION = 25
 # layout 0 (marker absent) with a working inline index until the user opts in.
 #   1 = v23 external-content layout (content/tool_name/tool_calls,
 #       tool-row-excluded trigram)
-#   2 = + session Unicode metadata external-content layout over raw
-#       (title, id, display_name) keyed by named sessions.row_id (#25)
-FTS_STORAGE_VERSION = 2
+FTS_STORAGE_VERSION = 1
 
 
 # Cap on user-controlled FTS5 query input before regex/sanitizer processing.

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -163,7 +163,9 @@ SCHEMA_VERSION = 25
 # layout 0 (marker absent) with a working inline index until the user opts in.
 #   1 = v23 external-content layout (content/tool_name/tool_calls,
 #       tool-row-excluded trigram)
-FTS_STORAGE_VERSION = 1
+#   2 = + session Unicode metadata external-content layout over raw
+#       (title, id, display_name) keyed by named sessions.row_id (#25)
+FTS_STORAGE_VERSION = 2
 
 
 # Cap on user-controlled FTS5 query input before regex/sanitizer processing.
@@ -641,24 +643,66 @@ FTS_CJK_STALE_KEY = "fts_cjk_stale"
 # (which would create the external-content trigram source VIEW and leave the
 # DB in a mixed, broken state). `optimize_fts_storage()` is what migrates a
 # legacy DB to the v23 shape.
-# ── Sessions FTS5 — title search ────────────────────────────────────────
+# ── Sessions FTS5 — raw Unicode metadata search (v2 / issue #25) ────────
+# Same architecture as the v23 message FTS: metadata text is canonical ONLY
+# in ``sessions`` (read through the named ``row_id``), never duplicated in
+# FTS content shadow storage. The document is the RAW ``(title, id,
+# display_name)`` tuple — no title normalization, no synthetic concatenation
+# (normalized arbitrary-infix belongs to #30). A dedicated marker pair
+# (``fts_session_rebuild_high_water`` / ``fts_session_rebuild_progress``)
+# drives the resumable chunked backfill and gates every trigger on the same
+# indexed-row invariant as the message indexes: a row is safe to mutate in
+# FTS only when ``row_id <= P`` (already backfilled) or ``row_id > H``
+# (inserted after capture — AUTOINCREMENT guarantees new rows are always
+# > H). Rows in ``(P, H]`` are owned by the historical worker: triggers leave
+# them alone, and search supplements the bounded gap. The UPDATE trigger
+# fires only on title/id/display_name changes (AFTER UPDATE OF plus a
+# value-change guard) so token/accounting/heartbeat metadata writes never
+# rewrite the metadata index.
 SESSIONS_FTS_SQL = """
 CREATE VIRTUAL TABLE IF NOT EXISTS sessions_fts USING fts5(
     title,
+    id,
+    display_name,
+    content='sessions',
+    content_rowid='row_id',
     tokenize='unicode61'
 );
 
-CREATE TRIGGER IF NOT EXISTS sessions_fts_insert AFTER INSERT ON sessions BEGIN
-    INSERT INTO sessions_fts(rowid, title) VALUES (new.rowid, new.title);
+CREATE TRIGGER IF NOT EXISTS sessions_fts_insert AFTER INSERT ON sessions
+WHEN (new.row_id > COALESCE((SELECT CAST(value AS INTEGER) FROM state_meta
+                             WHERE key = 'fts_session_rebuild_high_water'), -1)
+   OR new.row_id <= COALESCE((SELECT CAST(value AS INTEGER) FROM state_meta
+                              WHERE key = 'fts_session_rebuild_progress'), -1))
+BEGIN
+    INSERT INTO sessions_fts(rowid, title, id, display_name)
+    VALUES (new.row_id, new.title, new.id, new.display_name);
 END;
 
-CREATE TRIGGER IF NOT EXISTS sessions_fts_delete AFTER DELETE ON sessions BEGIN
-    DELETE FROM sessions_fts WHERE rowid = old.rowid;
+CREATE TRIGGER IF NOT EXISTS sessions_fts_delete AFTER DELETE ON sessions
+WHEN (old.row_id > COALESCE((SELECT CAST(value AS INTEGER) FROM state_meta
+                             WHERE key = 'fts_session_rebuild_high_water'), -1)
+   OR old.row_id <= COALESCE((SELECT CAST(value AS INTEGER) FROM state_meta
+                              WHERE key = 'fts_session_rebuild_progress'), -1))
+BEGIN
+    INSERT INTO sessions_fts(sessions_fts, rowid, title, id, display_name)
+    VALUES ('delete', old.row_id, old.title, old.id, old.display_name);
 END;
 
-CREATE TRIGGER IF NOT EXISTS sessions_fts_update AFTER UPDATE ON sessions BEGIN
-    DELETE FROM sessions_fts WHERE rowid = old.rowid;
-    INSERT INTO sessions_fts(rowid, title) VALUES (new.rowid, new.title);
+CREATE TRIGGER IF NOT EXISTS sessions_fts_update
+AFTER UPDATE OF title, id, display_name ON sessions
+WHEN (old.title IS NOT new.title
+   OR old.id IS NOT new.id
+   OR old.display_name IS NOT new.display_name)
+   AND (old.row_id > COALESCE((SELECT CAST(value AS INTEGER) FROM state_meta
+                               WHERE key = 'fts_session_rebuild_high_water'), -1)
+     OR old.row_id <= COALESCE((SELECT CAST(value AS INTEGER) FROM state_meta
+                                WHERE key = 'fts_session_rebuild_progress'), -1))
+BEGIN
+    INSERT INTO sessions_fts(sessions_fts, rowid, title, id, display_name)
+    VALUES ('delete', old.row_id, old.title, old.id, old.display_name);
+    INSERT INTO sessions_fts(rowid, title, id, display_name)
+    VALUES (new.row_id, new.title, new.id, new.display_name);
 END;
 """
 

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -193,7 +193,8 @@ CREATE TABLE IF NOT EXISTS system_prompts (
 );
 
 CREATE TABLE IF NOT EXISTS sessions (
-    id TEXT PRIMARY KEY,
+    row_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    id TEXT NOT NULL UNIQUE,
     source TEXT NOT NULL,
     user_id TEXT,
     session_key TEXT,
@@ -378,6 +379,100 @@ CREATE INDEX IF NOT EXISTS idx_sessions_handoff_state
 CREATE INDEX IF NOT EXISTS idx_sessions_system_prompt_hash
     ON sessions(system_prompt_hash);
 """
+
+
+# ── Sessions named row_id migration (#25) ──────────────────────────────
+# SQLite cannot ALTER a PRIMARY KEY, so giving ``sessions`` a named
+# ``row_id INTEGER PRIMARY KEY AUTOINCREMENT`` (the stable storage/document
+# identity the external-content ``sessions_fts`` needs) requires a full table
+# rebuild. The migration runs as ONE explicit BEGIN IMMEDIATE transaction:
+# create -> copy with the OLD hidden ``rowid`` copied verbatim into
+# ``row_id`` (an order-preserving copy is NOT enough — deleted-row holes must
+# be preserved exactly) -> verify count + ``{id: row_id}`` identity -> drop
+# old -> rename -> recreate indexes. Foreign keys stay OFF only outside that
+# transaction and are re-verified afterward. Do NOT use ``executescript()``
+# inside the swap — it issues an implicit COMMIT and defeats the transaction
+# boundary (see the donor-bug note in docs/research/issue-32-*.md).
+SESSION_TABLE_REBUILD_SQL = """
+CREATE TABLE sessions_new (
+    row_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    id TEXT NOT NULL UNIQUE,
+    source TEXT NOT NULL,
+    user_id TEXT,
+    session_key TEXT,
+    chat_id TEXT,
+    chat_type TEXT,
+    thread_id TEXT,
+    display_name TEXT,
+    origin_json TEXT,
+    expiry_finalized INTEGER DEFAULT 0,
+    model TEXT,
+    model_config TEXT,
+    system_prompt TEXT,
+    system_prompt_hash TEXT,
+    parent_session_id TEXT,
+    started_at REAL NOT NULL,
+    ended_at REAL,
+    end_reason TEXT,
+    message_count INTEGER DEFAULT 0,
+    tool_call_count INTEGER DEFAULT 0,
+    input_tokens INTEGER DEFAULT 0,
+    output_tokens INTEGER DEFAULT 0,
+    cache_read_tokens INTEGER DEFAULT 0,
+    cache_write_tokens INTEGER DEFAULT 0,
+    reasoning_tokens INTEGER DEFAULT 0,
+    cwd TEXT,
+    git_branch TEXT,
+    git_repo_root TEXT,
+    billing_provider TEXT,
+    billing_base_url TEXT,
+    billing_mode TEXT,
+    estimated_cost_usd REAL,
+    actual_cost_usd REAL,
+    cost_status TEXT,
+    cost_source TEXT,
+    pricing_version TEXT,
+    title TEXT,
+    last_activity_at REAL,
+    last_activity_description TEXT,
+    last_activity_provenance TEXT,
+    api_call_count INTEGER DEFAULT 0,
+    handoff_state TEXT,
+    handoff_platform TEXT,
+    handoff_error TEXT,
+    compression_failure_cooldown_until REAL,
+    compression_failure_error TEXT,
+    compression_fallback_streak INTEGER NOT NULL DEFAULT 0,
+    compression_ineffective_count INTEGER NOT NULL DEFAULT 0,
+    profile_name TEXT,
+    rewind_count INTEGER NOT NULL DEFAULT 0,
+    archived INTEGER NOT NULL DEFAULT 0,
+    pinned INTEGER NOT NULL DEFAULT 0,
+    FOREIGN KEY (parent_session_id) REFERENCES sessions(id),
+    FOREIGN KEY (system_prompt_hash) REFERENCES system_prompts(hash)
+)
+"""
+
+
+# Indexes on ``sessions`` that DROP TABLE removes during the row_id swap and
+# the migration must recreate inside the same transaction (all IF NOT EXISTS
+# so the later SCHEMA_SQL / DEFERRED_INDEX_SQL passes no-op on them).
+SESSION_INDEX_SQL_STATEMENTS = (
+    "CREATE INDEX IF NOT EXISTS idx_sessions_source ON sessions(source)",
+    "CREATE INDEX IF NOT EXISTS idx_sessions_source_id ON sessions(source, id)",
+    "CREATE INDEX IF NOT EXISTS idx_sessions_parent ON sessions(parent_session_id)",
+    "CREATE INDEX IF NOT EXISTS idx_sessions_started ON sessions(started_at DESC)",
+    "CREATE INDEX IF NOT EXISTS idx_sessions_session_key "
+    "ON sessions(session_key, started_at DESC)",
+    "CREATE INDEX IF NOT EXISTS idx_sessions_gateway_peer ON sessions("
+    "source, user_id, chat_id, chat_type, thread_id, started_at DESC)",
+    "CREATE INDEX IF NOT EXISTS idx_sessions_handoff_state "
+    "ON sessions(handoff_state, started_at)",
+    "CREATE INDEX IF NOT EXISTS idx_sessions_system_prompt_hash "
+    "ON sessions(system_prompt_hash)",
+    "CREATE UNIQUE INDEX IF NOT EXISTS idx_sessions_title_unique "
+    "ON sessions(title) WHERE title IS NOT NULL",
+)
 
 
 # ── Deferred FTS rebuild bookkeeping (schema v23) ──

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -1059,16 +1059,6 @@ class SessionSchemaMixin:
                 ).fetchone() is None
                 and not self._has_fts_trash(cursor)
                 and not self._fts_external_index_empty_with_messages(cursor)
-                # #25 (session metadata FTS): "fully optimized" also requires
-                # the session Unicode index to be external-content AND settled
-                # (no pending session H/P rebuild claim). A pre-#25 DB whose
-                # sessions_fts is still internal-content, or one mid-backfill,
-                # must not be stamped at the current layout version.
-                and not self._db_has_internal_content_sessions_fts(cursor)
-                and cursor.execute(
-                    "SELECT 1 FROM state_meta "
-                    "WHERE key = 'fts_session_rebuild_high_water' LIMIT 1"
-                ).fetchone() is None
             ):
                 self.set_meta(
                     "fts_storage_version", str(FTS_STORAGE_VERSION), cursor=cursor

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -1059,6 +1059,16 @@ class SessionSchemaMixin:
                 ).fetchone() is None
                 and not self._has_fts_trash(cursor)
                 and not self._fts_external_index_empty_with_messages(cursor)
+                # #25 (session metadata FTS): "fully optimized" also requires
+                # the session Unicode index to be external-content AND settled
+                # (no pending session H/P rebuild claim). A pre-#25 DB whose
+                # sessions_fts is still internal-content, or one mid-backfill,
+                # must not be stamped at the current layout version.
+                and not self._db_has_internal_content_sessions_fts(cursor)
+                and cursor.execute(
+                    "SELECT 1 FROM state_meta "
+                    "WHERE key = 'fts_session_rebuild_high_water' LIMIT 1"
+                ).fetchone() is None
             ):
                 self.set_meta(
                     "fts_storage_version", str(FTS_STORAGE_VERSION), cursor=cursor
@@ -1170,26 +1180,26 @@ class SessionSchemaMixin:
                     # the surfaces above and gated on the loadable tokenizer:
                     self._ensure_fts_cjk_schema(cursor)
 
-                # ── Sessions FTS5 (title search) ────────────────────────
-                # unicode61 table for non-CJK titles; cjk_unicode61 table
-                # for CJK titles, gated on the loadable tokenizer (LIKE
-                # fallback otherwise). Mirrors the messages FTS pattern.
-                sessions_fts_ok = self._ensure_fts_schema(
-                    cursor, "sessions_fts", SESSIONS_FTS_SQL,
-                )
+                # ── Sessions FTS5 (metadata search, issue #25) ──────────
+                # external-content Unicode over raw (title, id, display_name)
+                # keyed by named sessions.row_id, staged and crash-resumable.
+                # Startup no longer performs a blocking Unicode one-shot
+                # backfill: the external index is claimed with durable H/P
+                # markers and backfilled by the resumable chunk engine
+                # (fts_session_rebuild_step), with search supplementing the
+                # bounded gap meanwhile.
+                sessions_fts_ok = self._ensure_sessions_fts_schema(cursor)
+                self._sessions_fts_available = sessions_fts_ok
+                # CJK title table stays internal-content and one-shot
+                # backfilled (the CJK lifecycle is owned by #26).
                 sessions_cjk_ok = False
                 if sessions_fts_ok and self._fts_cjk_loaded:
                     sessions_cjk_ok = self._ensure_fts_schema(
                         cursor, "sessions_fts_cjk", SESSIONS_FTS_CJK_SQL,
                     )
-                self._sessions_fts_available = sessions_fts_ok
                 self._sessions_cjk_available = sessions_cjk_ok
-                if sessions_fts_ok:
-                    # One-time backfill of pre-existing session titles.
-                    self._backfill_sessions_fts(
-                        cursor,
-                        include_cjk=sessions_cjk_ok,
-                    )
+                if sessions_cjk_ok:
+                    self._backfill_sessions_fts_cjk(cursor)
 
             # Replace any pre-existing broad AFTER UPDATE triggers with
             # AFTER UPDATE OF variants. IF NOT EXISTS cannot rewrite them.

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -1170,26 +1170,35 @@ class SessionSchemaMixin:
                     # the surfaces above and gated on the loadable tokenizer:
                     self._ensure_fts_cjk_schema(cursor)
 
-                # ── Sessions FTS5 (metadata search, issue #25) ──────────
-                # external-content Unicode over raw (title, id, display_name)
-                # keyed by named sessions.row_id, staged and crash-resumable.
-                # Startup no longer performs a blocking Unicode one-shot
-                # backfill: the external index is claimed with durable H/P
-                # markers and backfilled by the resumable chunk engine
-                # (fts_session_rebuild_step), with search supplementing the
-                # bounded gap meanwhile.
-                sessions_fts_ok = self._ensure_sessions_fts_schema(cursor)
-                self._sessions_fts_available = sessions_fts_ok
-                # CJK title table stays internal-content and one-shot
-                # backfilled (the CJK lifecycle is owned by #26).
-                sessions_cjk_ok = False
-                if sessions_fts_ok and self._fts_cjk_loaded:
-                    sessions_cjk_ok = self._ensure_fts_schema(
-                        cursor, "sessions_fts_cjk", SESSIONS_FTS_CJK_SQL,
-                    )
-                self._sessions_cjk_available = sessions_cjk_ok
-                if sessions_cjk_ok:
-                    self._backfill_sessions_fts_cjk(cursor)
+            # ── Sessions FTS5 (metadata search, issue #25) ──────────
+            # external-content Unicode over raw (title, id, display_name)
+            # keyed by named sessions.row_id, staged and crash-resumable.
+            # Startup no longer performs a blocking Unicode one-shot
+            # backfill: the external index is claimed with durable H/P
+            # markers and backfilled by the resumable chunk engine
+            # (fts_session_rebuild_step), with search supplementing the
+            # bounded gap meanwhile.
+            #
+            # Deliberately runs for BOTH message-FTS layouts (legacy v22
+            # inline AND v23 external): whether messages_fts is still legacy
+            # is MESSAGE storage state and must not gate the independent
+            # sessions_fts upgrade (#25). _migrate_sessions_row_id() earlier
+            # DROP TABLE'd the old sessions (taking any pre-#25
+            # sessions_fts_* triggers with it), so the legacy-message path
+            # would otherwise strand the old internal title-only
+            # sessions_fts with no triggers and no H/P claim.
+            sessions_fts_ok = self._ensure_sessions_fts_schema(cursor)
+            self._sessions_fts_available = sessions_fts_ok
+            # CJK title table stays internal-content and one-shot
+            # backfilled (the CJK lifecycle is owned by #26).
+            sessions_cjk_ok = False
+            if sessions_fts_ok and self._fts_cjk_loaded:
+                sessions_cjk_ok = self._ensure_fts_schema(
+                    cursor, "sessions_fts_cjk", SESSIONS_FTS_CJK_SQL,
+                )
+            self._sessions_cjk_available = sessions_cjk_ok
+            if sessions_cjk_ok:
+                self._backfill_sessions_fts_cjk(cursor)
 
             # Replace any pre-existing broad AFTER UPDATE triggers with
             # AFTER UPDATE OF variants. IF NOT EXISTS cannot rewrite them.

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -26,6 +26,8 @@ from hermes_state_common import (
     SCHEMA_VERSION,
     SESSIONS_FTS_CJK_SQL,
     SESSIONS_FTS_SQL,
+    SESSION_INDEX_SQL_STATEMENTS,
+    SESSION_TABLE_REBUILD_SQL,
     _FTS_TRIGGERS,
     _ephemeral_child_sql,
 )
@@ -378,6 +380,142 @@ class SessionSchemaMixin:
                             "reconcile %s.%s: %s", table_name, col_name, exc,
                         )
 
+    def _migrate_sessions_row_id(self, cursor: sqlite3.Cursor) -> None:
+        """Give ``sessions`` a named ``row_id INTEGER PRIMARY KEY`` (#25).
+
+        Session-metadata FTS is migrating to external-content backed by the
+        canonical ``sessions`` table, which needs a stable integer document
+        identity. SQLite cannot ALTER a PRIMARY KEY, so this rebuilds the
+        table with ``row_id INTEGER PRIMARY KEY AUTOINCREMENT`` while keeping
+        the text ``id`` as ``NOT NULL UNIQUE`` — the public/logical session
+        identity every SessionDB API, relationship, and
+        ``messages.session_id`` reference continues to use.
+
+        Idempotent: no-op when ``row_id`` already exists (fresh installs and
+        already-migrated DBs). Runs BEFORE ``_reconcile_columns`` (which must
+        not ALTER-ADD a PK column) and before any DML starts a transaction
+        (``PRAGMA foreign_keys`` can only toggle outside a transaction, and
+        the DROP TABLE swap requires FKs off).
+
+        The legacy hidden ``rowid`` value itself is copied into ``row_id``.
+        An order-preserving copy (``ORDER BY rowid`` + fresh AUTOINCREMENT
+        allocation) is NOT sufficient: deleted-row holes would be densified
+        (1=A, 3=B, 7=C must stay 1,3,7, not become 1,2,3). The whole
+        create/copy/verify/drop/rename/index-recreate swap is one explicit
+        BEGIN IMMEDIATE transaction, so an interrupted swap rolls back to the
+        intact legacy layout instead of stranding an empty replacement.
+        """
+        if getattr(self, "read_only", False):
+            return
+        try:
+            rows = cursor.execute('PRAGMA table_info("sessions")').fetchall()
+        except sqlite3.OperationalError:
+            return
+        names = {
+            (r["name"] if isinstance(r, sqlite3.Row) else r[1]) for r in rows
+        }
+        if "row_id" in names:
+            return
+
+        # Preflight pathological legacy rows before mutating anything: the
+        # new shape requires id NOT NULL UNIQUE, and we refuse to invent an
+        # ID for a row that never had one.
+        null_id = cursor.execute(
+            "SELECT COUNT(*) FROM sessions WHERE id IS NULL"
+        ).fetchone()
+        null_count = int(
+            null_id[0] if not isinstance(null_id, sqlite3.Row) else null_id[0]
+        )
+        if null_count > 0:
+            logger.error(
+                "Cannot migrate sessions to named row_id: %d row(s) have NULL "
+                "id; sessions table left unchanged", null_count,
+            )
+            raise sqlite3.IntegrityError(
+                "sessions.id contains NULL rows; cannot make id NOT NULL UNIQUE"
+            )
+
+        logger.warning(
+            "Migrating sessions table to named row_id (#25); one transactional "
+            "rebuild (preserves every logical id and exact numeric rowid)"
+        )
+        # Clear any transaction executescript may have left open so the
+        # PRAGMA foreign_keys toggle is legal (autocommit only).
+        try:
+            cursor.execute("COMMIT")
+        except sqlite3.OperationalError:
+            pass
+        cursor.execute("PRAGMA foreign_keys=OFF")
+        try:
+            cursor.execute("BEGIN IMMEDIATE")
+            # A donor-style interrupted attempt may have left a partial
+            # sessions_new behind; drop it inside the transaction.
+            cursor.execute("DROP TABLE IF EXISTS sessions_new")
+            cursor.execute(SESSION_TABLE_REBUILD_SQL)
+            new_cols = {
+                (r["name"] if isinstance(r, sqlite3.Row) else r[1])
+                for r in cursor.execute(
+                    'PRAGMA table_info("sessions_new")'
+                ).fetchall()
+            }
+            # Copy only columns the new table declares (guards against drift
+            # if an old table ever carries a stray extra column), copying the
+            # OLD hidden rowid explicitly into row_id.
+            shared = (names & new_cols) - {"row_id"}
+            cols_sql = ", ".join(f'"{c}"' for c in sorted(shared))
+            cursor.execute(
+                f"INSERT INTO sessions_new (row_id, {cols_sql}) "
+                f"SELECT rowid, {cols_sql} FROM sessions"
+            )
+            # Verify row count and exact {id: row_id} identity before the
+            # destructive drop — never commit a densified / lost-row swap.
+            old_count = cursor.execute(
+                "SELECT COUNT(*) FROM sessions"
+            ).fetchone()[0]
+            new_count = cursor.execute(
+                "SELECT COUNT(*) FROM sessions_new"
+            ).fetchone()[0]
+            if old_count != new_count:
+                raise sqlite3.OperationalError(
+                    "sessions row_id migration row-count mismatch: "
+                    f"old={old_count} new={new_count}"
+                )
+            mismatch = cursor.execute(
+                "SELECT COUNT(*) FROM sessions s "
+                "LEFT JOIN sessions_new n "
+                "  ON n.id = s.id AND n.row_id = s.rowid "
+                "WHERE n.id IS NULL"
+            ).fetchone()[0]
+            if int(mismatch) > 0:
+                raise sqlite3.OperationalError(
+                    "sessions row_id migration failed {id: row_id} identity check"
+                )
+            cursor.execute("DROP TABLE sessions")
+            cursor.execute("ALTER TABLE sessions_new RENAME TO sessions")
+            # Recreate the sessions indexes DROP TABLE removed. All IF NOT
+            # EXISTS; the later SCHEMA_SQL / DEFERRED_INDEX_SQL passes no-op.
+            for stmt in SESSION_INDEX_SQL_STATEMENTS:
+                cursor.execute(stmt)
+            cursor.execute("COMMIT")
+        except sqlite3.Error:
+            try:
+                cursor.execute("ROLLBACK")
+            except sqlite3.OperationalError:
+                pass
+            logger.exception(
+                "sessions row_id migration failed; sessions table left unchanged"
+            )
+            raise
+        finally:
+            cursor.execute("PRAGMA foreign_keys=ON")
+        # FK integrity across every reference to sessions(id) after the swap.
+        fk_violations = cursor.execute("PRAGMA foreign_key_check").fetchall()
+        if fk_violations:
+            logger.error(
+                "sessions row_id migration left %d FK violation(s)",
+                len(fk_violations),
+            )
+
     def _heal_gateway_routing_pk(self, cursor: sqlite3.Cursor) -> None:
         """Rebuild ``gateway_routing`` when its PRIMARY KEY predates scoping.
 
@@ -587,6 +725,14 @@ class SessionSchemaMixin:
         cursor = self._conn.cursor()
 
         cursor.executescript(SCHEMA_SQL)
+
+        # ── Named sessions.row_id migration (#25) ──────────────────────
+        # Give sessions a named INTEGER PRIMARY KEY storage identity before
+        # any reconciler runs: SQLite cannot ALTER a primary key, and
+        # _reconcile_columns must never ALTER-ADD a PK column. Detection-based
+        # and idempotent — fresh installs are already born with the new shape
+        # (SCHEMA_SQL), so this only rebuilds legacy tables.
+        self._migrate_sessions_row_id(cursor)
 
         # ── Declarative column reconciliation ──────────────────────────
         # Diff live tables against SCHEMA_SQL and ADD any missing columns.

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -32,6 +32,51 @@ from hermes_state_common import (
 logger = logging.getLogger("hermes_state")
 
 
+# Deferred-rebuild specs shared by the message and session metadata FTS
+# engines. Each spec describes one external-content index family so the
+# crash-safe claim / chunk / finish rules (accepted through #76832 for
+# messages, #25 for sessions) are implemented ONCE in
+# ``fts_rebuild_status/step`` / ``_fts_rebuild_finish`` and only the SQL,
+# table, row key, and marker names differ. ``available`` /
+# ``trigram_available`` are callables taking the SessionDB host (the mixin
+# methods cannot read ``self._fts_enabled`` at import time).
+_FTS_MESSAGE_SPEC = {
+    "name": "messages",
+    "high_water_key": "fts_rebuild_high_water",
+    "progress_key": "fts_rebuild_progress",
+    "fts_table": "messages_fts",
+    "fts_columns": ("content", "tool_name", "tool_calls"),
+    "source_table": "messages",
+    "source_columns": ("content", "tool_name", "tool_calls"),
+    "row_key": "id",
+    "trigram_fts": "messages_fts_trigram",
+    "trigram_columns": ("content", "tool_name", "tool_calls"),
+    "trigram_where": "role <> 'tool'",
+    "reset_tables": ("messages_fts", "messages_fts_trigram"),
+    "available": lambda self: self._fts_enabled,
+    "trigram_available": lambda self: self._trigram_available,
+}
+
+_FTS_SESSION_SPEC = {
+    "name": "sessions",
+    "high_water_key": "fts_session_rebuild_high_water",
+    "progress_key": "fts_session_rebuild_progress",
+    "fts_table": "sessions_fts",
+    # Raw canonical values only — no normalization / synthetic concatenation
+    # (normalized arbitrary infix belongs to #30).
+    "fts_columns": ("title", "id", "display_name"),
+    "source_table": "sessions",
+    "source_columns": ("title", "id", "display_name"),
+    "row_key": "row_id",
+    "trigram_fts": None,
+    "trigram_columns": (),
+    "trigram_where": None,
+    "reset_tables": ("sessions_fts",),
+    "available": lambda self: getattr(self, "_sessions_fts_available", False),
+    "trigram_available": lambda self: False,
+}
+
+
 class SessionSearchMixin:
     """See module docstring — mixin for SessionDB (Search cluster)."""
 
@@ -79,7 +124,26 @@ class SessionSearchMixin:
             # optional missing index.
             logger.warning("FTS incremental merge failed: %s", exc)
 
-    def fts_rebuild_status(self) -> Optional[Dict[str, Any]]:
+    def _fts_rebuild_pause(self, chunk_seconds: float) -> None:
+        """Inter-chunk throttle shared by every deferred FTS rebuild loop.
+
+        Extracted from ``optimize_fts_storage``'s nested closure so both the
+        message and the session metadata (issue #25) rebuilds route through
+        ONE monkeypatchable helper. The duty cycle is what keeps a live
+        gateway/CLI process sharing the DB responsive: without it, back-to-
+        back BEGIN IMMEDIATE chunks starve concurrent writers out of their
+        lock retries (the measured ~85% write-lock ownership that froze
+        concurrent sessions). No session-specific copy of ``500`` / ``4.0`` /
+        ``0.2`` or this formula is introduced.
+        """
+        time.sleep(max(
+            self._FTS_REBUILD_MIN_PAUSE,
+            chunk_seconds * self._FTS_REBUILD_DUTY_FACTOR,
+        ))
+
+    def fts_rebuild_status(
+        self, spec: Optional[Dict[str, Any]] = None
+    ) -> Optional[Dict[str, Any]]:
         """Return deferred-rebuild progress, or None when no rebuild pending.
 
         Shape: {"pending": True, "total": <rows at drop time>,
@@ -87,28 +151,31 @@ class SessionSearchMixin:
         Consumed by search_messages() notes and by status surfaces
         (dashboard/desktop can poll this to render a progress indicator).
 
-        Reads state_meta directly via _read_ctx instead of calling
-        get_meta() (which takes self._lock) so search_messages doesn't
-        block on the writer lock when checking rebuild status.
+        ``spec`` selects the marker pair: the message rebuild by default, or
+        the session Unicode metadata rebuild (issue #25). Reads state_meta
+        directly via _read_ctx instead of calling get_meta() (which takes
+        self._lock) so search_messages doesn't block on the writer lock when
+        checking rebuild status.
         """
+        spec = spec or _FTS_MESSAGE_SPEC
         with self._read_ctx() as conn:
             row = conn.execute(
                 "SELECT key, value FROM state_meta WHERE key IN (?, ?)",
-                ("fts_rebuild_high_water", "fts_rebuild_progress"),
+                (spec["high_water_key"], spec["progress_key"]),
             ).fetchall()
         meta = {r["key"]: r["value"] for r in row}
-        high_water = meta.get("fts_rebuild_high_water")
+        high_water = meta.get(spec["high_water_key"])
         if high_water is None:
             return None
-        progress = int(meta.get("fts_rebuild_progress") or 0)
+        progress = int(meta.get(spec["progress_key"]) or 0)
         total = int(high_water)
         if total <= 0:
             return None
         pct = min(100, int(100 * progress / total))
         return {"pending": True, "total": total, "indexed": progress, "percent": pct}
 
-    def _fts_rebuild_finish(self) -> None:
-        """Finalize the deferred rebuild: boundary sweep + clear markers.
+    def _fts_rebuild_finish(self, spec: Optional[Dict[str, Any]] = None) -> None:
+        """Finalize a deferred rebuild: boundary sweep + clear markers.
 
         The sweep is cheap insurance against any write that slipped through
         the migration-boundary instant (between high_water capture and
@@ -116,46 +183,64 @@ class SessionSearchMixin:
         index is missing. docsize has one row per indexed doc, so the
         anti-join is exact and runs on a narrow id range.
 
-        The trigram half of the sweep is gated on ``self._trigram_available``
-        for the same reason ``fts_rebuild_step()`` gates its backfill INSERT:
-        when the SQLite build has no trigram tokenizer (or the table was
-        never created), an unconditional INSERT raises ``no such table``
+        The trigram half of the sweep is gated on the spec's availability
+        probe for the same reason ``fts_rebuild_step()`` gates its backfill
+        INSERT: when the SQLite build has no trigram tokenizer (or the table
+        was never created), an unconditional INSERT raises ``no such table``
         and aborts the whole rebuild — taking ``optimize_fts_storage()``
         down with it.
         """
-        include_trigram = self._trigram_available
+        spec = spec or _FTS_MESSAGE_SPEC
+        include_trigram = bool(
+            spec.get("trigram_fts") and spec["trigram_available"](self)
+        )
+        fts_table = spec["fts_table"]
+        source_table = spec["source_table"]
+        row_key = spec["row_key"]
+        fts_cols = ", ".join(spec["fts_columns"])
+        src_cols = ", ".join(spec["source_columns"])
 
         def _do(conn):
             hw_row = conn.execute(
-                "SELECT value FROM state_meta WHERE key = 'fts_rebuild_high_water'"
+                "SELECT value FROM state_meta WHERE key = ?",
+                (spec["high_water_key"],),
             ).fetchone()
             if hw_row is not None:
                 hw = int(hw_row[0])
                 # Sweep a generous window around the boundary.
                 lo, hi = hw - 1000, hw + 1000
                 conn.execute(
-                    "INSERT INTO messages_fts(rowid, content, tool_name, tool_calls) "
-                    "SELECT m.id, m.content, m.tool_name, m.tool_calls "
-                    "FROM messages m "
-                    "WHERE m.id > ? AND m.id <= ? "
-                    "AND NOT EXISTS (SELECT 1 FROM messages_fts_docsize d WHERE d.id = m.id)",
+                    f"INSERT INTO {fts_table}(rowid, {fts_cols}) "
+                    f"SELECT {source_table}.{row_key}, {src_cols} "
+                    f"FROM {source_table} "
+                    f"WHERE {source_table}.{row_key} > ? "
+                    f"AND {source_table}.{row_key} <= ? "
+                    f"AND NOT EXISTS (SELECT 1 FROM {fts_table}_docsize d "
+                    f"                WHERE d.id = {source_table}.{row_key})",
                     (lo, hi),
                 )
-                if include_trigram:
+                trigram = spec.get("trigram_fts")
+                if trigram and include_trigram:
+                    trigram_cols = ", ".join(spec["trigram_columns"])
                     conn.execute(
-                        "INSERT INTO messages_fts_trigram(rowid, content, tool_name, tool_calls) "
-                        "SELECT m.id, m.content, m.tool_name, m.tool_calls "
-                        "FROM messages m "
-                        "WHERE m.id > ? AND m.id <= ? AND m.role <> 'tool' "
-                        "AND NOT EXISTS (SELECT 1 FROM messages_fts_trigram_docsize d WHERE d.id = m.id)",
+                        f"INSERT INTO {trigram}(rowid, {trigram_cols}) "
+                        f"SELECT {source_table}.{row_key}, {src_cols} "
+                        f"FROM {source_table} "
+                        f"WHERE {source_table}.{row_key} > ? "
+                        f"AND {source_table}.{row_key} <= ? "
+                        f"AND {spec['trigram_where']} "
+                        f"AND NOT EXISTS (SELECT 1 FROM {trigram}_docsize d "
+                        f"                WHERE d.id = {source_table}.{row_key})",
                         (lo, hi),
                     )
             conn.execute(
-                "DELETE FROM state_meta WHERE key IN "
-                "('fts_rebuild_high_water', 'fts_rebuild_progress')"
+                "DELETE FROM state_meta WHERE key IN (?, ?)",
+                (spec["high_water_key"], spec["progress_key"]),
             )
         self._execute_write(_do)
-        logger.info("Deferred FTS rebuild complete — all messages indexed.")
+        logger.info(
+            "Deferred %s FTS rebuild complete — all rows indexed.", spec["name"]
+        )
 
     def _fts_teardown_trash_step(self) -> bool:
         """Tear down one chunk of a demoted v22 FTS shadow table.
@@ -199,29 +284,41 @@ class SessionSearchMixin:
             logger.debug("FTS trash teardown chunk failed (will retry): %s", exc)
             return True
 
-    def fts_rebuild_step(self) -> bool:
-        """Backfill one chunk of the deferred FTS rebuild.
+    def fts_rebuild_step(self, spec: Optional[Dict[str, Any]] = None) -> bool:
+        """Backfill one chunk of a deferred FTS rebuild.
 
         Returns True when more work remains, False when the rebuild is
         complete (or none is pending). Safe to call from any process at any
         time; chunks are claimed atomically inside the write transaction, so
         concurrent callers interleave instead of duplicating rows.
+
+        ``spec`` selects the rebuild: messages by default, or the session
+        Unicode metadata rebuild (issue #25) via ``fts_session_rebuild_step``.
         """
-        if not self._fts_enabled:
+        spec = spec or _FTS_MESSAGE_SPEC
+        if not spec["available"](self):
             return False
-        high_water_raw = self.get_meta("fts_rebuild_high_water")
+        high_water_raw = self.get_meta(spec["high_water_key"])
         if high_water_raw is None:
             return False
         high_water = int(high_water_raw)
-        include_trigram = self._trigram_available
         chunk = self._FTS_REBUILD_CHUNK_ROWS
+        fts_table = spec["fts_table"]
+        source_table = spec["source_table"]
+        row_key = spec["row_key"]
+        fts_cols = ", ".join(spec["fts_columns"])
+        src_cols = ", ".join(spec["source_columns"])
+        include_trigram = bool(
+            spec.get("trigram_fts") and spec["trigram_available"](self)
+        )
 
         def _do(conn):
             # Re-read progress inside the write transaction (BEGIN IMMEDIATE
             # is already held by _execute_write) — this is the claim: two
             # workers can't read the same progress value concurrently.
             row = conn.execute(
-                "SELECT value FROM state_meta WHERE key = 'fts_rebuild_progress'"
+                "SELECT value FROM state_meta WHERE key = ?",
+                (spec["progress_key"],),
             ).fetchone()
             if row is None:
                 return False  # finished (or cleared) by another process
@@ -233,39 +330,62 @@ class SessionSearchMixin:
             # deleted rows don't shrink chunks below the claimed range.
             upper = min(progress + chunk, high_water)
             conn.execute(
-                "INSERT INTO messages_fts(rowid, content, tool_name, tool_calls) "
-                "SELECT id, content, tool_name, tool_calls FROM messages "
-                "WHERE id > ? AND id <= ?",
+                f"INSERT INTO {fts_table}(rowid, {fts_cols}) "
+                f"SELECT {row_key}, {src_cols} FROM {source_table} "
+                f"WHERE {row_key} > ? AND {row_key} <= ?",
                 (progress, upper),
             )
-            if include_trigram:
+            trigram = spec.get("trigram_fts")
+            if trigram and include_trigram:
+                trigram_cols = ", ".join(spec["trigram_columns"])
                 conn.execute(
-                    "INSERT INTO messages_fts_trigram"
-                    "(rowid, content, tool_name, tool_calls) "
-                    "SELECT id, content, tool_name, tool_calls FROM messages "
-                    "WHERE id > ? AND id <= ? AND role <> 'tool'",
+                    f"INSERT INTO {trigram}(rowid, {trigram_cols}) "
+                    f"SELECT {row_key}, {src_cols} FROM {source_table} "
+                    f"WHERE {row_key} > ? AND {row_key} <= ? "
+                    f"AND {spec['trigram_where']}",
                     (progress, upper),
                 )
             # Publish progress in the same transaction as the rows it
             # covers — crash-atomic: either both land or neither does.
             conn.execute(
-                "UPDATE state_meta SET value = ? "
-                "WHERE key = 'fts_rebuild_progress'",
-                (str(upper),),
+                "UPDATE state_meta SET value = ? WHERE key = ?",
+                (str(upper), spec["progress_key"]),
             )
             return upper < high_water
 
         try:
             more = self._execute_write(_do)
         except sqlite3.OperationalError as exc:
-            logger.debug("FTS rebuild chunk failed (will retry): %s", exc)
+            logger.debug(
+                "%s FTS rebuild chunk failed (will retry): %s", spec["name"], exc
+            )
             return True  # transient (lock contention) — caller retries
         if more is False:
-            status = self.fts_rebuild_status()
+            status = self.fts_rebuild_status(spec)
             if status is not None and status["indexed"] >= status["total"]:
-                self._fts_rebuild_finish()
+                self._fts_rebuild_finish(spec)
             return False
         return bool(more)
+
+    def fts_session_rebuild_status(self) -> Optional[Dict[str, Any]]:
+        """Session Unicode metadata index backfill progress, or None when none
+        is pending (issue #25)."""
+        return self.fts_rebuild_status(spec=_FTS_SESSION_SPEC)
+
+    def fts_session_rebuild_step(self) -> bool:
+        """Backfill one chunk of the session Unicode metadata index (issue #25).
+
+        True while work remains. Shares the crash-safe chunk claim / atomic
+        progress / finish rules with the message rebuild — only the source
+        table, row key, columns, and marker names differ.
+        """
+        return self.fts_rebuild_step(spec=_FTS_SESSION_SPEC)
+
+    def _fts_session_rebuild_finish(self) -> None:
+        """Boundary sweep + clear the session markers (issue #25)."""
+        self._fts_rebuild_finish(spec=_FTS_SESSION_SPEC)
+        self._sessions_fts_available = True
+        logger.info("Session metadata FTS backfill complete — serving search.")
 
     def fts_cjk_rebuild_status(self) -> Optional[Dict[str, Any]]:
         """CJK-index backfill progress, or None when none is pending."""
@@ -396,20 +516,23 @@ class SessionSearchMixin:
                 self._ensure_fts_cjk_schema(self._conn)
                 self._conn.commit()
 
-    def _fts_external_index_empty_with_messages(self, conn) -> bool:
-        """True when the base FTS table exists but indexes nothing while
-        ``messages`` has rows. Caller must hold ``self._lock``.
+    def _fts_external_index_empty_with_source(
+        self, conn, source_table: str, fts_table: str
+    ) -> bool:
+        """True when an external-content FTS table exists but indexes nothing
+        while its canonical source table has rows. Caller must hold
+        ``self._lock``.
 
-        This is the post-demote empty-index shape: external-content FTS with
-        zero ``messages_fts_docsize`` rows against a non-empty messages table.
-        Healthy installs (and mid-backfill installs that still hold markers)
-        never match.
+        This is the post-demote / crash-window empty-index shape: external-
+        content FTS with zero ``<fts>_docsize`` rows against a non-empty
+        source table. Healthy installs (and mid-backfill installs that still
+        hold markers) never match.
         """
         try:
-            has_msg = conn.execute(
-                "SELECT EXISTS(SELECT 1 FROM messages)"
+            has_src = conn.execute(
+                f"SELECT EXISTS(SELECT 1 FROM {source_table})"
             ).fetchone()[0]
-            if not has_msg:
+            if not has_src:
                 return False
             # docsize is the authoritative "is this rowid indexed" surface for
             # external-content FTS5; probing the virtual table itself is
@@ -418,50 +541,62 @@ class SessionSearchMixin:
             # condition, and COUNT(*) is a full b-tree scan (~100ms on a
             # 2M-row table) while EXISTS is O(1).
             has_fts = conn.execute(
-                "SELECT EXISTS(SELECT 1 FROM messages_fts_docsize)"
+                f"SELECT EXISTS(SELECT 1 FROM {fts_table}_docsize)"
             ).fetchone()[0]
             return not has_fts
         except sqlite3.OperationalError:
             # Table absent / FTS disabled mid-init — not this failure class.
             return False
 
-    def _fts_index_known_empty(self, conn) -> bool:
-        """True when the base external-content index holds no rows.
+    def _fts_external_index_empty_with_messages(self, conn) -> bool:
+        """Message-index variant of ``_fts_external_index_empty_with_source``."""
+        return self._fts_external_index_empty_with_source(
+            conn, "messages", "messages_fts"
+        )
+
+    def _fts_index_known_empty(
+        self, conn, fts_table: str = "messages_fts"
+    ) -> bool:
+        """True when an external-content index holds no rows.
 
         A missing table counts as empty: the schema ensure that follows
         creates it fresh.
         """
         try:
             n = conn.execute(
-                "SELECT COUNT(*) FROM messages_fts_docsize"
+                f"SELECT COUNT(*) FROM {fts_table}_docsize"
             ).fetchone()[0]
             return int(n) == 0
         except sqlite3.OperationalError:
             return True
 
-    def _reset_fts_index_to_empty(self, conn) -> None:
-        """Delete every indexed row from the v23 external-content tables.
+    def _reset_fts_index_to_empty(
+        self, conn, tables: Optional[Collection[str]] = None
+    ) -> None:
+        """Delete every indexed row from the given external-content tables.
 
         Uses the FTS5 ``'delete-all'`` special command — the documented O(1)
         truncate for external-content tables. A plain no-WHERE ``DELETE`` is
         O(rows) on external-content FTS5 (each row's delete tokens are
         regenerated from the content table; measured ~12µs/row, minutes on a
         large index, while holding the write lock) and corrupts the index if
-        indexed rows have diverged from ``messages`` — precisely the broken-
-        bookkeeping shape this repair path handles. The backfill chunk worker
-        replays its whole selected id range with no anti-join, so a replay
-        from zero is only safe once the index is known empty — this is how a
-        partially indexed DB gets there.
+        indexed rows have diverged from the canonical source table — precisely
+        the broken-bookkeeping shape this repair path handles. The backfill
+        chunk worker replays its whole selected id range with no anti-join, so
+        a replay from zero is only safe once the index is known empty — this
+        is how a partially indexed DB gets there.
         """
-        for tbl in ("messages_fts", "messages_fts_trigram"):
+        for tbl in tables or ("messages_fts", "messages_fts_trigram"):
             try:
                 conn.execute(f"INSERT INTO {tbl}({tbl}) VALUES('delete-all')")
             except sqlite3.OperationalError:
                 pass  # table absent — already an empty surface
 
-    def _seed_fts_rebuild_markers(self, conn, *, force: bool = False) -> int:
-        """Write ``fts_rebuild_high_water`` / ``fts_rebuild_progress`` for a
-        full backfill. Returns the high-water id.
+    def _seed_fts_rebuild_markers(
+        self, conn, spec: Optional[Dict[str, Any]] = None, *, force: bool = False
+    ) -> int:
+        """Write a rebuild's high_water / progress keys for a full backfill.
+        Returns the high-water id.
 
         When ``force`` is False and high_water is already set, only repairs a
         missing progress key (stuck no-op when high_water exists alone), and
@@ -471,33 +606,36 @@ class SessionSearchMixin:
         zero on top of surviving rows. Caller must hold the write
         transaction / lock as appropriate.
         """
+        spec = spec or _FTS_MESSAGE_SPEC
         existing_hw = conn.execute(
-            "SELECT value FROM state_meta WHERE key = 'fts_rebuild_high_water'"
+            "SELECT value FROM state_meta WHERE key = ?",
+            (spec["high_water_key"],),
         ).fetchone()
         if existing_hw is not None and not force:
             hw = int(existing_hw[0])
             progress = conn.execute(
-                "SELECT value FROM state_meta WHERE key = 'fts_rebuild_progress'"
+                "SELECT value FROM state_meta WHERE key = ?",
+                (spec["progress_key"],),
             ).fetchone()
             if progress is None:
                 # high_water without progress: fts_rebuild_step treats missing
                 # progress as "done by another process" and optimize would
                 # no-op then stamp. Re-seed progress so the chunk loop runs.
-                if not self._fts_index_known_empty(conn):
-                    self._reset_fts_index_to_empty(conn)
+                if not self._fts_index_known_empty(conn, spec["fts_table"]):
+                    self._reset_fts_index_to_empty(conn, spec["reset_tables"])
                 conn.execute(
-                    "INSERT INTO state_meta (key, value) VALUES "
-                    "('fts_rebuild_progress', '0') "
-                    "ON CONFLICT(key) DO UPDATE SET value = excluded.value"
+                    "INSERT INTO state_meta (key, value) VALUES (?, '0') "
+                    "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                    (spec["progress_key"],),
                 )
             return hw
 
         hw = conn.execute(
-            "SELECT COALESCE(MAX(id), 0) FROM messages"
+            f"SELECT COALESCE(MAX({spec['row_key']}), 0) FROM {spec['source_table']}"
         ).fetchone()[0]
         for k, v in (
-            ("fts_rebuild_high_water", str(hw)),
-            ("fts_rebuild_progress", "0"),
+            (spec["high_water_key"], str(hw)),
+            (spec["progress_key"], "0"),
         ):
             conn.execute(
                 "INSERT INTO state_meta (key, value) VALUES (?, ?) "
@@ -506,44 +644,66 @@ class SessionSearchMixin:
             )
         return int(hw)
 
-    def _repair_optimize_bookkeeping(self) -> None:
+    def _seed_session_fts_rebuild_markers(
+        self, conn, *, force: bool = False
+    ) -> int:
+        """Session Unicode metadata variant of ``_seed_fts_rebuild_markers``.
+
+        An empty DB is complete by construction (the triggers cover every
+        future row) and must not carry a spurious claim that would make
+        ``fts_optimize_available`` advertise pending work forever.
+        """
+        n = conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0]
+        if n == 0 and not force:
+            return 0
+        return self._seed_fts_rebuild_markers(
+            conn, _FTS_SESSION_SPEC, force=force
+        )
+
+    def _repair_optimize_bookkeeping(
+        self, spec: Optional[Dict[str, Any]] = None
+    ) -> None:
         """Heal interrupted demote/backfill bookkeeping before optimize runs.
 
         Covers two post-#65798 failure classes:
 
-        1. Empty external-content index with messages present and no rebuild
-           markers (demote crash window after empty v23 tables landed but
-           before markers, or settle that stamped without backfill). Seed a
-           full backfill.
-        2. ``fts_rebuild_high_water`` present without ``fts_rebuild_progress``
-           (partial meta) — seed progress so the chunk loop is not a no-op,
-           resetting a partially populated index to a known-empty surface
-           first so the anti-join-free chunk replay cannot duplicate rows.
+        1. Empty external-content index with the source table present and no
+           rebuild markers (demote crash window after empty v23 tables landed
+           but before markers, or settle that stamped without backfill). Seed
+           a full backfill.
+        2. high_water present without progress (partial meta) — seed progress
+           so the chunk loop is not a no-op, resetting a partially populated
+           index to a known-empty surface first so the anti-join-free chunk
+           replay cannot duplicate rows.
 
         Must not invent markers on a still-legacy inline DB: that would make
         ``optimize_fts_storage`` skip demote (``legacy and not pending``) and
         attempt v23-shaped INSERTs against the inline table forever.
         """
+        spec = spec or _FTS_MESSAGE_SPEC
+
         def _do(conn):
             existing_hw = conn.execute(
-                "SELECT value FROM state_meta "
-                "WHERE key = 'fts_rebuild_high_water'"
+                "SELECT value FROM state_meta WHERE key = ?",
+                (spec["high_water_key"],),
             ).fetchone()
 
             if existing_hw is not None:
                 # Repair orphan high_water-without-progress only. Never
                 # invent a fresh claim on a healthy complete index.
                 progress = conn.execute(
-                    "SELECT 1 FROM state_meta "
-                    "WHERE key = 'fts_rebuild_progress'"
+                    "SELECT 1 FROM state_meta WHERE key = ?",
+                    (spec["progress_key"],),
                 ).fetchone()
                 if progress is None:
-                    if not self._fts_index_known_empty(conn):
-                        self._reset_fts_index_to_empty(conn)
+                    if not self._fts_index_known_empty(
+                        conn, spec["fts_table"]
+                    ):
+                        self._reset_fts_index_to_empty(conn, spec["reset_tables"])
                     conn.execute(
-                        "INSERT INTO state_meta (key, value) VALUES "
-                        "('fts_rebuild_progress', '0') "
-                        "ON CONFLICT(key) DO UPDATE SET value = '0'"
+                        "INSERT INTO state_meta (key, value) VALUES (?, '0') "
+                        "ON CONFLICT(key) DO UPDATE SET value = '0'",
+                        (spec["progress_key"],),
                     )
                 return
 
@@ -558,6 +718,41 @@ class SessionSearchMixin:
                     "DELETE FROM state_meta WHERE key = 'fts_storage_version'"
                 )
                 self._seed_fts_rebuild_markers(conn, force=True)
+        self._execute_write(_do)
+
+    def _repair_session_fts_bookkeeping(self) -> None:
+        """Heal interrupted session Unicode metadata backfill bookkeeping
+        (#25). Mirrors ``_repair_optimize_bookkeeping`` on the session marker
+        pair, reusing the same crash-safe rule: never infer P=0 over a
+        maybe-partial index; either recover a proven boundary or reset the
+        derived index to a known-empty surface first.
+        """
+        def _do(conn):
+            existing_hw = conn.execute(
+                "SELECT value FROM state_meta "
+                "WHERE key = 'fts_session_rebuild_high_water'"
+            ).fetchone()
+            if existing_hw is not None:
+                progress = conn.execute(
+                    "SELECT 1 FROM state_meta "
+                    "WHERE key = 'fts_session_rebuild_progress'"
+                ).fetchone()
+                if progress is None:
+                    if not self._fts_index_known_empty(conn, "sessions_fts"):
+                        self._reset_fts_index_to_empty(conn, ("sessions_fts",))
+                    conn.execute(
+                        "INSERT INTO state_meta (key, value) VALUES "
+                        "('fts_session_rebuild_progress', '0') "
+                        "ON CONFLICT(key) DO UPDATE SET value = '0'"
+                    )
+                return
+            # No claim: a freshly-created external index over a populated DB
+            # that lost its markers, or a crash window after schema ensure
+            # without a claim. Seed a full backfill (orphan recovery).
+            if self._fts_external_index_empty_with_source(
+                conn, "sessions", "sessions_fts"
+            ):
+                self._seed_session_fts_rebuild_markers(conn, force=True)
         self._execute_write(_do)
 
     def fts_optimize_available(self) -> bool:
@@ -586,6 +781,14 @@ class SessionSearchMixin:
                 "WHERE key = 'fts_rebuild_high_water' LIMIT 1"
             ).fetchone():
                 return True
+            # Session Unicode metadata rebuild pending (issue #25): the
+            # external index was staged at open with a durable H/P claim and
+            # the historical backfill is not complete yet.
+            if self._conn.execute(
+                "SELECT 1 FROM state_meta "
+                "WHERE key = 'fts_session_rebuild_high_water' LIMIT 1"
+            ).fetchone():
+                return True
             # CJK-bigram index work — only offerable when THIS process can
             # tokenize: a pending backfill (markers set at creation on a
             # populated DB) or a stale index awaiting a from-scratch rebuild.
@@ -599,7 +802,13 @@ class SessionSearchMixin:
             # Pre-fix crash window: empty external-content index with
             # messages still present, no markers, no trash (teardown already
             # finished or never needed). Re-run seeds markers and backfills.
-            return self._fts_external_index_empty_with_messages(self._conn)
+            if self._fts_external_index_empty_with_messages(self._conn):
+                return True
+            # Session orphan: external sessions_fts empty with sessions
+            # present and no claim (crash window) — healable on re-run.
+            return self._fts_external_index_empty_with_source(
+                self._conn, "sessions", "sessions_fts"
+            )
 
     def _demote_legacy_fts_to_trash(self) -> int:
         """Demote the legacy inline FTS vtables and stage their shadow tables
@@ -695,6 +904,8 @@ class SessionSearchMixin:
         # markers when trash was already staged (or torn down) without a
         # backfill claim so the phases below actually run.
         self._repair_optimize_bookkeeping()
+        # Same healing for the session Unicode metadata rebuild (issue #25).
+        self._repair_session_fts_bookkeeping()
 
         # Only demote if we're actually still on the legacy shape. If a prior
         # run already demoted (markers/trash present), skip straight to
@@ -744,26 +955,14 @@ class SessionSearchMixin:
             st = self.fts_rebuild_status()
             if st is None:
                 st = self.fts_cjk_rebuild_status()
+            if st is None:
+                st = self.fts_session_rebuild_status()
             progress_cb({
                 "phase": phase,
                 "percent": st["percent"] if st else 100,
                 "indexed": st["indexed"] if st else 0,
                 "total": st["total"] if st else 0,
             })
-
-        def _pause(chunk_seconds: float) -> None:
-            """Inter-chunk throttle (see the chunk-engine note above).
-
-            The chunk methods themselves never sleep, so this loop is the
-            single place the duty cycle is enforced: without it, back-to-back
-            BEGIN IMMEDIATE chunks starve any live gateway/CLI process
-            sharing the DB out of its lock retries (the measured ~85%
-            write-lock ownership that froze concurrent sessions).
-            """
-            time.sleep(max(
-                self._FTS_REBUILD_MIN_PAUSE,
-                chunk_seconds * self._FTS_REBUILD_DUTY_FACTOR,
-            ))
 
         # Phase 1: backfill (foreground, throttled between chunks so a live
         # gateway sharing the DB stays responsive).
@@ -773,7 +972,7 @@ class SessionSearchMixin:
             if not self.fts_rebuild_step():
                 break
             _emit("backfill")
-            _pause(time.monotonic() - _t0)
+            self._fts_rebuild_pause(time.monotonic() - _t0)
         _emit("backfill")
 
         # Phase 1b: backfill the CJK-bigram index (its own marker pair; a
@@ -783,7 +982,19 @@ class SessionSearchMixin:
             if not self.fts_cjk_rebuild_step():
                 break
             _emit("backfill")
-            _pause(time.monotonic() - _t0)
+            self._fts_rebuild_pause(time.monotonic() - _t0)
+
+        # Phase 1c: backfill the session Unicode metadata index (issue #25)
+        # — same shared chunk engine and pacing as the message rebuild. Gated
+        # on pending markers so a DB with no session work never enters the
+        # loop (and never trips a monkeypatched message ``fts_rebuild_step``).
+        if self.fts_session_rebuild_status() is not None:
+            while True:
+                _t0 = time.monotonic()
+                if not self.fts_session_rebuild_step():
+                    break
+                _emit("backfill")
+                self._fts_rebuild_pause(time.monotonic() - _t0)
 
         # Phase 2: tear down the demoted legacy shadow tables in chunks.
         _emit("teardown")
@@ -792,19 +1003,26 @@ class SessionSearchMixin:
             if not self._fts_teardown_trash_step():
                 break
             _emit("teardown")
-            _pause(time.monotonic() - _t0)
+            self._fts_rebuild_pause(time.monotonic() - _t0)
 
         # Refuse to stamp "optimized" while work remains or the base index is
         # still empty against a non-empty messages table. Pre-fix code could
         # tear down trash and settle after a no-op backfill when markers were
-        # missing — permanent search-index loss for historical rows.
+        # missing — permanent search-index loss for historical rows. Session
+        # markers / empty session index (issue #25) count as remaining work.
         with self._lock:
             still_pending = self._conn.execute(
                 "SELECT 1 FROM state_meta "
-                "WHERE key = 'fts_rebuild_high_water' LIMIT 1"
+                "WHERE key IN ('fts_rebuild_high_water', "
+                "'fts_session_rebuild_high_water') LIMIT 1"
             ).fetchone() is not None
             still_trash = self._has_fts_trash(self._conn)
-            empty_index = self._fts_external_index_empty_with_messages(self._conn)
+            empty_index = (
+                self._fts_external_index_empty_with_messages(self._conn)
+                or self._fts_external_index_empty_with_source(
+                    self._conn, "sessions", "sessions_fts"
+                )
+            )
         if still_pending or still_trash or empty_index:
             reason = (
                 "backfill_incomplete" if still_pending or empty_index

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -381,12 +381,6 @@ class SessionSearchMixin:
         """
         return self.fts_rebuild_step(spec=_FTS_SESSION_SPEC)
 
-    def _fts_session_rebuild_finish(self) -> None:
-        """Boundary sweep + clear the session markers (issue #25)."""
-        self._fts_rebuild_finish(spec=_FTS_SESSION_SPEC)
-        self._sessions_fts_available = True
-        logger.info("Session metadata FTS backfill complete — serving search.")
-
     def fts_cjk_rebuild_status(self) -> Optional[Dict[str, Any]]:
         """CJK-index backfill progress, or None when none is pending."""
         with self._read_ctx() as conn:
@@ -660,6 +654,23 @@ class SessionSearchMixin:
             conn, _FTS_SESSION_SPEC, force=force
         )
 
+    def _repair_missing_progress(self, conn, spec: Dict[str, Any]) -> None:
+        """Repair an orphan high_water-without-progress for one rebuild spec.
+
+        Re-seeds P=0 so the chunk loop is not a no-op, resetting a partially
+        populated index to a known-empty surface first so the anti-join-free
+        chunk replay cannot duplicate rows. This is THE crash-safe recovery
+        rule, shared by the message and session metadata rebuilds (the #76832
+        seam) — session repairs must never re-implement it.
+        """
+        if not self._fts_index_known_empty(conn, spec["fts_table"]):
+            self._reset_fts_index_to_empty(conn, spec["reset_tables"])
+        conn.execute(
+            "INSERT INTO state_meta (key, value) VALUES (?, '0') "
+            "ON CONFLICT(key) DO UPDATE SET value = '0'",
+            (spec["progress_key"],),
+        )
+
     def _repair_optimize_bookkeeping(
         self, spec: Optional[Dict[str, Any]] = None
     ) -> None:
@@ -696,15 +707,7 @@ class SessionSearchMixin:
                     (spec["progress_key"],),
                 ).fetchone()
                 if progress is None:
-                    if not self._fts_index_known_empty(
-                        conn, spec["fts_table"]
-                    ):
-                        self._reset_fts_index_to_empty(conn, spec["reset_tables"])
-                    conn.execute(
-                        "INSERT INTO state_meta (key, value) VALUES (?, '0') "
-                        "ON CONFLICT(key) DO UPDATE SET value = '0'",
-                        (spec["progress_key"],),
-                    )
+                    self._repair_missing_progress(conn, spec)
                 return
 
             # No markers. On a still-legacy DB demote owns marker creation.
@@ -722,10 +725,11 @@ class SessionSearchMixin:
 
     def _repair_session_fts_bookkeeping(self) -> None:
         """Heal interrupted session Unicode metadata backfill bookkeeping
-        (#25). Mirrors ``_repair_optimize_bookkeeping`` on the session marker
-        pair, reusing the same crash-safe rule: never infer P=0 over a
-        maybe-partial index; either recover a proven boundary or reset the
-        derived index to a known-empty surface first.
+        (#25). Reuses ``_repair_missing_progress`` (the shared crash-safe
+        rule) for the orphan high_water-without-progress case, and its own
+        orphan claim-seeding for a fresh external index over a populated DB
+        that lost its markers. Never re-implements the reset-before-replay
+        rule.
         """
         def _do(conn):
             existing_hw = conn.execute(
@@ -738,13 +742,7 @@ class SessionSearchMixin:
                     "WHERE key = 'fts_session_rebuild_progress'"
                 ).fetchone()
                 if progress is None:
-                    if not self._fts_index_known_empty(conn, "sessions_fts"):
-                        self._reset_fts_index_to_empty(conn, ("sessions_fts",))
-                    conn.execute(
-                        "INSERT INTO state_meta (key, value) VALUES "
-                        "('fts_session_rebuild_progress', '0') "
-                        "ON CONFLICT(key) DO UPDATE SET value = '0'"
-                    )
+                    self._repair_missing_progress(conn, _FTS_SESSION_SPEC)
                 return
             # No claim: a freshly-created external index over a populated DB
             # that lost its markers, or a crash window after schema ensure

--- a/tests/test_session_metadata_fts.py
+++ b/tests/test_session_metadata_fts.py
@@ -15,7 +15,12 @@ import time
 
 import pytest
 
-from hermes_state import SCHEMA_SQL, SessionDB
+from hermes_state import (
+    LEGACY_FTS_SQL,
+    SCHEMA_SQL,
+    SessionDB,
+    _fts_unicode61_fold,
+)
 
 
 @pytest.fixture()
@@ -107,6 +112,30 @@ CREATE TABLE sessions (
 """
 
 
+# The pre-#25 sessions_fts shape (base/dev): INTERNAL-content, title-only,
+# unicode61, maintained by three broad triggers keyed by the hidden rowid.
+# (#25 replaces this with the external-content Unicode metadata index.)
+_LEGACY_SESSIONS_FTS_DDL = """
+CREATE VIRTUAL TABLE sessions_fts USING fts5(
+    title,
+    tokenize='unicode61'
+);
+
+CREATE TRIGGER sessions_fts_insert AFTER INSERT ON sessions BEGIN
+    INSERT INTO sessions_fts(rowid, title) VALUES (new.rowid, new.title);
+END;
+
+CREATE TRIGGER sessions_fts_delete AFTER DELETE ON sessions BEGIN
+    DELETE FROM sessions_fts WHERE rowid = old.rowid;
+END;
+
+CREATE TRIGGER sessions_fts_update AFTER UPDATE ON sessions BEGIN
+    DELETE FROM sessions_fts WHERE rowid = old.rowid;
+    INSERT INTO sessions_fts(rowid, title) VALUES (new.rowid, new.title);
+END;
+"""
+
+
 def _build_legacy_sessions_db(db_path):
     """Build a pre-#25 DB by hand: sessions WITHOUT ``row_id`` (``id TEXT
     PRIMARY KEY``), with explicit hidden rowids that contain deleted-row
@@ -150,6 +179,59 @@ def _build_legacy_sessions_db(db_path):
         (t0 + 3,),
     )
 
+    conn.commit()
+    conn.close()
+
+
+def _build_legacy_message_and_session_fts_db(db_path):
+    """Build the real pre-#25 CROSS-LAYOUT DB the #25 upgrade path must
+    handle: legacy v22 INLINE messages_fts + old INTERNAL title-only
+    sessions_fts + broad session triggers + legacy sessions (no named
+    row_id) with historical rows.
+
+    Opening the new SessionDB on this must (a) migrate sessions to named
+    row_id (DROP TABLE sessions — which SQLite uses to delete the old
+    sessions_fts triggers too), (b) STILL convert sessions_fts to the
+    external Unicode shape + recreate the gated triggers + stage the H/P
+    claim even though the legacy-message branch is taken, and (c) settle
+    BOTH message and session migration in a single optimize_fts_storage()
+    call with no reopen.
+    """
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA foreign_keys=OFF")
+    conn.executescript(SCHEMA_SQL)
+    # Demote sessions to the pre-#25 shape (no named row_id).
+    conn.execute("DROP TABLE sessions")
+    conn.executescript(_LEGACY_SESSIONS_DDL)
+    # Historical sessions with deleted-row holes in hidden rowids.
+    t0 = time.time()
+    for rowid, sid, title in (
+        (1, "A", "Alpha Project"),
+        (3, "B", "Beta Project"),
+        (7, "C", "Gamma Project"),
+    ):
+        conn.execute(
+            "INSERT INTO sessions (rowid, id, source, started_at, title) "
+            "VALUES (?, ?, 'cli', ?, ?)",
+            (rowid, sid, t0 + rowid, title),
+        )
+    conn.execute(
+        "INSERT INTO sessions (id, source, started_at) "
+        "VALUES ('A-child', 'cli', ?)",
+        (t0 + 8,),
+    )
+    # Legacy v22 inline messages_fts (+ triggers) over a couple of messages
+    # so the message optimize phase has real work to migrate.
+    conn.executescript(LEGACY_FTS_SQL)
+    conn.executemany(
+        "INSERT INTO messages (session_id, role, content, timestamp) "
+        "VALUES (?, 'user', ?, ?)",
+        [("A", "hello legacy world", t0), ("B", "second legacy note", t0 + 1)],
+    )
+    # Old INTERNAL title-only sessions_fts (+ broad triggers keyed by the
+    # hidden rowid) — the pre-#25 shape _ensure_sessions_fts_schema must
+    # detect and convert.
+    conn.executescript(_LEGACY_SESSIONS_FTS_DDL)
     conn.commit()
     conn.close()
 
@@ -771,11 +853,13 @@ class TestBoundedGapSearch:
             r.close()
 
     def test_gap_supplement_unicode_folding_matches_fts(self, tmp_path):
-        """The bounded-gap supplement folds with the same Unicode rules as the
-        unicode61 index (case fold + diacritic removal), so both 'ecole' and
-        'école' find a gap row titled 'École des Beaux-Arts' — a session must
-        not vanish while it sits in (P,H] just because it is not backfilled
-        yet (SQLite's ASCII-only LOWER() would hide it)."""
+        """The bounded-gap supplement folds with a conservative Unicode
+        approximation of the unicode61 rules (case fold + diacritic removal),
+        so both 'ecole' and 'école' find a gap row titled 'École des
+        Beaux-Arts' — a session must not vanish while it sits in (P,H] just
+        because it is not backfilled yet (SQLite's ASCII-only LOWER() would
+        hide it). The approximation is looser than exact tokenizer parity by
+        design (see test_gap_fold_is_conservative_not_exact_parity)."""
         r = _gap_db(tmp_path)  # H=8, P=0: every row is in the gap
         try:
             r.set_session_title("C", "École des Beaux-Arts")  # row 7 in gap
@@ -784,6 +868,26 @@ class TestBoundedGapSearch:
             # The Unicode-aware supplement finds it for both spellings.
             assert _metadata_search_ids(r, "ecole") == ["C"]
             assert _metadata_search_ids(r, "école") == ["C"]
+        finally:
+            r.close()
+
+    def test_gap_fold_is_conservative_not_exact_parity(self, tmp_path):
+        """The gap fold is a conservative approximation of unicode61, NOT a
+        parity mirror: it strips ALL combining marks across scripts and
+        casefolds, so a single-codepoint multi-diacritic character like 'ộ'
+        (U+1ED9) folds to 'o' — broader than the real tokenizer, which
+        preserves such characters under remove_diacritics=1. This temporary
+        false positive is accepted: the #25 gap lane exists to avoid MISSING
+        a migration result, not to exactly mirror the index."""
+        r = _gap_db(tmp_path)  # H=8, P=0: every row is in the gap
+        try:
+            # The helper itself is looser than the tokenizer would be.
+            assert _fts_unicode61_fold("ộ") == "o"
+            r.set_session_title("B", "Một ộ")  # row 3 in the gap
+            # The gap supplement surfaces B for 'o' — a candidate the
+            # authoritative tokenizer may not match once the row is
+            # backfilled. Over-matching is the accepted conservative side.
+            assert "B" in _metadata_search_ids(r, "o")
         finally:
             r.close()
 
@@ -936,5 +1040,78 @@ class TestConcurrencyAndThrottle:
             assert sleeps
             assert all(s >= r._FTS_REBUILD_MIN_PAUSE for s in sleeps)
             assert r.get_meta("fts_session_rebuild_high_water") is None
+        finally:
+            r.close()
+
+
+# =========================================================================
+# Group G — legacy-message-FTS × old-session-FTS cross-layout upgrade path
+# =========================================================================
+
+
+class TestLegacyMessageFTSUpgradePath:
+    def test_legacy_message_fts_does_not_block_session_fts_upgrade(
+        self, tmp_path
+    ):
+        """A legacy v22 INLINE messages_fts must NOT block the independent
+        sessions_fts upgrade (#25), and a single optimize must settle BOTH.
+
+        _migrate_sessions_row_id() rebuilds sessions via DROP TABLE, and
+        SQLite drops table triggers with the table — so the pre-#25
+        sessions_fts_* triggers are gone the moment the swap lands. The
+        sessions_fts ensure must therefore run for legacy-message DBs too
+        (not just the v23-message path), or the DB is left with the old
+        internal title-only index, no triggers, and no H/P claim.
+        """
+        db_path = tmp_path / "legacy-cross.db"
+        _build_legacy_message_and_session_fts_db(db_path)
+
+        r = SessionDB(db_path=db_path)
+        try:
+            # sessions migrated to named row_id (hidden-rowid holes kept).
+            assert _row_id_map(r._conn) == {
+                "A": 1, "B": 3, "C": 7, "A-child": 8,
+            }
+            # messages_fts is STILL the legacy inline shape — the #25 path
+            # must not have forced the message v23 migration (decoupled).
+            assert "tool_name" not in _fts_sql(r._conn, "messages_fts")
+            # sessions_fts was converted to the #25 external Unicode shape.
+            sql = _fts_sql(r._conn, "sessions_fts")
+            assert "content='sessions'" in sql
+            assert "content_rowid='row_id'" in sql
+            assert "tokenize='unicode61'" in sql
+            # Durable H/P claim staged over the historical rows.
+            assert r.get_meta("fts_session_rebuild_high_water") == "8"
+            assert r.get_meta("fts_session_rebuild_progress") == "0"
+            # All three gated session triggers exist (recreated, since the
+            # DROP TABLE swap removed the pre-#25 ones).
+            for trig in (
+                "sessions_fts_insert", "sessions_fts_delete",
+                "sessions_fts_update",
+            ):
+                assert r._conn.execute(
+                    "SELECT 1 FROM sqlite_master WHERE type = 'trigger' "
+                    "AND name = ?", (trig,)
+                ).fetchone() is not None
+            # A session created after high-water capture is searchable
+            # immediately — live trigger maintenance works on this path.
+            r.create_session("E", source="cli")
+            r.set_session_title("E", "Fresh Post-Capture Title")
+            assert _raw_metadata_match_ids(r, "fresh") == ["E"]
+
+            # ONE optimize settles BOTH the legacy message migration AND the
+            # session backfill — no close/reopen + second optimize needed.
+            result = r.optimize_fts_storage(vacuum=False)
+            assert result["ok"] is True, result
+            assert r.fts_optimize_available() is False
+            assert r.get_meta("fts_rebuild_high_water") is None
+            assert r.get_meta("fts_session_rebuild_high_water") is None
+            # messages_fts is now v23 external (tool metadata indexed).
+            assert "tool_name" in _fts_sql(r._conn, "messages_fts")
+            # Historical sessions backfilled and searchable; index fully
+            # consistent (rank=1 cross-check).
+            assert _raw_metadata_match_ids(r, "alpha") == ["A"]
+            assert _raw_metadata_match_ids(r, "gamma") == ["C"]
+            _assert_sessions_fts_integrity(r)
         finally:
             r.close()

--- a/tests/test_session_metadata_fts.py
+++ b/tests/test_session_metadata_fts.py
@@ -556,6 +556,23 @@ def _metadata_search_ids(db, query):
     return [c["id"] for c in db._fts_metadata_candidates(query)]
 
 
+def _build_populated_sessions_db(db_path, n=1200):
+    """Build a DB with ``n`` sessions (explicit row_ids 1..n) and NO
+    sessions_fts, so the open stages a full H/P claim over an empty external
+    index (the real #25 migration shape)."""
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA foreign_keys=OFF")
+    conn.executescript(SCHEMA_SQL)
+    t0 = time.time()
+    conn.executemany(
+        "INSERT INTO sessions (row_id, id, source, started_at, title) "
+        "VALUES (?, ?, 'cli', ?, ?)",
+        [(i, f"s{i}", t0 + i, f"Title {i}") for i in range(1, n + 1)],
+    )
+    conn.commit()
+    conn.close()
+
+
 class TestBoundedGapSearch:
     def test_gap_session_searchable_via_bounded_supplement(self, tmp_path):
         """A session whose row_id is in the unbackfilled (P,H] gap is still
@@ -637,5 +654,86 @@ class TestBoundedGapSearch:
             assert r.get_meta("fts_session_rebuild_high_water") is None
             assert _metadata_search_ids(r, "gamma") == []
             _assert_sessions_fts_integrity(r)
+        finally:
+            r.close()
+
+
+# =========================================================================
+# Group F — concurrency + shared throttle
+# =========================================================================
+
+
+class TestConcurrencyAndThrottle:
+    def test_two_runners_claim_disjoint_chunks(self, tmp_path):
+        """Two concurrent rebuild runners cannot claim/settle the same chunk:
+        progress advances through non-overlapping ranges, every document
+        appears exactly once, and the index stays healthy."""
+        db_path = tmp_path / "s.db"
+        _build_populated_sessions_db(db_path, n=1200)
+        r1 = SessionDB(db_path=db_path)  # stages H=1200, P=0
+        r2 = SessionDB(db_path=db_path)
+        try:
+            assert r1.get_meta("fts_session_rebuild_high_water") == "1200"
+            assert r2.get_meta("fts_session_rebuild_high_water") == "1200"
+            guards = 0
+            while (r1.fts_session_rebuild_step()
+                   or r2.fts_session_rebuild_step()):
+                guards += 1
+                assert guards < 1000, "rebuild loop did not terminate"
+            assert r1.get_meta("fts_session_rebuild_high_water") is None
+            n_sessions = r1._conn.execute(
+                "SELECT COUNT(*) FROM sessions"
+            ).fetchone()[0]
+            n_docs = r1._conn.execute(
+                "SELECT COUNT(*) FROM sessions_fts_docsize"
+            ).fetchone()[0]
+            assert n_docs == n_sessions
+            dup = r1._conn.execute(
+                "SELECT COUNT(*) FROM (SELECT rowid FROM sessions_fts_docsize "
+                "GROUP BY rowid HAVING COUNT(*) > 1)"
+            ).fetchone()[0]
+            assert dup == 0
+            r1._conn.execute(
+                "INSERT INTO sessions_fts(sessions_fts) VALUES('integrity-check')"
+            )
+        finally:
+            r1.close()
+            r2.close()
+
+    def test_shared_pause_formula_monkeypatched(self, tmp_path, monkeypatch):
+        """The shared pause is max(min_pause, build_time * duty_factor), proven
+        without wall-clock sleeps."""
+        db_path = tmp_path / "s.db"
+        _build_populated_sessions_db(db_path, n=20)
+        r = SessionDB(db_path=db_path)
+        try:
+            r._FTS_REBUILD_DUTY_FACTOR = 4.0
+            r._FTS_REBUILD_MIN_PAUSE = 0.2
+            sleeps = []
+            monkeypatch.setattr("hermes_state_search.time.sleep", sleeps.append)
+            r._fts_rebuild_pause(0.5)   # 0.5 * 4.0 = 2.0 >= 0.2
+            assert sleeps[-1] == 2.0
+            r._fts_rebuild_pause(0.01)  # 0.01 * 4.0 = 0.04 < min 0.2
+            assert sleeps[-1] == 0.2
+        finally:
+            r.close()
+
+    def test_session_loop_routes_through_shared_pause(self, tmp_path, monkeypatch):
+        """optimize_fts_storage's session backfill phase uses the SAME shared
+        pause helper as the message rebuild — no session copy of the policy."""
+        db_path = tmp_path / "s.db"
+        _build_populated_sessions_db(db_path, n=1200)
+        r = SessionDB(db_path=db_path)
+        try:
+            sleeps = []
+            monkeypatch.setattr("hermes_state_search.time.sleep", sleeps.append)
+            result = r.optimize_fts_storage(vacuum=False)
+            assert result["ok"] is True
+            # The only chunks optimize runs here are the session backfill ones
+            # (no messages, no trash, no cjk tokenizer), so every recorded
+            # pause went through the shared helper and honors the floor.
+            assert sleeps
+            assert all(s >= r._FTS_REBUILD_MIN_PAUSE for s in sleeps)
+            assert r.get_meta("fts_session_rebuild_high_water") is None
         finally:
             r.close()

--- a/tests/test_session_metadata_fts.py
+++ b/tests/test_session_metadata_fts.py
@@ -336,18 +336,31 @@ def _raw_metadata_match_ids(db, query):
     return [r["id"] for r in rows]
 
 
-def _three_region_db(tmp_path):
-    """SessionDB with rows 1..4 and H=4, P=2 → ``<=P``={1,2}, ``(P,H]``={3,4},
-    and (after a fresh insert) ``>H`` rows. Pre-seeds the external index by
-    re-opening a populated DB so rebuild markers exist."""
+def _gap_db(tmp_path):
+    """Populated DB with a staged #25 rebuild: the external sessions_fts was
+    freshly created on a populated DB, so the durable H/P claim exists and
+    every historical row falls in the (0, H] gap (nothing indexed yet)."""
     db_path = tmp_path / "s.db"
-    w = SessionDB(db_path=db_path)
-    for sid in ("A", "B", "C", "D"):
-        w.create_session(sid, source="cli")
-        w.set_session_title(sid, f"Title {sid}")
-    w.close()
-    r = SessionDB(db_path=db_path)
-    _set_session_rebuild_markers(r, 4, 2)
+    _build_legacy_sessions_db(db_path)  # sessions A(1), B(3), C(7), A-child(8)
+    r = SessionDB(db_path=db_path)      # stages markers H=8, P=0; empty index
+    return r
+
+
+def _three_region_db(tmp_path):
+    """SessionDB with a #25 rebuild staged so all three ownership regions are
+    represented: rows <= P are backfilled into FTS, rows (P,H] are the
+    unindexed gap, and newly created sessions are > H (live-indexed by the
+    triggers). Uses the real migration shape (fresh external table on a
+    populated DB), not a fresh-DB-then-create flow where every row would be
+    live-indexed."""
+    r = _gap_db(tmp_path)  # H=8, P=0, empty index
+    # Backfill the <= P prefix the way the chunk engine would.
+    r._conn.execute(
+        "INSERT INTO sessions_fts(rowid, title, id, display_name) "
+        "SELECT row_id, title, id, display_name FROM sessions "
+        "WHERE row_id <= 3"
+    )
+    r.set_meta("fts_session_rebuild_progress", "3")
     return r
 
 
@@ -404,14 +417,15 @@ class TestUnicodeExternalContent:
 
 class TestRebuildMarkers:
     def test_populated_db_stages_rebuild_markers(self, tmp_path):
-        """Opening a populated DB with an external sessions_fts must stage the
-        durable H/P rebuild claim (never serve an empty index as complete)."""
+        """Opening a populated DB whose external sessions_fts is freshly
+        created must stage the durable H/P rebuild claim (never serve an
+        empty index as complete). Sessions added after a table already exists
+        are live-indexed by the triggers and need no claim."""
         db_path = tmp_path / "s.db"
-        w = SessionDB(db_path=db_path)
-        w.create_session("A", source="cli")
-        w.create_session("B", source="cli")
-        w.create_session("C", source="cli")
-        w.close()
+        # Build a populated DB WITHOUT opening a SessionDB first, so no
+        # external sessions_fts exists yet — the open creates it and must
+        # stage the claim over the historical rows.
+        _build_legacy_sessions_db(db_path)
         r = SessionDB(db_path=db_path)
         try:
             assert r.get_meta("fts_session_rebuild_high_water") is not None
@@ -527,5 +541,101 @@ class TestTriggerOwnershipRegions:
             r.create_session("E", source="cli")  # row_id 5 > H
             r.set_session_title("E", "Fresh Live Title")
             assert _raw_metadata_match_ids(r, "fresh") == ["E"]
+        finally:
+            r.close()
+
+
+# =========================================================================
+# Group E — bounded-gap search supplementation + boundary finish
+# =========================================================================
+
+
+def _metadata_search_ids(db, query):
+    """Search session metadata through the raw Unicode lane + bounded (P,H]
+    supplement (issue #25). Returns logical session ids, deduplicated."""
+    return [c["id"] for c in db._fts_metadata_candidates(query)]
+
+
+class TestBoundedGapSearch:
+    def test_gap_session_searchable_via_bounded_supplement(self, tmp_path):
+        """A session whose row_id is in the unbackfilled (P,H] gap is still
+        found by raw metadata search through bounded supplementation."""
+        r = _three_region_db(tmp_path)
+        try:
+            # C (row 7) is in (P,H] = (3,8], so its title is NOT in FTS.
+            assert _raw_metadata_match_ids(r, "gamma") == []
+            # The bounded supplement must surface it.
+            assert _metadata_search_ids(r, "gamma") == ["C"]
+        finally:
+            r.close()
+
+    def test_gap_supplement_dedupes_with_fts_candidates(self, tmp_path):
+        """A session reachable through both the FTS lane and the supplemental
+        (P,H] route (a boundary-overlap row) is returned exactly once."""
+        r = _three_region_db(tmp_path)
+        try:
+            # B (row 3) is <= P so it is in FTS. Narrow P below B so the same
+            # row also falls in the gap — the boundary overlap case.
+            _set_session_rebuild_markers(r, 8, 1)  # gap = (1, 8]
+            hits = _metadata_search_ids(r, "beta")
+            assert hits == ["B"]
+            # A (row 1) stays <= P: it must NOT be re-scanned by the gap.
+            assert _metadata_search_ids(r, "alpha") == ["A"]
+        finally:
+            r.close()
+
+    def test_supplement_is_bounded_to_gap(self, tmp_path):
+        """The supplemental query must be bounded by ``row_id > P AND row_id
+        <= H`` — never an unbounded all-sessions migration scan."""
+        r = _three_region_db(tmp_path)
+        try:
+            r.create_session("E", source="cli")  # row 9 > H, live-indexed
+            r.set_session_title("E", "Live Term E")
+            # > H rows are in FTS (live trigger) — found without the gap.
+            assert _metadata_search_ids(r, "live") == ["E"]
+            gap = r._session_fts_rebuild_gap()
+            assert gap == (3, 8)
+        finally:
+            r.close()
+
+    def test_finish_repairs_missing_boundary_doc(self, tmp_path):
+        """Finish performs a narrow boundary sweep: a document missing near H
+        is re-inserted before the rebuild markers are cleared."""
+        r = _gap_db(tmp_path)  # H=8, P=0, empty index
+        try:
+            # Backfill everything by hand, then remove C's document to
+            # simulate a write that slipped at the boundary.
+            r._conn.execute(
+                "INSERT INTO sessions_fts(rowid, title, id, display_name) "
+                "SELECT row_id, title, id, display_name FROM sessions "
+                "WHERE row_id <= 8"
+            )
+            r.set_meta("fts_session_rebuild_progress", "8")
+            r._conn.execute(
+                "INSERT INTO sessions_fts(sessions_fts, rowid, title, id, display_name) "
+                "SELECT 'delete', s.row_id, s.title, s.id, s.display_name "
+                "FROM sessions s WHERE s.id = 'C'"
+            )
+            r._conn.commit()
+            assert "C" not in _raw_metadata_match_ids(r, "gamma")
+            # A single step: no chunk to claim (P >= H), but the status check
+            # runs the finish boundary sweep before clearing the markers.
+            assert r.fts_session_rebuild_step() is False
+            assert r.get_meta("fts_session_rebuild_high_water") is None
+            assert _raw_metadata_match_ids(r, "gamma") == ["C"]
+        finally:
+            r.close()
+
+    def test_deleted_gap_row_not_resurrected_by_finish(self, tmp_path):
+        """A canonical row deleted inside (P,H] is simply absent: the boundary
+        sweep must not resurrect it."""
+        r = _gap_db(tmp_path)  # H=8, P=0, empty index
+        try:
+            r.delete_session("C")  # row 7 in gap
+            while r.fts_session_rebuild_step():
+                pass
+            assert r.get_meta("fts_session_rebuild_high_water") is None
+            assert _metadata_search_ids(r, "gamma") == []
+            _assert_sessions_fts_integrity(r)
         finally:
             r.close()

--- a/tests/test_session_metadata_fts.py
+++ b/tests/test_session_metadata_fts.py
@@ -297,3 +297,235 @@ class TestNamedRowIdMigration:
             assert leftover is None
         finally:
             session_db.close()
+
+
+# =========================================================================
+# Raw Unicode external-content sessions_fts — helpers
+# =========================================================================
+
+
+def _fts_sql(conn, table):
+    row = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?",
+        (table,),
+    ).fetchone()
+    return (row[0] if isinstance(row, sqlite3.Row) else row[0]) if row else ""
+
+
+def _set_session_rebuild_markers(db, high_water, progress):
+    db.set_meta("fts_session_rebuild_high_water", str(high_water))
+    db.set_meta("fts_session_rebuild_progress", str(progress))
+
+
+def _assert_sessions_fts_integrity(db):
+    """FTS5 integrity-check raises on a corrupt external-content index."""
+    db._conn.execute(
+        "INSERT INTO sessions_fts(sessions_fts) VALUES('integrity-check')"
+    )
+
+
+def _raw_metadata_match_ids(db, query):
+    """Return session ids whose raw Unicode metadata document MATCHes query."""
+    with db._read_ctx() as conn:
+        rows = conn.execute(
+            "SELECT s.id FROM sessions_fts f "
+            "JOIN sessions s ON s.row_id = f.rowid "
+            "WHERE sessions_fts MATCH ?",
+            (query,),
+        ).fetchall()
+    return [r["id"] for r in rows]
+
+
+def _three_region_db(tmp_path):
+    """SessionDB with rows 1..4 and H=4, P=2 → ``<=P``={1,2}, ``(P,H]``={3,4},
+    and (after a fresh insert) ``>H`` rows. Pre-seeds the external index by
+    re-opening a populated DB so rebuild markers exist."""
+    db_path = tmp_path / "s.db"
+    w = SessionDB(db_path=db_path)
+    for sid in ("A", "B", "C", "D"):
+        w.create_session(sid, source="cli")
+        w.set_session_title(sid, f"Title {sid}")
+    w.close()
+    r = SessionDB(db_path=db_path)
+    _set_session_rebuild_markers(r, 4, 2)
+    return r
+
+
+# =========================================================================
+# Group B — raw Unicode external-content shape and search dimensions
+# =========================================================================
+
+
+class TestUnicodeExternalContent:
+    def test_sessions_fts_ddl_is_external_content_raw_metadata(self, db):
+        """sessions_fts is external-content over raw (title, id, display_name)
+        keyed by named ``row_id``."""
+        sql = _fts_sql(db._conn, "sessions_fts")
+        assert "content='sessions'" in sql
+        assert "content_rowid='row_id'" in sql
+        assert "tokenize='unicode61'" in sql
+        for col in ("title", "id", "display_name"):
+            assert col in sql
+
+    def test_raw_unicode_search_covers_title_id_display_name(self, db):
+        db.create_session("s1", source="cli")
+        db.set_session_title("s1", "Alpha Project")
+        db._conn.execute(
+            "UPDATE sessions SET display_name = 'Alpha Display' WHERE id = 's1'"
+        )
+        db._conn.commit()
+        assert _raw_metadata_match_ids(db, "alpha") == ["s1"]      # title
+        assert _raw_metadata_match_ids(db, "s1") == ["s1"]         # logical id
+        assert _raw_metadata_match_ids(db, "display") == ["s1"]    # display_name
+
+    def test_unrelated_metadata_update_does_not_rewrite_fts(self, db):
+        """Only narrow UPDATE OF title/id/display_name maintain the index; an
+        unrelated column write must not fire the FTS update trigger."""
+        db.create_session("s1", source="cli")
+        db.set_session_title("s1", "Alpha")
+        db._conn.execute(
+            "UPDATE sessions SET message_count = 5 WHERE id = 's1'"
+        )
+        db._conn.commit()
+        assert _raw_metadata_match_ids(db, "alpha") == ["s1"]
+        trig = db._conn.execute(
+            "SELECT sql FROM sqlite_master "
+            "WHERE type = 'trigger' AND name = 'sessions_fts_update'"
+        ).fetchone()
+        sql = trig[0] if not isinstance(trig, sqlite3.Row) else trig["sql"]
+        compact = " ".join(sql.split())
+        assert "AFTER UPDATE OF title, id, display_name" in compact
+
+
+# =========================================================================
+# Group C — crash/restart H/P bookkeeping
+# =========================================================================
+
+
+class TestRebuildMarkers:
+    def test_populated_db_stages_rebuild_markers(self, tmp_path):
+        """Opening a populated DB with an external sessions_fts must stage the
+        durable H/P rebuild claim (never serve an empty index as complete)."""
+        db_path = tmp_path / "s.db"
+        w = SessionDB(db_path=db_path)
+        w.create_session("A", source="cli")
+        w.create_session("B", source="cli")
+        w.create_session("C", source="cli")
+        w.close()
+        r = SessionDB(db_path=db_path)
+        try:
+            assert r.get_meta("fts_session_rebuild_high_water") is not None
+            assert r.get_meta("fts_session_rebuild_progress") == "0"
+        finally:
+            r.close()
+
+    def test_empty_db_has_no_markers(self, db):
+        """An empty DB's index is complete by construction — no claim."""
+        assert db.get_meta("fts_session_rebuild_high_water") is None
+
+    def test_markers_survive_reopen_no_reseed(self, tmp_path):
+        """A completed/advanced progress must never be reseeded to zero on
+        reopen."""
+        db_path = tmp_path / "s.db"
+        w = SessionDB(db_path=db_path)
+        w.create_session("A", source="cli")
+        w.create_session("B", source="cli")
+        w.close()
+        r = SessionDB(db_path=db_path)
+        _set_session_rebuild_markers(r, 2, 1)
+        r.close()
+        r2 = SessionDB(db_path=db_path)
+        try:
+            assert r2.get_meta("fts_session_rebuild_high_water") == "2"
+            assert r2.get_meta("fts_session_rebuild_progress") == "1"
+        finally:
+            r2.close()
+
+    def test_crash_after_claim_before_schema_resumes(self, tmp_path):
+        """Durable markers with the external table missing (death between the
+        claim commit and the schema ensure) must re-ensure the external schema
+        on reopen — never stamp the migration complete."""
+        db_path = tmp_path / "s.db"
+        w = SessionDB(db_path=db_path)
+        w.create_session("A", source="cli")
+        w.create_session("B", source="cli")
+        w.close()
+        with sqlite3.connect(db_path) as conn:
+            for t in (
+                "sessions_fts", "sessions_fts_data", "sessions_fts_idx",
+                "sessions_fts_content", "sessions_fts_docsize",
+                "sessions_fts_config",
+            ):
+                conn.execute(f"DROP TABLE IF EXISTS {t}")
+            conn.commit()
+        r = SessionDB(db_path=db_path)
+        try:
+            assert "content='sessions'" in _fts_sql(r._conn, "sessions_fts")
+            # Backfill still pending (markers present), not stamped done.
+            assert r.get_meta("fts_session_rebuild_high_water") is not None
+        finally:
+            r.close()
+
+
+# =========================================================================
+# Group D — trigger ownership regions (<=P, (P,H], >H) + deletes + integrity
+# =========================================================================
+
+
+class TestTriggerOwnershipRegions:
+    def test_delete_indexed_prefix_row_removes_doc(self, tmp_path):
+        """Deleting a ``<=P`` row removes its already-indexed document."""
+        r = _three_region_db(tmp_path)
+        try:
+            r.delete_session("A")  # row_id 1, indexed
+            assert "A" not in _raw_metadata_match_ids(r, "title")
+            _assert_sessions_fts_integrity(r)
+        finally:
+            r.close()
+
+    def test_delete_gap_row_does_not_issue_fts_delete(self, tmp_path):
+        """Deleting a ``(P,H]`` row (never indexed) must not issue an
+        external-content FTS delete; integrity stays healthy."""
+        r = _three_region_db(tmp_path)
+        try:
+            r.delete_session("C")  # row_id 3, in (P,H]
+            _assert_sessions_fts_integrity(r)
+            # Row is simply absent — backfill later finds no canonical row.
+            assert r.get_session("C") is None
+        finally:
+            r.close()
+
+    def test_delete_live_row_removes_doc(self, tmp_path):
+        """Deleting a ``>H`` live row (indexed by the trigger at insert time)
+        removes its live document."""
+        r = _three_region_db(tmp_path)
+        try:
+            r.create_session("E", source="cli")  # row_id 5 > H
+            r.set_session_title("E", "Live Echo")
+            assert _raw_metadata_match_ids(r, "echo") == ["E"]
+            r.delete_session("E")
+            assert "E" not in _raw_metadata_match_ids(r, "echo")
+            _assert_sessions_fts_integrity(r)
+        finally:
+            r.close()
+
+    def test_gap_region_update_does_not_corrupt_index(self, tmp_path):
+        """Updating a ``(P,H]`` row must not rewrite a document that was never
+        indexed; integrity stays healthy."""
+        r = _three_region_db(tmp_path)
+        try:
+            r.set_session_title("C", "New Title C")  # row_id 3, in (P,H]
+            _assert_sessions_fts_integrity(r)
+        finally:
+            r.close()
+
+    def test_live_session_searchable_while_backfill_pending(self, tmp_path):
+        """A session created after high-water capture is searchable
+        immediately while the historical backfill remains incomplete."""
+        r = _three_region_db(tmp_path)
+        try:
+            r.create_session("E", source="cli")  # row_id 5 > H
+            r.set_session_title("E", "Fresh Live Title")
+            assert _raw_metadata_match_ids(r, "fresh") == ["E"]
+        finally:
+            r.close()

--- a/tests/test_session_metadata_fts.py
+++ b/tests/test_session_metadata_fts.py
@@ -835,30 +835,29 @@ class TestTriggerOwnershipRegions:
         full rebuild."""
         db_path = tmp_path / "legacy.db"
         _build_legacy_message_and_session_fts_db(db_path)  # A(1) B(3) C(7) A-child(8)
-        real_ensure = SessionDB._ensure_fts_schema
+        real_transition = SessionDB._fts_session_schema_transition
 
-        def _ensure_with_window_insert(self, cursor, table_name, ddl):
-            if table_name == "sessions_fts":
-                # Simulate the other-process write in the trigger-free window:
-                # the stage transaction already committed H; insert a row above
-                # it via a second raw connection (no sessions_fts trigger
-                # exists yet, so the row is not indexed).
-                with sqlite3.connect(str(db_path)) as conn:
-                    hw = conn.execute(
-                        "SELECT CAST(value AS INTEGER) FROM state_meta "
-                        "WHERE key = 'fts_session_rebuild_high_water'"
-                    ).fetchone()
-                    hw = int(hw[0]) if hw else 0
-                    conn.execute(
-                        "INSERT INTO sessions (id, source, started_at) "
-                        "VALUES ('W', 'cli', ?)",
-                        (time.time(),),
-                    )
-                    conn.commit()
-            return real_ensure(self, cursor, table_name, ddl)
+        def _transition_with_window_insert(self, cursor):
+            # Simulate the other-process write in the trigger-free window:
+            # the stage transaction already committed H; insert a row above
+            # it via a second raw connection (no sessions_fts trigger exists
+            # yet, so the row is not indexed).
+            with sqlite3.connect(str(db_path)) as conn:
+                hw = conn.execute(
+                    "SELECT CAST(value AS INTEGER) FROM state_meta "
+                    "WHERE key = 'fts_session_rebuild_high_water'"
+                ).fetchone()
+                hw = int(hw[0]) if hw else 0
+                conn.execute(
+                    "INSERT INTO sessions (id, source, started_at) "
+                    "VALUES ('W', 'cli', ?)",
+                    (time.time(),),
+                )
+                conn.commit()
+            return real_transition(self, cursor)
 
         monkeypatch.setattr(
-            SessionDB, "_ensure_fts_schema", _ensure_with_window_insert
+            SessionDB, "_fts_session_schema_transition", _transition_with_window_insert
         )
         r = SessionDB(db_path=db_path)
         try:
@@ -885,29 +884,124 @@ class TestTriggerOwnershipRegions:
         up, not left invisible."""
         db_path = tmp_path / "s.db"
         _build_populated_sessions_db(db_path, n=50)  # no sessions_fts yet
-        real_ensure = SessionDB._ensure_fts_schema
+        real_transition = SessionDB._fts_session_schema_transition
 
-        def _ensure_with_window_insert(self, cursor, table_name, ddl):
-            if table_name == "sessions_fts":
-                with sqlite3.connect(str(db_path)) as conn:
-                    hw = conn.execute(
-                        "SELECT CAST(value AS INTEGER) FROM state_meta "
-                        "WHERE key = 'fts_session_rebuild_high_water'"
-                    ).fetchone()
-                    hw = int(hw[0]) if hw else 0
-                    conn.execute(
-                        "INSERT INTO sessions (id, source, started_at) "
-                        "VALUES ('W', 'cli', ?)",
-                        (time.time(),),
-                    )
-                    conn.commit()
-            return real_ensure(self, cursor, table_name, ddl)
+        def _transition_with_window_insert(self, cursor):
+            with sqlite3.connect(str(db_path)) as conn:
+                hw = conn.execute(
+                    "SELECT CAST(value AS INTEGER) FROM state_meta "
+                    "WHERE key = 'fts_session_rebuild_high_water'"
+                ).fetchone()
+                hw = int(hw[0]) if hw else 0
+                conn.execute(
+                    "INSERT INTO sessions (id, source, started_at) "
+                    "VALUES ('W', 'cli', ?)",
+                    (time.time(),),
+                )
+                conn.commit()
+            return real_transition(self, cursor)
 
         monkeypatch.setattr(
-            SessionDB, "_ensure_fts_schema", _ensure_with_window_insert
+            SessionDB, "_fts_session_schema_transition", _transition_with_window_insert
         )
         r = SessionDB(db_path=db_path)
         try:
+            assert _raw_metadata_match_ids(r, "W") == ["W"]
+            result = r.optimize_fts_storage(vacuum=False)
+            assert result["ok"] is True, result
+            n_sessions = r._conn.execute(
+                "SELECT COUNT(*) FROM sessions"
+            ).fetchone()[0]
+            n_docs = r._conn.execute(
+                "SELECT COUNT(*) FROM sessions_fts_docsize"
+            ).fetchone()[0]
+            assert n_docs == n_sessions
+        finally:
+            r.close()
+
+    def test_empty_legacy_first_row_window_is_caught_up(
+        self, tmp_path, monkeypatch
+    ):
+        """Case A: on a legacy empty DB the H/P markers are deliberately
+        absent (complete-by-construction), so an early-return on 'no markers'
+        would drop a FIRST row inserted by another connection in the
+        trigger-free window. The crash-atomic transition's COALESCE(H,-1)
+        predicate makes every row trigger-owned, so the first window row is
+        caught up and immediately searchable."""
+        db_path = tmp_path / "legacy-empty.db"
+        _build_legacy_empty_session_fts_db(db_path)  # old internal FTS, 0 rows
+        real_transition = SessionDB._fts_session_schema_transition
+
+        def _transition_with_first_row(self, cursor):
+            # Insert the FIRST session via a second connection in the
+            # trigger-free window (the old internal table + triggers were
+            # dropped by the stage commit; no external trigger exists yet).
+            with sqlite3.connect(str(db_path)) as conn:
+                conn.execute(
+                    "INSERT INTO sessions (id, source, started_at) "
+                    "VALUES ('W', 'cli', ?)",
+                    (time.time(),),
+                )
+                conn.commit()
+            return real_transition(self, cursor)
+
+        monkeypatch.setattr(
+            SessionDB, "_fts_session_schema_transition", _transition_with_first_row
+        )
+        r = SessionDB(db_path=db_path)
+        try:
+            # The first window row is immediately searchable (COALESCE(H,-1)
+            # covers the no-marker case).
+            assert _raw_metadata_match_ids(r, "W") == ["W"]
+            result = r.optimize_fts_storage(vacuum=False)
+            assert result["ok"] is True, result
+            n_sessions = r._conn.execute(
+                "SELECT COUNT(*) FROM sessions"
+            ).fetchone()[0]
+            n_docs = r._conn.execute(
+                "SELECT COUNT(*) FROM sessions_fts_docsize"
+            ).fetchone()[0]
+            assert n_docs == n_sessions
+        finally:
+            r.close()
+
+    def test_populated_crash_before_transition_reopen_catches_up(
+        self, tmp_path
+    ):
+        """Case B: schema/triggers committed but the catch-up never became
+        durable (a crash between the old separate transactions). With the
+        crash-atomic transition this state means schema + catch-up rolled back
+        together, so a reopen re-runs the transition and a >H window row is
+        caught up — never left invisible."""
+        db_path = tmp_path / "s.db"
+        _build_populated_sessions_db(db_path, n=50)  # 50 sessions, no sessions_fts
+        w = SessionDB(db_path=db_path)  # completes the atomic transition
+        w.close()
+        # Simulate the crash window: external schema + triggers rolled back,
+        # H/P markers durable, and a >H row committed in the trigger-free
+        # window (no trigger existed to index it).
+        with sqlite3.connect(db_path) as conn:
+            for t in (
+                "sessions_fts", "sessions_fts_data", "sessions_fts_idx",
+                "sessions_fts_content", "sessions_fts_docsize",
+                "sessions_fts_config",
+            ):
+                conn.execute(f"DROP TABLE IF EXISTS {t}")
+            for trig in (
+                "sessions_fts_insert", "sessions_fts_delete",
+                "sessions_fts_update",
+            ):
+                conn.execute(f"DROP TRIGGER IF EXISTS {trig}")
+            conn.execute(
+                "INSERT INTO sessions (id, source, started_at) "
+                "VALUES ('W', 'cli', ?)",
+                (time.time(),),
+            )
+            conn.commit()
+        r = SessionDB(db_path=db_path)
+        try:
+            # The >H row is immediately searchable after the reopened atomic
+            # transition catches it up.
             assert _raw_metadata_match_ids(r, "W") == ["W"]
             result = r.optimize_fts_storage(vacuum=False)
             assert result["ok"] is True, result

--- a/tests/test_session_metadata_fts.py
+++ b/tests/test_session_metadata_fts.py
@@ -298,6 +298,46 @@ class TestNamedRowIdMigration:
         finally:
             session_db.close()
 
+    def test_legacy_duplicate_titles_do_not_break_open(self, tmp_path):
+        """A legacy DB with duplicate titles (allowed before the unique-title
+        constraint was enforced) must still open after the row_id migration.
+
+        The migration must NOT rebuild ``idx_sessions_title_unique`` inside
+        its swap transaction — a duplicate title would raise
+        ``UNIQUE constraint failed``, roll back the whole open, and the
+        existing post-migration duplicate repair would never run.
+        """
+        db_path = tmp_path / "legacy.db"
+        _build_legacy_sessions_db(db_path)
+        with sqlite3.connect(db_path) as conn:
+            conn.execute(
+                "UPDATE sessions SET title = 'dupe-title' "
+                "WHERE id IN ('A', 'B')"
+            )
+            conn.commit()
+
+        session_db = SessionDB(db_path=db_path)
+        try:
+            rows = {
+                r["id"]: r["title"] for r in session_db._conn.execute(
+                    "SELECT id, title FROM sessions"
+                ).fetchall()
+            }
+            # Every row survives; the duplicate is repaired by the existing
+            # post-migration block (older rowid loses the alias).
+            assert set(rows) == {"A", "B", "C", "A-child"}
+            assert rows["A"] is None
+            assert rows["B"] == "dupe-title"
+            assert rows["C"] == "Gamma Project"
+            # The unique title index now exists (built after the repair).
+            idx = session_db._conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE type = 'index' "
+                "AND name = 'idx_sessions_title_unique'"
+            ).fetchone()
+            assert idx is not None
+        finally:
+            session_db.close()
+
 
 # =========================================================================
 # Raw Unicode external-content sessions_fts — helpers
@@ -318,9 +358,17 @@ def _set_session_rebuild_markers(db, high_water, progress):
 
 
 def _assert_sessions_fts_integrity(db):
-    """FTS5 integrity-check raises on a corrupt external-content index."""
+    """FTS5 integrity-check in the mode that also verifies external-content /
+    content consistency (``rank = 1``).
+
+    The plain ``integrity-check`` only checks the index's internal shadow-table
+    structure; it does NOT detect an orphan posting whose canonical row was
+    deleted. The ``rank = 1`` form additionally cross-checks the index against
+    the ``sessions`` content table, which is what catches a stale posting left
+    by a broken delete trigger.
+    """
     db._conn.execute(
-        "INSERT INTO sessions_fts(sessions_fts) VALUES('integrity-check')"
+        "INSERT INTO sessions_fts(sessions_fts, rank) VALUES('integrity-check', 1)"
     )
 
 
@@ -334,6 +382,22 @@ def _raw_metadata_match_ids(db, query):
             (query,),
         ).fetchall()
     return [r["id"] for r in rows]
+
+
+def _raw_fts_rowids(db, query):
+    """Return the FTS rowids (sessions.row_id values) that MATCH query, read
+    DIRECTLY from the index — no canonical-sessions JOIN.
+
+    This is the delete-test probe: a stale posting left behind by a broken
+    delete trigger would still MATCH here even though its canonical row is
+    gone, whereas the JOIN-based ``_raw_metadata_match_ids`` would hide it.
+    """
+    with db._read_ctx() as conn:
+        rows = conn.execute(
+            "SELECT rowid FROM sessions_fts WHERE sessions_fts MATCH ?",
+            (query,),
+        ).fetchall()
+    return [r["rowid"] for r in rows]
 
 
 def _gap_db(tmp_path):
@@ -505,20 +569,32 @@ class TestTriggerOwnershipRegions:
         """Deleting a ``<=P`` row removes its already-indexed document."""
         r = _three_region_db(tmp_path)
         try:
-            r.delete_session("A")  # row_id 1, indexed
-            assert "A" not in _raw_metadata_match_ids(r, "title")
-            _assert_sessions_fts_integrity(r)
+            # A (row 1) is indexed with title "Alpha Project".
+            assert _raw_fts_rowids(r, "alpha") == [1]
+            r.delete_session("A")
+            # Direct index probe: no stale posting survives the delete, and
+            # the canonical row is gone too. (The rank=1 consistency check is
+            # intentionally NOT used here: the (P,H] gap rows are legitimately
+            # unindexed mid-rebuild, so full-content consistency is expected
+            # only after the backfill completes.)
+            assert _raw_fts_rowids(r, "alpha") == []
+            assert _raw_metadata_match_ids(r, "alpha") == []
         finally:
             r.close()
 
     def test_delete_gap_row_does_not_issue_fts_delete(self, tmp_path):
         """Deleting a ``(P,H]`` row (never indexed) must not issue an
-        external-content FTS delete; integrity stays healthy."""
+        external-content FTS delete; the index stays free of stale postings
+        and the canonical row is simply absent."""
         r = _three_region_db(tmp_path)
         try:
-            r.delete_session("C")  # row_id 3, in (P,H]
-            _assert_sessions_fts_integrity(r)
-            # Row is simply absent — backfill later finds no canonical row.
+            # C (row 7) is in (P,H] — never indexed, so no posting exists.
+            assert _raw_fts_rowids(r, "gamma") == []
+            r.delete_session("C")
+            # Still no posting (a broken trigger would have tried to 'delete'
+            # an unindexed doc and either corrupted the index or left a
+            # posting); the canonical row is simply absent.
+            assert _raw_fts_rowids(r, "gamma") == []
             assert r.get_session("C") is None
         finally:
             r.close()
@@ -528,11 +604,30 @@ class TestTriggerOwnershipRegions:
         removes its live document."""
         r = _three_region_db(tmp_path)
         try:
-            r.create_session("E", source="cli")  # row_id 5 > H
+            r.create_session("E", source="cli")  # row_id > H
             r.set_session_title("E", "Live Echo")
-            assert _raw_metadata_match_ids(r, "echo") == ["E"]
+            assert _raw_fts_rowids(r, "echo") != []
             r.delete_session("E")
-            assert "E" not in _raw_metadata_match_ids(r, "echo")
+            # Direct index probe: the live document is gone, not hidden by a
+            # canonical-row JOIN.
+            assert _raw_fts_rowids(r, "echo") == []
+        finally:
+            r.close()
+
+    def test_deleted_row_leaves_no_orphan_in_completed_index(self, tmp_path):
+        """After the backfill completes (index fully consistent), deleting an
+        indexed row must leave NO orphan posting — proven by the rank=1
+        external-content consistency check, which a plain integrity-check
+        would miss."""
+        r = _gap_db(tmp_path)  # H=8, P=0, empty index
+        try:
+            while r.fts_session_rebuild_step():
+                pass
+            assert r.get_meta("fts_session_rebuild_high_water") is None
+            # Full index, one live delete.
+            r.delete_session("A")
+            assert _raw_fts_rowids(r, "alpha") == []
+            # rank=1 cross-checks the index against the content table.
             _assert_sessions_fts_integrity(r)
         finally:
             r.close()
@@ -542,8 +637,11 @@ class TestTriggerOwnershipRegions:
         indexed; integrity stays healthy."""
         r = _three_region_db(tmp_path)
         try:
-            r.set_session_title("C", "New Title C")  # row_id 3, in (P,H]
-            _assert_sessions_fts_integrity(r)
+            r.set_session_title("C", "New Title C")  # row 7 in (P,H]
+            # The gap row is still not indexed (gate is off), and the index
+            # carries no stale entry for the old title either.
+            assert _raw_fts_rowids(r, "gamma") == []
+            assert _raw_fts_rowids(r, "newtitle") == []
         finally:
             r.close()
 
@@ -552,7 +650,7 @@ class TestTriggerOwnershipRegions:
         immediately while the historical backfill remains incomplete."""
         r = _three_region_db(tmp_path)
         try:
-            r.create_session("E", source="cli")  # row_id 5 > H
+            r.create_session("E", source="cli")  # row_id > H
             r.set_session_title("E", "Fresh Live Title")
             assert _raw_metadata_match_ids(r, "fresh") == ["E"]
         finally:
@@ -567,7 +665,8 @@ class TestTriggerOwnershipRegions:
 def _metadata_search_ids(db, query):
     """Search session metadata through the raw Unicode lane + bounded (P,H]
     supplement (issue #25). Returns logical session ids, deduplicated."""
-    return [c["id"] for c in db._fts_metadata_candidates(query)]
+    _, candidates = db._fts_metadata_candidates(query)
+    return [c["id"] for c in candidates]
 
 
 def _build_populated_sessions_db(db_path, n=1200):
@@ -671,6 +770,70 @@ class TestBoundedGapSearch:
         finally:
             r.close()
 
+    def test_gap_supplement_unicode_folding_matches_fts(self, tmp_path):
+        """The bounded-gap supplement folds with the same Unicode rules as the
+        unicode61 index (case fold + diacritic removal), so both 'ecole' and
+        'école' find a gap row titled 'École des Beaux-Arts' — a session must
+        not vanish while it sits in (P,H] just because it is not backfilled
+        yet (SQLite's ASCII-only LOWER() would hide it)."""
+        r = _gap_db(tmp_path)  # H=8, P=0: every row is in the gap
+        try:
+            r.set_session_title("C", "École des Beaux-Arts")  # row 7 in gap
+            # FTS lane alone finds nothing: C is in the gap, not indexed.
+            assert _raw_metadata_match_ids(r, "ecole") == []
+            # The Unicode-aware supplement finds it for both spellings.
+            assert _metadata_search_ids(r, "ecole") == ["C"]
+            assert _metadata_search_ids(r, "école") == ["C"]
+        finally:
+            r.close()
+
+    def test_resolve_title_prefers_newer_gap_continuation(self, tmp_path):
+        """resolve_session_by_title must resume the LATEST continuation even
+        when the newer one is still in the (P,H] gap and the older one is
+        already indexed — the FTS+gap merge is sorted globally by
+        started_at DESC, not lane-then-gap."""
+        r = _three_region_db(tmp_path)  # P=3, H=8: A(1)/B(3) indexed, C(7) gap
+        try:
+            t0 = 1_000_000.0
+            r._conn.execute(
+                "UPDATE sessions SET title = 'Project #2', started_at = ? "
+                "WHERE id = 'A'",
+                (t0,),
+            )
+            r._conn.execute(
+                "UPDATE sessions SET title = 'Project #3', started_at = ? "
+                "WHERE id = 'C'",
+                (t0 + 100,),
+            )
+            r._conn.commit()
+            # A (row 1, <= P) is indexed -> its FTS doc is now "Project #2".
+            # C (row 7, gap) is not indexed -> only the supplement sees it.
+            assert r.resolve_session_by_title("Project") == "C"
+        finally:
+            r.close()
+
+    def test_resolve_title_falls_back_to_like_when_fts_lane_fails(
+        self, tmp_path
+    ):
+        """If the sessions_fts MATCH lane itself fails (table unavailable /
+        corrupt), numbered-title resolution must signal the LIKE fallback
+        instead of returning a partial/no-match result."""
+        db_path = tmp_path / "s.db"
+        w = SessionDB(db_path=db_path)
+        w.create_session("base", source="cli")
+        w.create_session("base2", source="cli")
+        w.set_session_title("base2", "Base Title #2")
+        w.close()
+        r = SessionDB(db_path=db_path)
+        try:
+            assert r.resolve_session_by_title("Base Title") == "base2"
+            # Break only the session FTS lane (message FTS stays alive).
+            r._conn.execute("DROP TABLE sessions_fts")
+            r._conn.commit()
+            assert r.resolve_session_by_title("Base Title") == "base2"
+        finally:
+            r.close()
+
 
 # =========================================================================
 # Group F — concurrency + shared throttle
@@ -679,9 +842,16 @@ class TestBoundedGapSearch:
 
 class TestConcurrencyAndThrottle:
     def test_two_runners_claim_disjoint_chunks(self, tmp_path):
-        """Two concurrent rebuild runners cannot claim/settle the same chunk:
+        """Two CONCURRENT rebuild runners cannot claim/settle the same chunk:
         progress advances through non-overlapping ranges, every document
-        appears exactly once, and the index stays healthy."""
+        appears exactly once, and the index stays healthy.
+
+        The runners are two threads with a barrier so both genuinely enter
+        the claim together — a naive ``a.step() or b.step()`` short-circuits
+        and never actually races.
+        """
+        import threading
+
         db_path = tmp_path / "s.db"
         _build_populated_sessions_db(db_path, n=1200)
         r1 = SessionDB(db_path=db_path)  # stages H=1200, P=0
@@ -689,12 +859,28 @@ class TestConcurrencyAndThrottle:
         try:
             assert r1.get_meta("fts_session_rebuild_high_water") == "1200"
             assert r2.get_meta("fts_session_rebuild_high_water") == "1200"
-            guards = 0
-            while (r1.fts_session_rebuild_step()
-                   or r2.fts_session_rebuild_step()):
-                guards += 1
-                assert guards < 1000, "rebuild loop did not terminate"
+
+            barrier = threading.Barrier(2)
+
+            def _runner(db, out):
+                barrier.wait()  # both runners enter the claim together
+                while db.fts_session_rebuild_step():
+                    pass
+                out["done"] = True
+
+            outs = ({}, {})
+            t1 = threading.Thread(target=_runner, args=(r1, outs[0]))
+            t2 = threading.Thread(target=_runner, args=(r2, outs[1]))
+            t1.start()
+            t2.start()
+            t1.join(timeout=120)
+            t2.join(timeout=120)
+            assert not t1.is_alive() and not t2.is_alive(), "runner stuck"
+            assert outs[0].get("done") and outs[1].get("done")
+
+            # Both runners saw completion; the markers were cleared once.
             assert r1.get_meta("fts_session_rebuild_high_water") is None
+            assert r2.get_meta("fts_session_rebuild_high_water") is None
             n_sessions = r1._conn.execute(
                 "SELECT COUNT(*) FROM sessions"
             ).fetchone()[0]
@@ -708,7 +894,8 @@ class TestConcurrencyAndThrottle:
             ).fetchone()[0]
             assert dup == 0
             r1._conn.execute(
-                "INSERT INTO sessions_fts(sessions_fts) VALUES('integrity-check')"
+                "INSERT INTO sessions_fts(sessions_fts, rank) "
+                "VALUES('integrity-check', 1)"
             )
         finally:
             r1.close()

--- a/tests/test_session_metadata_fts.py
+++ b/tests/test_session_metadata_fts.py
@@ -44,6 +44,69 @@ def _row_id_map(conn):
     }
 
 
+# The pre-#25 sessions shape: ``id TEXT PRIMARY KEY`` with NO named row_id.
+# (SCHEMA_SQL now declares the new shape, so fixtures that need a real legacy
+# table must demote ``sessions`` to this explicitly.)
+_LEGACY_SESSIONS_DDL = """
+CREATE TABLE sessions (
+    id TEXT PRIMARY KEY,
+    source TEXT NOT NULL,
+    user_id TEXT,
+    session_key TEXT,
+    chat_id TEXT,
+    chat_type TEXT,
+    thread_id TEXT,
+    display_name TEXT,
+    origin_json TEXT,
+    expiry_finalized INTEGER DEFAULT 0,
+    model TEXT,
+    model_config TEXT,
+    system_prompt TEXT,
+    system_prompt_hash TEXT,
+    parent_session_id TEXT,
+    started_at REAL NOT NULL,
+    ended_at REAL,
+    end_reason TEXT,
+    message_count INTEGER DEFAULT 0,
+    tool_call_count INTEGER DEFAULT 0,
+    input_tokens INTEGER DEFAULT 0,
+    output_tokens INTEGER DEFAULT 0,
+    cache_read_tokens INTEGER DEFAULT 0,
+    cache_write_tokens INTEGER DEFAULT 0,
+    reasoning_tokens INTEGER DEFAULT 0,
+    cwd TEXT,
+    git_branch TEXT,
+    git_repo_root TEXT,
+    billing_provider TEXT,
+    billing_base_url TEXT,
+    billing_mode TEXT,
+    estimated_cost_usd REAL,
+    actual_cost_usd REAL,
+    cost_status TEXT,
+    cost_source TEXT,
+    pricing_version TEXT,
+    title TEXT,
+    last_activity_at REAL,
+    last_activity_description TEXT,
+    last_activity_provenance TEXT,
+    api_call_count INTEGER DEFAULT 0,
+    handoff_state TEXT,
+    handoff_platform TEXT,
+    handoff_error TEXT,
+    compression_failure_cooldown_until REAL,
+    compression_failure_error TEXT,
+    compression_fallback_streak INTEGER NOT NULL DEFAULT 0,
+    compression_ineffective_count INTEGER NOT NULL DEFAULT 0,
+    profile_name TEXT,
+    rewind_count INTEGER NOT NULL DEFAULT 0,
+    archived INTEGER NOT NULL DEFAULT 0,
+    pinned INTEGER NOT NULL DEFAULT 0,
+    FOREIGN KEY (parent_session_id) REFERENCES sessions(id),
+    FOREIGN KEY (system_prompt_hash) REFERENCES system_prompts(hash)
+)
+"""
+
+
 def _build_legacy_sessions_db(db_path):
     """Build a pre-#25 DB by hand: sessions WITHOUT ``row_id`` (``id TEXT
     PRIMARY KEY``), with explicit hidden rowids that contain deleted-row
@@ -55,6 +118,9 @@ def _build_legacy_sessions_db(db_path):
     conn = sqlite3.connect(str(db_path))
     conn.execute("PRAGMA foreign_keys=OFF")
     conn.executescript(SCHEMA_SQL)
+    # Demote sessions to the pre-#25 shape (no named row_id).
+    conn.execute("DROP TABLE sessions")
+    conn.executescript(_LEGACY_SESSIONS_DDL)
 
     t0 = time.time()
     for rowid, sid, started_at, title in (
@@ -131,7 +197,9 @@ class TestNamedRowIdMigration:
 
         session_db = SessionDB(db_path=db_path)
         try:
-            assert _row_id_map(session_db._conn) == {"A": 1, "B": 3, "C": 7}
+            assert _row_id_map(session_db._conn) == {
+                "A": 1, "B": 3, "C": 7, "A-child": 8,
+            }
             # id stays NOT NULL UNIQUE (logical identity).
             ids = {
                 r["name"]: r for r in session_db._conn.execute(
@@ -219,7 +287,9 @@ class TestNamedRowIdMigration:
 
         session_db = SessionDB(db_path=db_path)
         try:
-            assert _row_id_map(session_db._conn) == {"A": 1, "B": 3, "C": 7}
+            assert _row_id_map(session_db._conn) == {
+                "A": 1, "B": 3, "C": 7, "A-child": 8,
+            }
             leftover = session_db._conn.execute(
                 "SELECT 1 FROM sqlite_master "
                 "WHERE type = 'table' AND name = 'sessions_new'"

--- a/tests/test_session_metadata_fts.py
+++ b/tests/test_session_metadata_fts.py
@@ -19,6 +19,7 @@ from hermes_state import (
     LEGACY_FTS_SQL,
     SCHEMA_SQL,
     SessionDB,
+    _fts_query_positive_terms,
     _fts_unicode61_fold,
 )
 
@@ -943,6 +944,46 @@ class TestBoundedGapSearch:
             assert _raw_metadata_match_ids(r, "alpha OR beta") == []
             # The gap supplement surfaces C via the 'alpha' term.
             assert "C" in _metadata_search_ids(r, "alpha OR beta")
+        finally:
+            r.close()
+
+    def test_positive_term_extractor_splits_punctuation(self):
+        """The term extractor splits on EVERY non-token character — including
+        '_', which Python's ``\\w`` wrongly treats as a word char — so the gap
+        predicate stays a superset of the FTS predicate across the
+        sanitizer-quoted [._-] punctuation."""
+        assert _fts_query_positive_terms("foo_bar") == ["foo", "bar"]
+        assert _fts_query_positive_terms("foo-bar") == ["foo", "bar"]
+        assert _fts_query_positive_terms("foo.bar") == ["foo", "bar"]
+        assert _fts_query_positive_terms("Alpha Project") == ["alpha", "project"]
+        assert _fts_query_positive_terms("alpha OR beta") == ["alpha", "beta"]
+        assert _fts_query_positive_terms("École") == ["ecole"]
+
+    @pytest.mark.parametrize("query", ["foo_bar", "foo-bar", "foo.bar"])
+    def test_gap_supplement_punctuation_query_no_hide(self, tmp_path, query):
+        """Punctuation the sanitizer quotes into an FTS phrase ('.', '-', '_')
+        must not hide a gap row: the index tokenizes a 'foo bar ...' document
+        and a 'foo_bar' query to the same two tokens, so the gap supplement
+        must too — the term extractor treats all three as separators, never a
+        literal part of the term."""
+        r = _three_region_db(tmp_path)  # A(1)/B(3) indexed, C(7) in gap
+        try:
+            # Distinct titles (the unique-title constraint forbids sharing the
+            # exact string) that both carry the adjacent 'foo bar' phrase.
+            r.set_session_title("A", "foo bar alpha")  # <= P, indexed
+            r.set_session_title("C", "foo bar beta")   # (P,H], gap
+            # Indexed control via the same sanitized quoted phrase the FTS
+            # lane uses (a bare '.foo.'/'-' query is not valid FTS5 syntax).
+            sanitized = r._sanitize_fts5_query(query)
+            assert _raw_metadata_match_ids(r, sanitized) == ["A"]
+            # Gap supplement must ALSO surface C.
+            hits = _metadata_search_ids(r, query)
+            assert "A" in hits and "C" in hits
+            # After backfill completes, C is index-findable too.
+            while r.fts_session_rebuild_step():
+                pass
+            assert r.get_meta("fts_session_rebuild_high_water") is None
+            assert "C" in _raw_metadata_match_ids(r, sanitized)
         finally:
             r.close()
 

--- a/tests/test_session_metadata_fts.py
+++ b/tests/test_session_metadata_fts.py
@@ -962,6 +962,9 @@ class TestBoundedGapSearch:
         assert _fts_query_positive_terms('"AND"') == ["and"]
         assert _fts_query_positive_terms('"foo bar"') == ["foo", "bar"]
         assert _fts_query_positive_terms("École") == ["ecole"]
+        # Private-Use codepoints (unicode61 category Co) are token chars too.
+        assert _fts_query_positive_terms("\ue000") == ["\ue000"]
+        assert _fts_query_positive_terms("a\ue000b") == ["a\ue000b"]
 
     @pytest.mark.parametrize("query", ["foo_bar", "foo-bar", "foo.bar"])
     def test_gap_supplement_punctuation_query_no_hide(self, tmp_path, query):
@@ -1011,6 +1014,28 @@ class TestBoundedGapSearch:
                 pass
             assert r.get_meta("fts_session_rebuild_high_water") is None
             assert "C" in _raw_metadata_match_ids(r, '"AND"')
+        finally:
+            r.close()
+
+    def test_gap_supplement_private_use_codepoint_no_hide(self, tmp_path):
+        """Private-Use codepoints (Unicode category Co) are unicode61 token
+        characters — U+E000 is indexable and MATCH-able — so the term
+        extractor must keep them too (isalnum() alone drops Co). A gap row
+        carrying the PUA token must be surfaced, or it hides until backfill."""
+        r = _three_region_db(tmp_path)  # A(1)/B(3) indexed, C(7) in gap
+        try:
+            r.set_session_title("A", "\ue000 alpha")  # <= P, indexed
+            r.set_session_title("C", "\ue000 beta")   # (P,H], gap
+            # Indexed control: U+E000 is a unicode61 token.
+            assert _raw_metadata_match_ids(r, "\ue000") == ["A"]
+            # Gap supplement must ALSO surface C.
+            hits = _metadata_search_ids(r, "\ue000")
+            assert "A" in hits and "C" in hits
+            # After backfill completes, C is index-findable too.
+            while r.fts_session_rebuild_step():
+                pass
+            assert r.get_meta("fts_session_rebuild_high_water") is None
+            assert "C" in _raw_metadata_match_ids(r, "\ue000")
         finally:
             r.close()
 

--- a/tests/test_session_metadata_fts.py
+++ b/tests/test_session_metadata_fts.py
@@ -236,6 +236,21 @@ def _build_legacy_message_and_session_fts_db(db_path):
     conn.close()
 
 
+def _build_legacy_empty_session_fts_db(db_path):
+    """Legacy DB with ZERO sessions: old INTERNAL title-only sessions_fts +
+    broad triggers over a legacy sessions table (no named row_id, no rows).
+    Opening it must convert sessions_fts to external WITHOUT staging an
+    H=0/P=0 claim that would leave optimize permanently pending."""
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA foreign_keys=OFF")
+    conn.executescript(SCHEMA_SQL)
+    conn.execute("DROP TABLE sessions")
+    conn.executescript(_LEGACY_SESSIONS_DDL)
+    conn.executescript(_LEGACY_SESSIONS_FTS_DDL)
+    conn.commit()
+    conn.close()
+
+
 # =========================================================================
 # Group A — named row_id migration (preserve exact legacy storage identity)
 # =========================================================================
@@ -891,6 +906,46 @@ class TestBoundedGapSearch:
         finally:
             r.close()
 
+    def test_gap_supplement_multi_token_query_no_hide(self, tmp_path):
+        """A multi-token FTS query (implicit AND) must not hide a gap row:
+        'Alpha middle Project' MATCHes 'Alpha Project' once indexed (both
+        tokens present), so the gap supplement must find it too — the old
+        whole-string substring test ('alpha project' in 'alpha middle
+        project' → False) would hide it until backfill."""
+        r = _three_region_db(tmp_path)  # A(1)/B(3) indexed, C(7) in gap
+        try:
+            # A's default title is already 'Alpha Project' (indexed, <= P).
+            r.set_session_title("C", "Alpha middle Project")  # gap row
+            # Indexed lane: A matches the two-token implicit-AND query.
+            assert _raw_metadata_match_ids(r, "Alpha Project") == ["A"]
+            # Gap supplement must ALSO surface C (not hide it mid-migration).
+            hits = _metadata_search_ids(r, "Alpha Project")
+            assert "A" in hits and "C" in hits
+            # After the backfill completes, C is findable via the index.
+            while r.fts_session_rebuild_step():
+                pass
+            assert r.get_meta("fts_session_rebuild_high_water") is None
+            assert "C" in _raw_metadata_match_ids(r, "Alpha Project")
+        finally:
+            r.close()
+
+    def test_gap_supplement_or_query_no_hide(self, tmp_path):
+        """A boolean OR query must not hide a gap row: the indexed lane
+        matches title='Alpha' for MATCH 'alpha OR beta', so the gap
+        supplement must surface it too. The supplement extracts positive
+        terms from the query ('alpha', 'beta') and matches ANY of them —
+        the old whole-string substring test ('alpha or beta' in 'alpha')
+        would hide the row until backfill."""
+        r = _gap_db(tmp_path)  # H=8, P=0: every row is in the gap
+        try:
+            r.set_session_title("C", "Alpha")  # row 7 in gap
+            # Nothing is indexed yet (P=0): the raw index has no hits.
+            assert _raw_metadata_match_ids(r, "alpha OR beta") == []
+            # The gap supplement surfaces C via the 'alpha' term.
+            assert "C" in _metadata_search_ids(r, "alpha OR beta")
+        finally:
+            r.close()
+
     def test_resolve_title_prefers_newer_gap_continuation(self, tmp_path):
         """resolve_session_by_title must resume the LATEST continuation even
         when the newer one is still in the (P,H] gap and the older one is
@@ -1115,3 +1170,34 @@ class TestLegacyMessageFTSUpgradePath:
             _assert_sessions_fts_integrity(r)
         finally:
             r.close()
+
+    def test_empty_legacy_db_leaves_no_zombie_hp_markers(self, tmp_path):
+        """An old INTERNAL sessions_fts on a legacy DB with ZERO sessions
+        must not leave a permanent H=0/P=0 claim after conversion to
+        external: with 0 rows the index is complete by construction, so no
+        markers should be staged, optimize must settle (not
+        backfill_incomplete), and a reopen must stay clean."""
+        db_path = tmp_path / "legacy-empty.db"
+        _build_legacy_empty_session_fts_db(db_path)
+
+        r = SessionDB(db_path=db_path)
+        try:
+            # sessions_fts converted to the #25 external Unicode shape.
+            assert "content='sessions'" in _fts_sql(r._conn, "sessions_fts")
+            # No zombie H/P pair (0 sessions = complete by construction).
+            assert r.get_meta("fts_session_rebuild_high_water") is None
+            assert r.get_meta("fts_session_rebuild_progress") is None
+            # optimize settles — not permanently pending.
+            result = r.optimize_fts_storage(vacuum=False)
+            assert result["ok"] is True, result
+            assert r.fts_optimize_available() is False
+        finally:
+            r.close()
+
+        # Reopen stays clean (markers do not reappear).
+        r2 = SessionDB(db_path=db_path)
+        try:
+            assert r2.get_meta("fts_session_rebuild_high_water") is None
+            assert r2.fts_optimize_available() is False
+        finally:
+            r2.close()

--- a/tests/test_session_metadata_fts.py
+++ b/tests/test_session_metadata_fts.py
@@ -1,0 +1,229 @@
+"""Tests for the #25 session-metadata FTS architecture.
+
+Covers the named ``sessions.row_id`` migration (preserving exact legacy
+hidden rowids including deleted-row holes), the raw ``(title, id,
+display_name)`` Unicode external-content ``sessions_fts``, the resumable
+crash-safe H/P rebuild, bounded-gap search supplementation, and the shared
+throttle/concurrency contract.
+
+Scoped per #25: raw Unicode only. CJK (#26), normalized trigram (#30), and
+unified lifecycle/storage settlement (#27) are explicitly out of scope here.
+"""
+
+import sqlite3
+import time
+
+import pytest
+
+from hermes_state import SCHEMA_SQL, SessionDB
+
+
+@pytest.fixture()
+def db(tmp_path):
+    """Fresh SessionDB (#25 layout: named sessions.row_id + raw Unicode
+    external-content session metadata FTS) over a temp database file."""
+    db_path = tmp_path / "state.db"
+    session_db = SessionDB(db_path=db_path)
+    yield session_db
+    session_db.close()
+
+
+def _column_names(conn, table):
+    return {
+        r[1] if isinstance(r, (tuple, list)) else r["name"]
+        for r in conn.execute(f'PRAGMA table_info("{table}")').fetchall()
+    }
+
+
+def _row_id_map(conn):
+    """Return ``{id: row_id}`` for every session."""
+    return {
+        (r[0] if isinstance(r, sqlite3.Row) else r[0]):
+        (r[1] if isinstance(r, sqlite3.Row) else r[1])
+        for r in conn.execute("SELECT id, row_id FROM sessions").fetchall()
+    }
+
+
+def _build_legacy_sessions_db(db_path):
+    """Build a pre-#25 DB by hand: sessions WITHOUT ``row_id`` (``id TEXT
+    PRIMARY KEY``), with explicit hidden rowids that contain deleted-row
+    holes (1=A, 3=B, 7=C — 2,4,5,6 never existed / were deleted), plus
+    relationship rows keyed by text ``id``. Everything else matches the
+    modern schema (SCHEMA_SQL), so the open path must add ``row_id`` via the
+    #25 migration and preserve every surviving numeric rowid.
+    """
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA foreign_keys=OFF")
+    conn.executescript(SCHEMA_SQL)
+
+    t0 = time.time()
+    for rowid, sid, started_at, title in (
+        (1, "A", t0, "Alpha Project"),
+        (3, "B", t0 + 1, "Beta Project"),
+        (7, "C", t0 + 2, "Gamma Project"),
+    ):
+        conn.execute(
+            "INSERT INTO sessions (rowid, id, source, started_at, title) "
+            "VALUES (?, ?, 'cli', ?, ?)",
+            (rowid, sid, started_at, title),
+        )
+
+    # Relationships keyed by text id (messages, model usage, parent/child).
+    conn.execute(
+        "INSERT INTO messages (session_id, role, content, timestamp) "
+        "VALUES (?, 'user', 'message-for-A', ?)",
+        ("A", t0),
+    )
+    conn.execute(
+        "INSERT INTO session_model_usage (session_id, model) VALUES (?, ?)",
+        ("B", "model-x"),
+    )
+    conn.execute(
+        "INSERT INTO sessions (id, source, started_at, parent_session_id) "
+        "VALUES ('A-child', 'cli', ?, 'A')",
+        (t0 + 3,),
+    )
+
+    conn.commit()
+    conn.close()
+
+
+# =========================================================================
+# Group A — named row_id migration (preserve exact legacy storage identity)
+# =========================================================================
+
+
+class TestNamedRowIdMigration:
+    def test_fresh_install_sessions_has_named_row_id(self, db):
+        """Fresh installs are born with ``row_id INTEGER PRIMARY KEY`` and
+        keep ``id`` as the NOT NULL UNIQUE logical identity."""
+        cols = _column_names(db._conn, "sessions")
+        assert "row_id" in cols
+        pk = db._conn.execute(
+            "PRAGMA table_info('sessions')"
+        ).fetchall()
+        row_id_col = next(
+            r for r in pk
+            if (r["name"] if isinstance(r, sqlite3.Row) else r[1]) == "row_id"
+        )
+        assert (row_id_col["pk"] if isinstance(row_id_col, sqlite3.Row) else row_id_col[5]) == 1
+
+        db.create_session("s1", source="cli")
+        db.create_session("s2", source="cli")
+        ids = [
+            r[1] if isinstance(r, sqlite3.Row) else r[1]
+            for r in db._conn.execute(
+                "SELECT row_id, id FROM sessions ORDER BY row_id"
+            ).fetchall()
+        ]
+        assert ids == ["s1", "s2"]
+
+    def test_legacy_rowid_holes_preserved_exactly(self, tmp_path):
+        """Opening a legacy DB preserves each surviving hidden rowid as the
+        same numeric ``row_id``, including deleted-row gaps.
+
+        old hidden rowids: 1=A, 3=B, 7=C
+        required row_id:   1=A, 3=B, 7=C
+        WRONG (densified): 1=A, 2=B, 3=C
+        """
+        db_path = tmp_path / "legacy.db"
+        _build_legacy_sessions_db(db_path)
+
+        session_db = SessionDB(db_path=db_path)
+        try:
+            assert _row_id_map(session_db._conn) == {"A": 1, "B": 3, "C": 7}
+            # id stays NOT NULL UNIQUE (logical identity).
+            ids = {
+                r["name"]: r for r in session_db._conn.execute(
+                    "PRAGMA table_info('sessions')"
+                ).fetchall()
+            }
+            id_col = ids["id"]
+            assert id_col["notnull"] == 1
+            unique_idx = session_db._conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE type = 'index' "
+                "AND name = 'sqlite_autoindex_sessions_1'"
+            ).fetchone()
+            assert unique_idx is not None
+        finally:
+            session_db.close()
+
+    def test_relationships_survive_migration(self, tmp_path):
+        """Message ownership, model usage, and parent/child sessions keyed by
+        text ``sessions.id`` continue to resolve unchanged after migration."""
+        db_path = tmp_path / "legacy.db"
+        _build_legacy_sessions_db(db_path)
+
+        session_db = SessionDB(db_path=db_path)
+        try:
+            # messages.session_id -> sessions.id still resolves.
+            msgs = session_db.get_messages("A")
+            assert [m["content"] for m in msgs] == ["message-for-A"]
+            # model usage keyed by session id.
+            usage = session_db._conn.execute(
+                "SELECT model FROM session_model_usage WHERE session_id = 'B'"
+            ).fetchone()
+            assert (usage[0] if not isinstance(usage, sqlite3.Row) else usage["model"]) == "model-x"
+            # parent/child by text id.
+            child = session_db._conn.execute(
+                "SELECT parent_session_id FROM sessions WHERE id = 'A-child'"
+            ).fetchone()
+            assert (
+                child[0] if not isinstance(child, sqlite3.Row) else child["parent_session_id"]
+            ) == "A"
+        finally:
+            session_db.close()
+
+    def test_vacuum_preserves_named_row_id(self, db):
+        """VACUUM must not renumber the named ``row_id`` (SQLite only
+        guarantees rowid stability for an explicit INTEGER PRIMARY KEY)."""
+        db.create_session("a", source="cli")
+        db.create_session("b", source="cli")
+        db.create_session("c", source="cli")
+        before = _row_id_map(db._conn)
+        db.vacuum()
+        after = _row_id_map(db._conn)
+        assert before == after
+
+    def test_fresh_session_row_id_above_max_legacy(self, tmp_path):
+        """A fresh session created after migration gets a ``row_id`` strictly
+        greater than every legacy row_id (AUTOINCREMENT monotonicity — the
+        property the > H live-trigger ownership relies on)."""
+        db_path = tmp_path / "legacy.db"
+        _build_legacy_sessions_db(db_path)
+
+        session_db = SessionDB(db_path=db_path)
+        try:
+            session_db.create_session("D", source="cli")
+            row = session_db._conn.execute(
+                "SELECT row_id FROM sessions WHERE id = 'D'"
+            ).fetchone()
+            new_row_id = row[0] if not isinstance(row, sqlite3.Row) else row["row_id"]
+            assert new_row_id > 7
+        finally:
+            session_db.close()
+
+    def test_stale_sessions_new_leftover_is_cleaned_up(self, tmp_path):
+        """A donor-style interrupted swap can leave a partial ``sessions_new``
+        behind (autocommit DDL between DROP/rename). The #25 migration must
+        drop stale ``sessions_new`` inside its transaction and never lose a
+        canonical session row."""
+        db_path = tmp_path / "legacy.db"
+        _build_legacy_sessions_db(db_path)
+        # Simulate a non-transactional interrupted attempt.
+        with sqlite3.connect(db_path) as conn:
+            conn.execute(
+                "CREATE TABLE sessions_new (id TEXT PRIMARY KEY, source TEXT)"
+            )
+            conn.commit()
+
+        session_db = SessionDB(db_path=db_path)
+        try:
+            assert _row_id_map(session_db._conn) == {"A": 1, "B": 3, "C": 7}
+            leftover = session_db._conn.execute(
+                "SELECT 1 FROM sqlite_master "
+                "WHERE type = 'table' AND name = 'sessions_new'"
+            ).fetchone()
+            assert leftover is None
+        finally:
+            session_db.close()

--- a/tests/test_session_metadata_fts.py
+++ b/tests/test_session_metadata_fts.py
@@ -470,6 +470,18 @@ def _assert_sessions_fts_integrity(db):
     )
 
 
+def _assert_sessions_fts_internal_integrity(db):
+    """Ordinary FTS5 internal integrity-check (shadow-table structure only).
+
+    Unlike ``_assert_sessions_fts_integrity`` (rank=1), this does NOT
+    cross-check against the content table, so it is safe mid-migration when
+    the ``(P, H]`` gap rows are legitimately unindexed.
+    """
+    db._conn.execute(
+        "INSERT INTO sessions_fts(sessions_fts) VALUES('integrity-check')"
+    )
+
+
 def _raw_metadata_match_ids(db, query):
     """Return session ids whose raw Unicode metadata document MATCHes query."""
     with db._read_ctx() as conn:
@@ -656,6 +668,56 @@ class TestRebuildMarkers:
         finally:
             r.close()
 
+    def test_partial_index_orphan_hp_resets_and_replays(self, tmp_path):
+        """#32: an orphan H-without-P over a PARTIALLY populated index must be
+        reset known-empty and replayed without duplicates — never serve the
+        partial index as complete. optimize must settle (doc count == sessions,
+        no duplicate rowid, rank=1 integrity, markers cleared) and reopen stays
+        settled."""
+        db_path = tmp_path / "s.db"
+        _build_populated_sessions_db(db_path, n=50)  # 50 sessions, no sessions_fts
+        r = SessionDB(db_path=db_path)  # stages H=50, P=0 over an empty index
+        try:
+            # Backfill a prefix by hand, then remove P to simulate an orphan
+            # high-water-without-progress (partial index of unknown extent).
+            r._conn.execute(
+                "INSERT INTO sessions_fts(rowid, title, id, display_name) "
+                "SELECT row_id, title, id, display_name FROM sessions "
+                "WHERE row_id <= 20"
+            )
+            r._conn.execute(
+                "DELETE FROM state_meta WHERE key = 'fts_session_rebuild_progress'"
+            )
+            r._conn.commit()
+            # optimize repairs (reset known-empty + P=0) then backfills fully.
+            result = r.optimize_fts_storage(vacuum=False)
+            assert result["ok"] is True, result
+            assert r.get_meta("fts_session_rebuild_high_water") is None
+            assert r.get_meta("fts_session_rebuild_progress") is None
+            n_sessions = r._conn.execute(
+                "SELECT COUNT(*) FROM sessions"
+            ).fetchone()[0]
+            n_docs = r._conn.execute(
+                "SELECT COUNT(*) FROM sessions_fts_docsize"
+            ).fetchone()[0]
+            assert n_docs == n_sessions
+            dup = r._conn.execute(
+                "SELECT COUNT(*) FROM (SELECT rowid FROM sessions_fts_docsize "
+                "GROUP BY rowid HAVING COUNT(*) > 1)"
+            ).fetchone()[0]
+            assert dup == 0
+            _assert_sessions_fts_integrity(r)
+        finally:
+            r.close()
+
+        # Reopen remains settled.
+        r2 = SessionDB(db_path=db_path)
+        try:
+            assert r2.get_meta("fts_session_rebuild_high_water") is None
+            assert r2.fts_optimize_available() is False
+        finally:
+            r2.close()
+
 
 # =========================================================================
 # Group D — trigger ownership regions (<=P, (P,H], >H) + deletes + integrity
@@ -677,6 +739,8 @@ class TestTriggerOwnershipRegions:
             # only after the backfill completes.)
             assert _raw_fts_rowids(r, "alpha") == []
             assert _raw_metadata_match_ids(r, "alpha") == []
+            # Ordinary internal integrity-check (safe mid-migration).
+            _assert_sessions_fts_internal_integrity(r)
         finally:
             r.close()
 
@@ -694,6 +758,8 @@ class TestTriggerOwnershipRegions:
             # posting); the canonical row is simply absent.
             assert _raw_fts_rowids(r, "gamma") == []
             assert r.get_session("C") is None
+            # Ordinary internal integrity-check (safe mid-migration).
+            _assert_sessions_fts_internal_integrity(r)
         finally:
             r.close()
 
@@ -709,6 +775,8 @@ class TestTriggerOwnershipRegions:
             # Direct index probe: the live document is gone, not hidden by a
             # canonical-row JOIN.
             assert _raw_fts_rowids(r, "echo") == []
+            # Ordinary internal integrity-check (safe mid-migration).
+            _assert_sessions_fts_internal_integrity(r)
         finally:
             r.close()
 
@@ -740,6 +808,8 @@ class TestTriggerOwnershipRegions:
             # carries no stale entry for the old title either.
             assert _raw_fts_rowids(r, "gamma") == []
             assert _raw_fts_rowids(r, "newtitle") == []
+            # Ordinary internal integrity-check (safe mid-migration).
+            _assert_sessions_fts_internal_integrity(r)
         finally:
             r.close()
 
@@ -751,6 +821,103 @@ class TestTriggerOwnershipRegions:
             r.create_session("E", source="cli")  # row_id > H
             r.set_session_title("E", "Fresh Live Title")
             assert _raw_metadata_match_ids(r, "fresh") == ["E"]
+        finally:
+            r.close()
+
+    def test_window_insert_between_teardown_and_trigger_install_is_caught_up(
+        self, tmp_path, monkeypatch
+    ):
+        """A session committed by ANOTHER connection in the window between the
+        H capture / old-table teardown and the install of the new gated
+        triggers (the stage transaction commits before the external schema is
+        ensured) is neither trigger-indexed nor in the (P,H] gap supplement —
+        the transition catch-up must index it, or it stays invisible until a
+        full rebuild."""
+        db_path = tmp_path / "legacy.db"
+        _build_legacy_message_and_session_fts_db(db_path)  # A(1) B(3) C(7) A-child(8)
+        real_ensure = SessionDB._ensure_fts_schema
+
+        def _ensure_with_window_insert(self, cursor, table_name, ddl):
+            if table_name == "sessions_fts":
+                # Simulate the other-process write in the trigger-free window:
+                # the stage transaction already committed H; insert a row above
+                # it via a second raw connection (no sessions_fts trigger
+                # exists yet, so the row is not indexed).
+                with sqlite3.connect(str(db_path)) as conn:
+                    hw = conn.execute(
+                        "SELECT CAST(value AS INTEGER) FROM state_meta "
+                        "WHERE key = 'fts_session_rebuild_high_water'"
+                    ).fetchone()
+                    hw = int(hw[0]) if hw else 0
+                    conn.execute(
+                        "INSERT INTO sessions (id, source, started_at) "
+                        "VALUES ('W', 'cli', ?)",
+                        (time.time(),),
+                    )
+                    conn.commit()
+            return real_ensure(self, cursor, table_name, ddl)
+
+        monkeypatch.setattr(
+            SessionDB, "_ensure_fts_schema", _ensure_with_window_insert
+        )
+        r = SessionDB(db_path=db_path)
+        try:
+            # The window row (row_id > H) must be searchable immediately —
+            # the transition catch-up indexed it.
+            assert _raw_metadata_match_ids(r, "W") == ["W"]
+            # optimize settles with every session covered (no invisible row).
+            result = r.optimize_fts_storage(vacuum=False)
+            assert result["ok"] is True, result
+            n_sessions = r._conn.execute(
+                "SELECT COUNT(*) FROM sessions"
+            ).fetchone()[0]
+            n_docs = r._conn.execute(
+                "SELECT COUNT(*) FROM sessions_fts_docsize"
+            ).fetchone()[0]
+            assert n_docs == n_sessions
+        finally:
+            r.close()
+
+    def test_fresh_create_window_insert_is_caught_up(self, tmp_path, monkeypatch):
+        """Same transition window on the fresh-create-over-populated path (no
+        pre-existing internal sessions_fts): a >H row committed by another
+        connection between the H/P seed and the trigger install must be caught
+        up, not left invisible."""
+        db_path = tmp_path / "s.db"
+        _build_populated_sessions_db(db_path, n=50)  # no sessions_fts yet
+        real_ensure = SessionDB._ensure_fts_schema
+
+        def _ensure_with_window_insert(self, cursor, table_name, ddl):
+            if table_name == "sessions_fts":
+                with sqlite3.connect(str(db_path)) as conn:
+                    hw = conn.execute(
+                        "SELECT CAST(value AS INTEGER) FROM state_meta "
+                        "WHERE key = 'fts_session_rebuild_high_water'"
+                    ).fetchone()
+                    hw = int(hw[0]) if hw else 0
+                    conn.execute(
+                        "INSERT INTO sessions (id, source, started_at) "
+                        "VALUES ('W', 'cli', ?)",
+                        (time.time(),),
+                    )
+                    conn.commit()
+            return real_ensure(self, cursor, table_name, ddl)
+
+        monkeypatch.setattr(
+            SessionDB, "_ensure_fts_schema", _ensure_with_window_insert
+        )
+        r = SessionDB(db_path=db_path)
+        try:
+            assert _raw_metadata_match_ids(r, "W") == ["W"]
+            result = r.optimize_fts_storage(vacuum=False)
+            assert result["ok"] is True, result
+            n_sessions = r._conn.execute(
+                "SELECT COUNT(*) FROM sessions"
+            ).fetchone()[0]
+            n_docs = r._conn.execute(
+                "SELECT COUNT(*) FROM sessions_fts_docsize"
+            ).fetchone()[0]
+            assert n_docs == n_sessions
         finally:
             r.close()
 
@@ -881,9 +1048,12 @@ class TestBoundedGapSearch:
             r.set_session_title("C", "École des Beaux-Arts")  # row 7 in gap
             # FTS lane alone finds nothing: C is in the gap, not indexed.
             assert _raw_metadata_match_ids(r, "ecole") == []
-            # The Unicode-aware supplement finds it for both spellings.
+            # The Unicode-aware supplement finds it for both spellings. The
+            # non-ASCII spelling ('école') also over-matches other gap rows
+            # (per-codepoint emission is a superset by design) — what matters
+            # is C is never hidden.
             assert _metadata_search_ids(r, "ecole") == ["C"]
-            assert _metadata_search_ids(r, "école") == ["C"]
+            assert "C" in _metadata_search_ids(r, "école")
         finally:
             r.close()
 
@@ -948,12 +1118,14 @@ class TestBoundedGapSearch:
             r.close()
 
     def test_positive_term_extractor_splits_punctuation(self):
-        """The term extractor splits on EVERY non-token character — including
-        '_', which Python's ``\\w`` wrongly treats as a word char — so the gap
-        predicate stays a superset of the FTS predicate across the
-        sanitizer-quoted [._-] punctuation. Boolean operator WORDS are kept
-        as terms: a quoted '"AND"' is a literal FTS phrase, not an operator,
-        so stripping it would empty the gap terms and hide a matched row."""
+        """The term extractor splits on ASCII non-alphanumerics only — Python
+        '\\w' wrongly keeps '_', and Python's Unicode categories can't mirror
+        unicode61 (Unicode 6.1). Non-ASCII characters are always kept inside
+        terms (never excluded), so the gap predicate stays a superset of the
+        FTS predicate across sanitizer-quoted [._-] punctuation, quoted
+        boolean literals, PUA, and unicode61-vs-Python category drift.
+        Boolean operator WORDS are kept as terms: a quoted '"AND"' is a
+        literal FTS phrase, not an operator."""
         assert _fts_query_positive_terms("foo_bar") == ["foo", "bar"]
         assert _fts_query_positive_terms("foo-bar") == ["foo", "bar"]
         assert _fts_query_positive_terms("foo.bar") == ["foo", "bar"]
@@ -961,10 +1133,15 @@ class TestBoundedGapSearch:
         assert _fts_query_positive_terms("alpha OR beta") == ["alpha", "or", "beta"]
         assert _fts_query_positive_terms('"AND"') == ["and"]
         assert _fts_query_positive_terms('"foo bar"') == ["foo", "bar"]
-        assert _fts_query_positive_terms("École") == ["ecole"]
-        # Private-Use codepoints (unicode61 category Co) are token chars too.
+        # ASCII-only boundary is unchanged; non-ASCII is kept + per-codepoint.
+        assert _fts_query_positive_terms("École") == ["ecole", "cole", "e"]
+        # PUA (Co) and a unicode61-token-char-that-Python-calls-So (U+1018C)
+        # are kept as terms (the merged run + the codepoint).
         assert _fts_query_positive_terms("\ue000") == ["\ue000"]
-        assert _fts_query_positive_terms("a\ue000b") == ["a\ue000b"]
+        assert _fts_query_positive_terms("a\ue000b") == [
+            "a\ue000b", "a", "b", "\ue000",
+        ]
+        assert _fts_query_positive_terms("\U0001018C") == ["\U0001018C"]
 
     @pytest.mark.parametrize("query", ["foo_bar", "foo-bar", "foo.bar"])
     def test_gap_supplement_punctuation_query_no_hide(self, tmp_path, query):

--- a/tests/test_session_metadata_fts.py
+++ b/tests/test_session_metadata_fts.py
@@ -951,12 +951,16 @@ class TestBoundedGapSearch:
         """The term extractor splits on EVERY non-token character — including
         '_', which Python's ``\\w`` wrongly treats as a word char — so the gap
         predicate stays a superset of the FTS predicate across the
-        sanitizer-quoted [._-] punctuation."""
+        sanitizer-quoted [._-] punctuation. Boolean operator WORDS are kept
+        as terms: a quoted '"AND"' is a literal FTS phrase, not an operator,
+        so stripping it would empty the gap terms and hide a matched row."""
         assert _fts_query_positive_terms("foo_bar") == ["foo", "bar"]
         assert _fts_query_positive_terms("foo-bar") == ["foo", "bar"]
         assert _fts_query_positive_terms("foo.bar") == ["foo", "bar"]
         assert _fts_query_positive_terms("Alpha Project") == ["alpha", "project"]
-        assert _fts_query_positive_terms("alpha OR beta") == ["alpha", "beta"]
+        assert _fts_query_positive_terms("alpha OR beta") == ["alpha", "or", "beta"]
+        assert _fts_query_positive_terms('"AND"') == ["and"]
+        assert _fts_query_positive_terms('"foo bar"') == ["foo", "bar"]
         assert _fts_query_positive_terms("École") == ["ecole"]
 
     @pytest.mark.parametrize("query", ["foo_bar", "foo-bar", "foo.bar"])
@@ -984,6 +988,29 @@ class TestBoundedGapSearch:
                 pass
             assert r.get_meta("fts_session_rebuild_high_water") is None
             assert "C" in _raw_metadata_match_ids(r, sanitized)
+        finally:
+            r.close()
+
+    def test_gap_supplement_quoted_boolean_literal_no_hide(self, tmp_path):
+        """A quoted boolean word ('"AND"') is a literal FTS phrase (the
+        sanitizer protects balanced quotes), NOT an operator — so the term
+        extractor must keep it as a term. An indexed 'AND' row is hit, a gap
+        row carrying the 'and' token must be surfaced too, and after backfill
+        it stays index-findable."""
+        r = _three_region_db(tmp_path)  # A(1)/B(3) indexed, C(7) in gap
+        try:
+            r.set_session_title("A", "AND")         # <= P, indexed
+            r.set_session_title("C", "AND beyond")  # (P,H], gap
+            # Indexed control: '"AND"' is a valid quoted-phrase query.
+            assert _raw_metadata_match_ids(r, '"AND"') == ["A"]
+            # Gap supplement must ALSO surface C (keeps 'and' as a term).
+            hits = _metadata_search_ids(r, '"AND"')
+            assert "A" in hits and "C" in hits
+            # After backfill completes, C is index-findable too.
+            while r.fts_session_rebuild_step():
+                pass
+            assert r.get_meta("fts_session_rebuild_high_water") is None
+            assert "C" in _raw_metadata_match_ids(r, '"AND"')
         finally:
             r.close()
 

--- a/tests/test_session_metadata_fts.py
+++ b/tests/test_session_metadata_fts.py
@@ -409,6 +409,20 @@ class TestUnicodeExternalContent:
         compact = " ".join(sql.split())
         assert "AFTER UPDATE OF title, id, display_name" in compact
 
+    def test_list_sessions_rich_search_covers_display_name(self, db):
+        """The production session listing's search_query lane matches the raw
+        display_name dimension (issue #25), not only title / logical id."""
+        db.create_session("s1", source="cli")
+        db._conn.execute(
+            "UPDATE sessions SET display_name = 'Team Zebra Display' "
+            "WHERE id = 's1'"
+        )
+        db._conn.commit()
+        rows = db.list_sessions_rich(
+            search_query="zebra", order_by_last_active=True
+        )
+        assert [r["id"] for r in rows] == ["s1"]
+
 
 # =========================================================================
 # Group C — crash/restart H/P bookkeeping


### PR DESCRIPTION
Closes #25.

Session metadata FTS: stable `row_id` + resumable Unicode external-content index.

- named `sessions.row_id INTEGER PRIMARY KEY AUTOINCREMENT` (legacy hidden rowids preserved, deleted-row holes kept, transactional swap)
- `sessions_fts` becomes external-content over raw `(title, id, display_name)` keyed by `row_id`, `tokenize='unicode61'`
- resumable crash-safe H/P chunk rebuild (shared message-FTS seam), bounded-gap search supplement that is a SUPERSET of the FTS predicate (never hides a matched session mid-migration)
- crash-atomic schema+catch-up transition (one BEGIN IMMEDIATE; COALESCE(H,-1) covers the empty-DB window)
- decoupled from message-FTS layout; empty-DB no-zombie-marker; partial-index orphan recovery; three-region delete integrity
- code-wiki: docs/design/session-metadata-fts.md
- tests: tests/test_session_metadata_fts.py (48 tests)

Out of scope (tracked separately): CJK (#26), normalized trigram (#30), unified storage-version settlement (#27).
