### PR TITLE
research: reconstruct ChatGPT import provenance for #60

### DIFF
--- a/research/chatgpt-import/extract_issue60_evidence.py
+++ b/research/chatgpt-import/extract_issue60_evidence.py
@@ -1,0 +1,851 @@
+#!/usr/bin/env python3
+"""Issue #60 read-only evidence extractor for ChatGPT -> Hermes import archaeology.
+
+Safety:
+- verifies the authoritative SHA-256;
+- refuses symlinks and non-empty SQLite sidecars;
+- opens SQLite with mode=ro&immutable=1 and PRAGMA query_only=ON;
+- performs no TEMP/schema/journal/FTS/VACUUM writes;
+- verifies database identity and SHA-256 again after extraction.
+
+The output directory contains only derived evidence files and may be zipped/uploaded.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import os
+import re
+import sqlite3
+import stat
+import textwrap
+import time
+from collections import Counter, defaultdict
+from pathlib import Path
+from urllib.parse import quote
+
+AUTHORITATIVE_PATH = Path(
+    "/home/skywind/hermes-recovery/runs/20260807-081043/state.recovered.patched.db"
+)
+AUTHORITATIVE_SHA256 = "23cfa3c8adb94ed403058329ae7e252e1d4c4bc01ead76e22ac7d0ff99948104"
+EXPECTED_COUNTS = {"sessions": 7268, "messages": 231513, "gateway_routing": 78}
+
+IMPORT_DATE_PREFIXES = tuple(f"202606{day:02d}_%" for day in range(14, 21))
+PRIMARY_DATE_PREFIX = "20260616_"
+ANOMALY_ROOT = "20260530_113929_d6a58f32"
+
+KEYWORDS = {
+    # Very specific importer/export structure.
+    "current_node": 12,
+    "chatgpt-export": 12,
+    "conversation_asset": 12,
+    "export_manifest": 12,
+    "conversations-": 10,
+    "zipfile": 9,
+    "downloads": 7,
+    "conversation_id": 7,
+    "default_model_slug": 7,
+    "content.parts": 7,
+    "author.role": 7,
+    "content_references": 7,
+    "mapping": 7,
+    # Merge/database implementation clues.
+    "state.db": 8,
+    "session.db": 8,
+    "sqlite": 5,
+    "merge": 5,
+    "import": 4,
+    "script": 3,
+    "parent": 2,
+}
+
+SESSION_FIELDS = (
+    "id",
+    "title",
+    "display_name",
+    "started_at",
+    "ended_at",
+    "source",
+    "model",
+    "parent_session_id",
+    "end_reason",
+    "model_config",
+    "cwd",
+    "created_at",
+    "updated_at",
+)
+
+MESSAGE_FIELDS = (
+    "id",
+    "session_id",
+    "role",
+    "content",
+    "timestamp",
+    "model",
+    "tool_name",
+    "tool_call_id",
+    "metadata",
+    "created_at",
+    "updated_at",
+)
+
+
+def sha256_file(path: Path, chunk: int = 8 * 1024 * 1024) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while True:
+            block = handle.read(chunk)
+            if not block:
+                break
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def file_identity(path: Path) -> dict[str, int]:
+    st = path.stat()
+    return {
+        "size": st.st_size,
+        "mtime_ns": st.st_mtime_ns,
+        "inode": st.st_ino,
+        "device": st.st_dev,
+        "mode": stat.S_IMODE(st.st_mode),
+    }
+
+
+def sidecar_receipt(path: Path) -> dict[str, dict[str, int | bool]]:
+    result: dict[str, dict[str, int | bool]] = {}
+    for suffix in ("-wal", "-shm", "-journal"):
+        side = Path(str(path) + suffix)
+        result[suffix] = {
+            "exists": side.exists(),
+            "size": side.stat().st_size if side.exists() else 0,
+        }
+    return result
+
+
+def enforce_safe_source(path: Path, expected_sha: str) -> tuple[str, dict]:
+    if path.is_symlink():
+        raise SystemExit(f"REFUSE: database path is a symlink: {path}")
+    if not path.is_file():
+        raise SystemExit(f"REFUSE: database is not a regular file: {path}")
+    sidecars = sidecar_receipt(path)
+    dirty = {
+        name: meta
+        for name, meta in sidecars.items()
+        if meta["exists"] and int(meta["size"]) > 0
+    }
+    if dirty:
+        raise SystemExit(f"REFUSE: frozen source has non-empty SQLite sidecars: {dirty}")
+    actual = sha256_file(path)
+    if actual.lower() != expected_sha.lower():
+        raise SystemExit(
+            "REFUSE: SHA-256 mismatch\n"
+            f" expected={expected_sha}\n actual={actual}\n path={path}"
+        )
+    return actual, sidecars
+
+
+def open_immutable(path: Path) -> sqlite3.Connection:
+    uri = (
+        "file:"
+        + quote(str(path.resolve()), safe="/:\\")
+        + "?mode=ro&immutable=1"
+    )
+    conn = sqlite3.connect(uri, uri=True, isolation_level=None)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA query_only=ON")
+    if int(conn.execute("PRAGMA query_only").fetchone()[0]) != 1:
+        conn.close()
+        raise RuntimeError("failed to enable PRAGMA query_only")
+    return conn
+
+
+def table_columns(conn: sqlite3.Connection, table: str) -> list[str]:
+    return [str(row["name"]) for row in conn.execute(f"PRAGMA table_info({table})")]
+
+
+def select_existing(columns: set[str], wanted: tuple[str, ...]) -> list[str]:
+    return [name for name in wanted if name in columns]
+
+
+def normalize_text(value: object) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return str(value)
+
+
+def clipped(text: str, limit: int = 700) -> str:
+    text = text.replace("\x00", "\\0")
+    if len(text) <= limit:
+        return text
+    return text[:limit] + f"… <{len(text) - limit} chars omitted>"
+
+
+def safe_filename(value: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_.-]+", "_", value)[:180] or "unnamed"
+
+
+def write_tsv(path: Path, rows: list[dict], fieldnames: list[str] | None = None) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if fieldnames is None:
+        fieldnames = []
+        seen: set[str] = set()
+        for row in rows:
+            for key in row:
+                if key not in seen:
+                    seen.add(key)
+                    fieldnames.append(key)
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames, delimiter="\t", extrasaction="ignore")
+        writer.writeheader()
+        for row in rows:
+            clean = {
+                key: normalize_text(value).replace("\t", "\\t").replace("\r", "\\r").replace("\n", "\\n")
+                for key, value in row.items()
+            }
+            writer.writerow(clean)
+
+
+def scalar(conn: sqlite3.Connection, sql: str, params: tuple = ()) -> object:
+    row = conn.execute(sql, params).fetchone()
+    return row[0] if row else None
+
+
+def session_date_scope_clause(column: str = "s.id") -> tuple[str, tuple[str, ...]]:
+    terms = [f"{column} LIKE ?" for _ in IMPORT_DATE_PREFIXES]
+    return "(" + " OR ".join(terms) + ")", IMPORT_DATE_PREFIXES
+
+
+def export_schema(conn: sqlite3.Connection, out: Path) -> dict[str, list[str]]:
+    schemas: dict[str, list[str]] = {}
+    for table in ("sessions", "messages"):
+        rows = [dict(row) for row in conn.execute(f"PRAGMA table_info({table})")]
+        write_tsv(out / f"schema_{table}.tsv", rows)
+        schemas[table] = [str(row["name"]) for row in rows]
+    return schemas
+
+
+def canonical_receipt(conn: sqlite3.Connection) -> dict:
+    tables = {
+        str(row["name"])
+        for row in conn.execute(
+            "SELECT name FROM sqlite_schema WHERE type='table' ORDER BY name"
+        )
+    }
+    counts = {
+        table: int(scalar(conn, f"SELECT COUNT(*) FROM {table}"))
+        if table in tables
+        else None
+        for table in EXPECTED_COUNTS
+    }
+    return {
+        "counts": counts,
+        "expected_counts": EXPECTED_COUNTS,
+        "counts_match": counts == EXPECTED_COUNTS,
+        "quick_check": [row[0] for row in conn.execute("PRAGMA quick_check")],
+        "foreign_key_violations": sum(
+            1 for _ in conn.execute("PRAGMA foreign_key_check")
+        ),
+        "sqlite_version": sqlite3.sqlite_version,
+        "python": os.sys.version,
+        "page_size": int(scalar(conn, "PRAGMA page_size")),
+        "page_count": int(scalar(conn, "PRAGMA page_count")),
+        "freelist_count": int(scalar(conn, "PRAGMA freelist_count")),
+    }
+
+
+def export_import_session_inventory(
+    conn: sqlite3.Connection, out: Path, session_columns: list[str]
+) -> list[dict]:
+    fields = select_existing(set(session_columns), SESSION_FIELDS)
+    if "id" not in fields:
+        raise RuntimeError("sessions.id is required")
+    if "source" not in fields:
+        raise RuntimeError("sessions.source is required for #60")
+    sql = (
+        "SELECT "
+        + ", ".join(fields)
+        + " FROM sessions "
+        "WHERE source='chatgpt-export' AND id LIKE ? ORDER BY id"
+    )
+    rows = [dict(row) for row in conn.execute(sql, (PRIMARY_DATE_PREFIX + "%",))]
+    write_tsv(out / "20260616_chatgpt_export_sessions.tsv", rows, fields)
+    return rows
+
+
+def export_chatgpt_field_profile(
+    conn: sqlite3.Connection, out: Path, session_columns: list[str]
+) -> list[dict]:
+    columns = set(session_columns)
+    total = int(
+        scalar(conn, "SELECT COUNT(*) FROM sessions WHERE source='chatgpt-export'")
+    )
+    rows: list[dict] = []
+    for field in SESSION_FIELDS:
+        if field not in columns:
+            continue
+        nonnull = int(
+            scalar(
+                conn,
+                f"SELECT COUNT(*) FROM sessions "
+                f"WHERE source='chatgpt-export' AND {field} IS NOT NULL",
+            )
+        )
+        nonempty = int(
+            scalar(
+                conn,
+                f"SELECT COUNT(*) FROM sessions "
+                f"WHERE source='chatgpt-export' "
+                f"AND NULLIF(TRIM(CAST({field} AS TEXT)), '') IS NOT NULL",
+            )
+        )
+        distinct = int(
+            scalar(
+                conn,
+                f"SELECT COUNT(DISTINCT {field}) FROM sessions "
+                "WHERE source='chatgpt-export'",
+            )
+        )
+        samples = [
+            normalize_text(row[0])
+            for row in conn.execute(
+                f"SELECT DISTINCT {field} FROM sessions "
+                f"WHERE source='chatgpt-export' AND {field} IS NOT NULL "
+                f"LIMIT 5"
+            )
+        ]
+        rows.append(
+            {
+                "field": field,
+                "total_sessions": total,
+                "nonnull": nonnull,
+                "nonempty_text": nonempty,
+                "distinct_values": distinct,
+                "sample_values": json.dumps(samples, ensure_ascii=False),
+            }
+        )
+    write_tsv(out / "chatgpt_export_session_field_profile.tsv", rows)
+    return rows
+
+
+def export_source_profile(conn: sqlite3.Connection, out: Path) -> list[dict]:
+    rows = [
+        dict(row)
+        for row in conn.execute(
+            """
+            SELECT
+              source,
+              COUNT(*) AS session_count,
+              SUM(CASE WHEN parent_session_id IS NOT NULL THEN 1 ELSE 0 END)
+                  AS with_parent,
+              SUM(CASE WHEN end_reason='compression' THEN 1 ELSE 0 END)
+                  AS compression_ended,
+              MIN(id) AS min_id,
+              MAX(id) AS max_id
+            FROM sessions
+            GROUP BY source
+            ORDER BY session_count DESC, source
+            """
+        )
+    ]
+    write_tsv(out / "session_source_profile.tsv", rows)
+    return rows
+
+
+def discover_keyword_hits(
+    conn: sqlite3.Connection,
+    out: Path,
+    session_columns: list[str],
+    message_columns: list[str],
+) -> tuple[list[dict], list[str]]:
+    if "content" not in message_columns or "session_id" not in message_columns:
+        raise RuntimeError("messages.content and messages.session_id are required")
+    sfields = select_existing(
+        set(session_columns),
+        ("id", "title", "started_at", "source", "model", "display_name"),
+    )
+    message_order = (
+        "m.timestamp, m.id"
+        if "timestamp" in message_columns and "id" in message_columns
+        else "m.id"
+        if "id" in message_columns
+        else "m.rowid"
+    )
+    scope_sql, scope_params = session_date_scope_clause("s.id")
+    sql = f"""
+        SELECT {", ".join("s." + field for field in sfields)},
+               m.id AS message_id,
+               {("m.role" if "role" in message_columns else "NULL")} AS role,
+               {("m.timestamp" if "timestamp" in message_columns else "NULL")} AS message_timestamp,
+               m.content AS content
+        FROM sessions AS s
+        JOIN messages AS m ON m.session_id=s.id
+        WHERE s.source='chatgpt-export'
+          AND {scope_sql}
+        ORDER BY s.id, {message_order}
+    """
+    hit_rows: list[dict] = []
+    per_session_terms: dict[str, set[str]] = defaultdict(set)
+    per_session_score: Counter[str] = Counter()
+    per_session_hits: Counter[str] = Counter()
+    per_session_meta: dict[str, dict] = {}
+
+    for row in conn.execute(sql, scope_params):
+        d = dict(row)
+        sid = normalize_text(d.get("id"))
+        per_session_meta.setdefault(
+            sid,
+            {key: d.get(key) for key in sfields if key != "id"} | {"id": sid},
+        )
+        content = normalize_text(d.get("content"))
+        lowered = content.lower()
+        matched = [term for term in KEYWORDS if term.lower() in lowered]
+        if not matched:
+            continue
+        for term in matched:
+            if term not in per_session_terms[sid]:
+                per_session_score[sid] += KEYWORDS[term]
+                per_session_terms[sid].add(term)
+        per_session_hits[sid] += 1
+        hit_rows.append(
+            {
+                "session_id": sid,
+                "title": d.get("title"),
+                "started_at": d.get("started_at"),
+                "source": d.get("source"),
+                "message_id": d.get("message_id"),
+                "role": d.get("role"),
+                "message_timestamp": d.get("message_timestamp"),
+                "matched_terms": ",".join(matched),
+                "content_excerpt": clipped(content, 1000),
+            }
+        )
+
+    write_tsv(out / "import_keyword_hits.tsv", hit_rows)
+
+    ranked: list[dict] = []
+    for sid in sorted(
+        per_session_meta,
+        key=lambda value: (
+            -per_session_score[value],
+            -len(per_session_terms[value]),
+            -per_session_hits[value],
+            value,
+        ),
+    ):
+        meta = per_session_meta[sid]
+        ranked.append(
+            {
+                "session_id": sid,
+                "title": meta.get("title"),
+                "started_at": meta.get("started_at"),
+                "source": meta.get("source"),
+                "score": per_session_score[sid],
+                "distinct_terms": len(per_session_terms[sid]),
+                "hit_messages": per_session_hits[sid],
+                "terms": ",".join(sorted(per_session_terms[sid])),
+            }
+        )
+    write_tsv(out / "import_candidate_sessions.tsv", ranked)
+
+    # Dump high-confidence candidates, then fill up to 12 strongest overall.
+    # A score >= 12 means at least one very specific importer/export marker
+    # (or several independent weaker clues) was present.
+    ordered = sorted(
+        ranked,
+        key=lambda row: (
+            -int(str(row["session_id"]).startswith(PRIMARY_DATE_PREFIX)),
+            -int(row["score"]),
+            -int(row["distinct_terms"]),
+            str(row["session_id"]),
+        ),
+    )
+    candidate_ids = [
+        str(row["session_id"]) for row in ordered if int(row["score"]) >= 12
+    ][:20]
+    if len(candidate_ids) < 12:
+        for row in ordered:
+            sid = str(row["session_id"])
+            if sid not in candidate_ids:
+                candidate_ids.append(sid)
+            if len(candidate_ids) >= 12:
+                break
+    return ranked, candidate_ids
+
+
+def dump_session_transcript(
+    conn: sqlite3.Connection,
+    out_dir: Path,
+    session_id: str,
+    session_columns: list[str],
+    message_columns: list[str],
+) -> Path:
+    sfields = select_existing(set(session_columns), SESSION_FIELDS)
+    mfields = select_existing(set(message_columns), MESSAGE_FIELDS)
+    session = conn.execute(
+        "SELECT "
+        + ", ".join(sfields)
+        + " FROM sessions WHERE id=? LIMIT 1",
+        (session_id,),
+    ).fetchone()
+    if session is None:
+        raise RuntimeError(f"session not found: {session_id}")
+
+    if "timestamp" in mfields and "id" in mfields:
+        order = "timestamp, id"
+    elif "id" in mfields:
+        order = "id"
+    else:
+        order = "rowid"
+
+    messages = [
+        dict(row)
+        for row in conn.execute(
+            "SELECT "
+            + ", ".join(mfields)
+            + f" FROM messages WHERE session_id=? ORDER BY {order}",
+            (session_id,),
+        )
+    ]
+
+    path = out_dir / (safe_filename(session_id) + ".md")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        f"# Session {session_id}",
+        "",
+        "## Session row",
+        "",
+        "```json",
+        json.dumps(dict(session), indent=2, ensure_ascii=False, default=str),
+        "```",
+        "",
+        f"## Messages ({len(messages)})",
+        "",
+    ]
+    for index, msg in enumerate(messages, 1):
+        role = normalize_text(msg.get("role") or "unknown")
+        msg_id = normalize_text(msg.get("id"))
+        ts = normalize_text(msg.get("timestamp"))
+        lines += [
+            f"### {index}. {role} — id={msg_id} — timestamp={ts}",
+            "",
+        ]
+        metadata = {
+            key: value
+            for key, value in msg.items()
+            if key not in {"content", "role", "id", "session_id", "timestamp"}
+            and value is not None
+        }
+        if metadata:
+            lines += [
+                "```json",
+                json.dumps(metadata, indent=2, ensure_ascii=False, default=str),
+                "```",
+                "",
+            ]
+        lines += [normalize_text(msg.get("content")), ""]
+    path.write_text("\n".join(lines), encoding="utf-8")
+    return path
+
+
+def anomaly_descendants(
+    conn: sqlite3.Connection,
+    out: Path,
+    session_columns: list[str],
+    message_columns: list[str],
+) -> list[str]:
+    if "parent_session_id" not in session_columns:
+        return []
+    sfields = select_existing(set(session_columns), SESSION_FIELDS)
+    rows = [dict(row) for row in conn.execute(
+        "SELECT " + ", ".join(sfields) + " FROM sessions"
+    )]
+    by_id = {normalize_text(row["id"]): row for row in rows}
+    children: dict[str, list[str]] = defaultdict(list)
+    for row in rows:
+        parent = normalize_text(row.get("parent_session_id"))
+        if parent:
+            children[parent].append(normalize_text(row["id"]))
+    for values in children.values():
+        values.sort()
+
+    found: list[str] = []
+    queue = [ANOMALY_ROOT]
+    seen: set[str] = set()
+    while queue:
+        sid = queue.pop(0)
+        if sid in seen:
+            continue
+        seen.add(sid)
+        if sid in by_id:
+            found.append(sid)
+        queue.extend(children.get(sid, []))
+
+    profile_rows: list[dict] = []
+    for sid in found:
+        row = dict(by_id[sid])
+        msg_count = int(
+            scalar(conn, "SELECT COUNT(*) FROM messages WHERE session_id=?", (sid,))
+        )
+        row["message_count"] = msg_count
+        if "timestamp" in message_columns:
+            row["message_min_timestamp"] = scalar(
+                conn, "SELECT MIN(timestamp) FROM messages WHERE session_id=?", (sid,)
+            )
+            row["message_max_timestamp"] = scalar(
+                conn, "SELECT MAX(timestamp) FROM messages WHERE session_id=?", (sid,)
+            )
+        profile_rows.append(row)
+    columns = sfields + [
+        key
+        for key in ("message_count", "message_min_timestamp", "message_max_timestamp")
+        if profile_rows and key in profile_rows[0]
+    ]
+    write_tsv(out / "prehermes_anomaly_lineage.tsv", profile_rows, columns)
+
+    # Small content samples only: first/last 2 messages per session.
+    sample_path = out / "prehermes_anomaly_message_samples.md"
+    sample_lines = [
+        f"# Pre-Hermes anomaly lineage samples",
+        "",
+        f"Root: `{ANOMALY_ROOT}`",
+        "",
+        "These are first/last message samples, not a full transcript dump.",
+        "",
+    ]
+    mfields = select_existing(
+        set(message_columns), ("id", "role", "content", "timestamp", "session_id")
+    )
+    if "timestamp" in mfields and "id" in mfields:
+        asc = "timestamp, id"
+        desc = "timestamp DESC, id DESC"
+    elif "id" in mfields:
+        asc = "id"
+        desc = "id DESC"
+    else:
+        asc = "rowid"
+        desc = "rowid DESC"
+    for sid in found:
+        first = [
+            dict(row)
+            for row in conn.execute(
+                "SELECT "
+                + ", ".join(mfields)
+                + f" FROM messages WHERE session_id=? ORDER BY {asc} LIMIT 2",
+                (sid,),
+            )
+        ]
+        last = [
+            dict(row)
+            for row in conn.execute(
+                "SELECT "
+                + ", ".join(mfields)
+                + f" FROM messages WHERE session_id=? ORDER BY {desc} LIMIT 2",
+                (sid,),
+            )
+        ]
+        sample_lines += [f"## {sid}", ""]
+        for label, batch in (("first", first), ("last", list(reversed(last)))):
+            sample_lines += [f"### {label}", ""]
+            for msg in batch:
+                sample_lines += [
+                    f"- id={normalize_text(msg.get('id'))} role={normalize_text(msg.get('role'))} timestamp={normalize_text(msg.get('timestamp'))}",
+                    "",
+                    clipped(normalize_text(msg.get("content")), 1200),
+                    "",
+                ]
+    sample_path.write_text("\n".join(sample_lines), encoding="utf-8")
+    return found
+
+
+def export_prehermes_nonchatgpt(
+    conn: sqlite3.Connection,
+    out: Path,
+    session_columns: list[str],
+) -> list[dict]:
+    fields = select_existing(set(session_columns), SESSION_FIELDS)
+    if "id" not in fields or "source" not in fields:
+        return []
+    sql = (
+        "SELECT "
+        + ", ".join(fields)
+        + " FROM sessions "
+        "WHERE id < '20260616_' AND COALESCE(source,'') <> 'chatgpt-export' "
+        "ORDER BY id"
+    )
+    rows = [dict(row) for row in conn.execute(sql)]
+    write_tsv(out / "prehermes_non_chatgpt_export_sessions.tsv", rows, fields)
+    return rows
+
+
+def write_manifest(
+    out: Path,
+    *,
+    db_path: Path,
+    sha: str,
+    sidecars: dict,
+    before_identity: dict,
+    after_identity: dict,
+    receipt: dict,
+    candidate_ids: list[str],
+    anomaly_ids: list[str],
+    elapsed_s: float,
+) -> None:
+    manifest = {
+        "issue": 60,
+        "purpose": "ChatGPT -> Hermes import/merge provenance evidence extraction",
+        "source": {
+            "path": str(db_path),
+            "sha256": sha,
+            "sidecars": sidecars,
+            "identity_before": before_identity,
+            "identity_after": after_identity,
+            "opened_mode": "mode=ro&immutable=1 + PRAGMA query_only=ON",
+            "mutations_performed": False,
+        },
+        "canonical_receipt": receipt,
+        "search_window": {
+            "session_id_prefixes": list(IMPORT_DATE_PREFIXES),
+            "primary_prefix": PRIMARY_DATE_PREFIX,
+            "keywords": KEYWORDS,
+        },
+        "candidate_transcript_session_ids": candidate_ids,
+        "prehermes_anomaly_root": ANOMALY_ROOT,
+        "prehermes_anomaly_session_ids": anomaly_ids,
+        "elapsed_s": elapsed_s,
+        "generated_at_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    }
+    (out / "manifest.json").write_text(
+        json.dumps(manifest, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
+
+
+def write_readme(out: Path) -> None:
+    text = f"""\
+# Hermes issue #60 evidence bundle
+
+This directory was produced by `extract_issue60_evidence.py`.
+
+Safety contract:
+
+- canonical DB expected SHA-256: `{AUTHORITATIVE_SHA256}`
+- SQLite open mode: `mode=ro&immutable=1`
+- `PRAGMA query_only=ON`
+- non-empty `-wal`, `-shm`, or `-journal` sidecars cause a hard refusal
+- the DB identity and SHA-256 are checked again after extraction
+- no TEMP/schema/FTS/VACUUM/journal writes are performed
+
+High-value files:
+
+- `20260616_chatgpt_export_sessions.tsv` — first target inventory from #60
+- `import_keyword_hits.tsv` — exact message locators around importer/export terms
+- `import_candidate_sessions.tsv` — ranked candidate historical discussions
+- `transcripts/*.md` — full transcripts for the strongest candidates
+- `chatgpt_export_session_field_profile.tsv` — NULL/default/distinct profile of importer-facing session fields
+- `prehermes_anomaly_lineage.tsv` — the May-30 depth-14 lineage metadata + message ranges
+- `prehermes_anomaly_message_samples.md` — bounded first/last message samples for that anomaly
+- `prehermes_non_chatgpt_export_sessions.tsv` — locator set for pre-adoption rows whose final source is not `chatgpt-export`
+- `manifest.json` — safety/runtime/count/hash receipt
+
+The files are evidence only. They intentionally do not label any field mapping
+PROVEN/INFERRED/OPEN; that judgment happens after transcript + DB comparison.
+"""
+    (out / "README.md").write_text(textwrap.dedent(text), encoding="utf-8")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--db", type=Path, default=AUTHORITATIVE_PATH)
+    parser.add_argument("--expected-sha", default=AUTHORITATIVE_SHA256)
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help="Evidence directory. Default: ./issue60-evidence-<UTC timestamp>",
+    )
+    args = parser.parse_args()
+
+    started = time.perf_counter()
+    stamp = time.strftime("%Y%m%d-%H%M%S", time.gmtime())
+    out = args.out or Path(f"issue60-evidence-{stamp}")
+    out.mkdir(parents=True, exist_ok=False)
+
+    db_path = args.db
+    before_identity = file_identity(db_path)
+    actual_sha, sidecars = enforce_safe_source(db_path, args.expected_sha)
+
+    conn = open_immutable(db_path)
+    try:
+        schemas = export_schema(conn, out)
+        receipt = canonical_receipt(conn)
+        if db_path.resolve() == AUTHORITATIVE_PATH.resolve():
+            if receipt["counts"] != EXPECTED_COUNTS:
+                raise RuntimeError(
+                    "authoritative row-count mismatch: "
+                    f"expected={EXPECTED_COUNTS} actual={receipt['counts']}"
+                )
+        export_import_session_inventory(conn, out, schemas["sessions"])
+        export_chatgpt_field_profile(conn, out, schemas["sessions"])
+        export_source_profile(conn, out)
+        export_prehermes_nonchatgpt(conn, out, schemas["sessions"])
+        _ranked, candidate_ids = discover_keyword_hits(
+            conn, out, schemas["sessions"], schemas["messages"]
+        )
+        transcript_dir = out / "transcripts"
+        for sid in candidate_ids:
+            dump_session_transcript(
+                conn,
+                transcript_dir,
+                sid,
+                schemas["sessions"],
+                schemas["messages"],
+            )
+        anomaly_ids = anomaly_descendants(
+            conn, out, schemas["sessions"], schemas["messages"]
+        )
+    finally:
+        conn.close()
+
+    after_identity = file_identity(db_path)
+    after_sha = sha256_file(db_path)
+    if before_identity != after_identity or actual_sha != after_sha:
+        raise RuntimeError(
+            "SAFETY FAILURE: frozen DB identity/hash changed during read-only extraction"
+        )
+
+    elapsed_s = time.perf_counter() - started
+    write_manifest(
+        out,
+        db_path=db_path,
+        sha=actual_sha,
+        sidecars=sidecars,
+        before_identity=before_identity,
+        after_identity=after_identity,
+        receipt=receipt,
+        candidate_ids=candidate_ids,
+        anomaly_ids=anomaly_ids,
+        elapsed_s=elapsed_s,
+    )
+    write_readme(out)
+
+    archive = out.with_suffix(".tar.gz")
+    import tarfile
+
+    with tarfile.open(archive, "w:gz") as tar:
+        tar.add(out, arcname=out.name)
+
+    print(f"evidence_dir={out}")
+    print(f"archive={archive}")
+    print(f"sha256={actual_sha}")
+    print(f"counts={json.dumps(receipt['counts'], ensure_ascii=False)}")
+    print(f"candidate_transcripts={len(candidate_ids)}")
+    print(f"anomaly_sessions={len(anomaly_ids)}")
+    print(f"elapsed_s={elapsed_s:.3f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/research/chatgpt-import/extract_issue60_stage2.py
+++ b/research/chatgpt-import/extract_issue60_stage2.py
@@ -1,0 +1,585 @@
+#!/usr/bin/env python3
+"""Issue #60 second-pass evidence extractor.
+
+Purpose:
+- search the *whole* frozen DB for the actual ChatGPT import/merge discussion;
+- quantify session-id / started_at / message-time alignment for chatgpt-export rows;
+- test whether pre-Hermes Hermes-shaped rows duplicate content from chatgpt-export rows.
+
+Safety:
+- authoritative SHA-256 required;
+- refuses non-empty SQLite sidecars;
+- mode=ro&immutable=1 + PRAGMA query_only=ON;
+- no TEMP/schema/FTS/VACUUM/journal writes;
+- source identity + SHA verified again after extraction.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import re
+import sqlite3
+import stat
+import tarfile
+import time
+from collections import Counter, defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from urllib.parse import quote
+from zoneinfo import ZoneInfo
+
+AUTHORITATIVE_PATH = Path(
+    "/home/skywind/hermes-recovery/runs/20260807-081043/state.recovered.patched.db"
+)
+AUTHORITATIVE_SHA256 = "23cfa3c8adb94ed403058329ae7e252e1d4c4bc01ead76e22ac7d0ff99948104"
+EXPECTED_COUNTS = {"sessions": 7268, "messages": 231513, "gateway_routing": 78}
+TAIPEI = ZoneInfo("Asia/Taipei")
+PRE_HERMES_CUTOFF = datetime(2026, 6, 16, 0, 0, 0, tzinfo=TAIPEI).timestamp()
+
+ANOMALY_IDS = (
+    "20260530_113929_d6a58f32",
+    "20260530_115158_865460",
+    "20260530_115227_bcc3af",
+    "20260530_115257_615c41",
+    "20260530_115429_f53e5e",
+    "20260530_115503_45592e",
+    "20260530_121329_ec5bb7",
+    "20260530_122122_363260",
+    "20260530_122213_8ed0b9",
+    "20260530_122919_b1b82b",
+    "20260530_123019_e8498d",
+    "20260530_123052_5fc886",
+    "20260530_123527_2efadd",
+    "20260530_123618_de633f",
+    "20260530_123708_7ddcf4",
+)
+
+KEYWORDS = {
+    "current_node": 15,
+    "chatgpt-export": 15,
+    "conversation_asset": 15,
+    "export_manifest": 15,
+    "conversations-": 13,
+    "conversation_id": 10,
+    "default_model_slug": 10,
+    "content.parts": 10,
+    "author.role": 10,
+    "content_references": 10,
+    "zipfile": 10,
+    "mapping": 8,
+    "mapping.parent": 10,
+    "parent": 2,
+    "chatgpt export": 10,
+    "state.db": 10,
+    "session.db": 10,
+    "sqlite": 6,
+    "merge": 7,
+    "import": 5,
+    "export": 4,
+    "script": 3,
+    "parent_session_id": 6,
+    "end_reason": 5,
+    "model_config": 5,
+    "downloads": 5,
+}
+
+SESSION_FIELDS = (
+    "id", "title", "display_name", "started_at", "ended_at", "source", "model",
+    "parent_session_id", "end_reason", "model_config", "cwd",
+)
+
+def sha256_file(path: Path, chunk: int = 8 * 1024 * 1024) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while True:
+            block = handle.read(chunk)
+            if not block:
+                break
+            digest.update(block)
+    return digest.hexdigest()
+
+def file_identity(path: Path) -> dict[str, int]:
+    st = path.stat()
+    return {
+        "size": st.st_size, "mtime_ns": st.st_mtime_ns, "inode": st.st_ino,
+        "device": st.st_dev, "mode": stat.S_IMODE(st.st_mode),
+    }
+
+def sidecar_receipt(path: Path) -> dict[str, dict[str, int | bool]]:
+    out = {}
+    for suffix in ("-wal", "-shm", "-journal"):
+        side = Path(str(path) + suffix)
+        out[suffix] = {
+            "exists": side.exists(),
+            "size": side.stat().st_size if side.exists() else 0,
+        }
+    return out
+
+def enforce_source(path: Path) -> tuple[str, dict]:
+    if path.is_symlink() or not path.is_file():
+        raise SystemExit(f"REFUSE: not a regular non-symlink DB: {path}")
+    sidecars = sidecar_receipt(path)
+    dirty = {k: v for k, v in sidecars.items() if v["exists"] and int(v["size"]) > 0}
+    if dirty:
+        raise SystemExit(f"REFUSE: non-empty SQLite sidecars: {dirty}")
+    actual = sha256_file(path)
+    if actual.lower() != AUTHORITATIVE_SHA256.lower():
+        raise SystemExit(
+            f"REFUSE: SHA-256 mismatch\n expected={AUTHORITATIVE_SHA256}\n actual={actual}"
+        )
+    return actual, sidecars
+
+def open_immutable(path: Path) -> sqlite3.Connection:
+    uri = "file:" + quote(str(path.resolve()), safe="/:\\") + "?mode=ro&immutable=1"
+    conn = sqlite3.connect(uri, uri=True, isolation_level=None)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA query_only=ON")
+    if int(conn.execute("PRAGMA query_only").fetchone()[0]) != 1:
+        conn.close()
+        raise RuntimeError("failed to enable query_only")
+    return conn
+
+def norm(value) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return str(value)
+
+def clip(text: str, n: int = 700) -> str:
+    text = text.replace("\x00", "\\0")
+    return text if len(text) <= n else text[:n] + f"… <{len(text)-n} chars omitted>"
+
+def write_tsv(path: Path, rows: list[dict], fields: list[str] | None = None) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if fields is None:
+        fields = []
+        seen = set()
+        for row in rows:
+            for k in row:
+                if k not in seen:
+                    seen.add(k)
+                    fields.append(k)
+    with path.open("w", encoding="utf-8", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=fields, delimiter="\t", extrasaction="ignore")
+        w.writeheader()
+        for row in rows:
+            w.writerow({
+                k: norm(v).replace("\t", "\\t").replace("\r", "\\r").replace("\n", "\\n")
+                for k, v in row.items()
+            })
+
+def iso(epoch) -> str:
+    if epoch is None or epoch == "":
+        return ""
+    try:
+        x = float(epoch)
+    except Exception:
+        return ""
+    return datetime.fromtimestamp(x, timezone.utc).isoformat()
+
+def iso_taipei(epoch) -> str:
+    if epoch is None or epoch == "":
+        return ""
+    try:
+        x = float(epoch)
+    except Exception:
+        return ""
+    return datetime.fromtimestamp(x, TAIPEI).isoformat()
+
+def session_id_date(session_id: str) -> str:
+    m = re.match(r"^(\d{8})_", session_id or "")
+    return m.group(1) if m else ""
+
+def scalar(conn, sql, params=()):
+    row = conn.execute(sql, params).fetchone()
+    return row[0] if row else None
+
+def dump_transcript(conn: sqlite3.Connection, session_id: str, out: Path) -> None:
+    s = conn.execute(
+        "SELECT id,title,display_name,started_at,ended_at,source,model,"
+        "parent_session_id,end_reason,model_config,cwd FROM sessions WHERE id=?",
+        (session_id,),
+    ).fetchone()
+    if not s:
+        return
+    msgs = conn.execute(
+        "SELECT id,role,content,timestamp,tool_name,tool_call_id,tool_calls,"
+        "finish_reason,display_kind,display_metadata "
+        "FROM messages WHERE session_id=? ORDER BY timestamp,id",
+        (session_id,),
+    ).fetchall()
+    lines = [
+        f"# Session {session_id}", "", "## Session row", "", "```json",
+        json.dumps(dict(s), ensure_ascii=False, indent=2), "```", "",
+        f"## Messages ({len(msgs)})", "",
+    ]
+    for i, m in enumerate(msgs, 1):
+        lines.append(
+            f"### {i}. {norm(m['role'])} — id={m['id']} — "
+            f"timestamp={m['timestamp']} ({iso_taipei(m['timestamp'])})"
+        )
+        lines.append("")
+        lines.append(norm(m["content"]))
+        extra = {k: m[k] for k in ("tool_name","tool_call_id","tool_calls","finish_reason",
+                                    "display_kind","display_metadata") if m[k] not in (None, "")}
+        if extra:
+            lines += ["", "```json", json.dumps(extra, ensure_ascii=False, indent=2), "```"]
+        lines.append("")
+    out.write_text("\n".join(lines), encoding="utf-8")
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--db", type=Path, default=AUTHORITATIVE_PATH)
+    ap.add_argument("--output-parent", type=Path, default=Path("."))
+    args = ap.parse_args()
+
+    started = time.monotonic()
+    actual_sha, sidecars = enforce_source(args.db)
+    identity_before = file_identity(args.db)
+
+    stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    out = args.output_parent / f"issue60-stage2-evidence-{stamp}"
+    out.mkdir(parents=True, exist_ok=False)
+
+    conn = open_immutable(args.db)
+    counts = {t: int(scalar(conn, f"SELECT COUNT(*) FROM {t}") or 0)
+              for t in ("sessions","messages","gateway_routing")}
+    if counts != EXPECTED_COUNTS:
+        conn.close()
+        raise SystemExit(f"REFUSE: canonical row counts mismatch: {counts}")
+
+    # 1) Whole-DB keyword scan, one pass over messages.
+    session_meta = {}
+    for r in conn.execute(
+        "SELECT id,title,source,started_at,ended_at,parent_session_id,end_reason FROM sessions"
+    ):
+        session_meta[r["id"]] = dict(r)
+
+    session_scores = defaultdict(int)
+    session_terms = defaultdict(set)
+    session_hit_msgs = defaultdict(set)
+    hits = []
+
+    for m in conn.execute(
+        "SELECT id,session_id,role,content,timestamp FROM messages ORDER BY id"
+    ):
+        text = norm(m["content"])
+        low = text.lower()
+        matched = [term for term in KEYWORDS if term in low]
+        if not matched:
+            continue
+        sid = norm(m["session_id"])
+        meta = session_meta.get(sid, {})
+        score = sum(KEYWORDS[t] for t in matched)
+        session_scores[sid] += score
+        session_terms[sid].update(matched)
+        session_hit_msgs[sid].add(m["id"])
+        hits.append({
+            "session_id": sid,
+            "title": meta.get("title"),
+            "source": meta.get("source"),
+            "session_started_at": meta.get("started_at"),
+            "message_id": m["id"],
+            "role": m["role"],
+            "message_timestamp": m["timestamp"],
+            "message_time_taipei": iso_taipei(m["timestamp"]),
+            "matched_terms": ",".join(matched),
+            "score": score,
+            "content_excerpt": clip(text, 1200),
+        })
+
+    ranked = []
+    for sid, score in session_scores.items():
+        meta = session_meta.get(sid, {})
+        ranked.append({
+            "session_id": sid,
+            "title": meta.get("title"),
+            "source": meta.get("source"),
+            "started_at": meta.get("started_at"),
+            "started_taipei": iso_taipei(meta.get("started_at")),
+            "score": score,
+            "distinct_terms": len(session_terms[sid]),
+            "hit_messages": len(session_hit_msgs[sid]),
+            "terms": ",".join(sorted(session_terms[sid])),
+        })
+    ranked.sort(key=lambda r: (-int(r["score"]), -int(r["distinct_terms"]),
+                               -int(r["hit_messages"]), r["session_id"]))
+    write_tsv(out/"all_source_import_keyword_hits.tsv", hits)
+    write_tsv(out/"all_source_import_candidate_sessions.tsv", ranked)
+
+    # 2) ChatGPT-export time alignment and import-time clustering.
+    alignment = []
+    minute_counts = Counter()
+    role_counts = Counter()
+    chatgpt_session_ids = {
+        r[0] for r in conn.execute("SELECT id FROM sessions WHERE source='chatgpt-export'")
+    }
+
+    msg_range = {}
+    for r in conn.execute(
+        "SELECT session_id,MIN(timestamp) AS min_ts,MAX(timestamp) AS max_ts,COUNT(*) AS n "
+        "FROM messages GROUP BY session_id"
+    ):
+        msg_range[r["session_id"]] = (r["min_ts"], r["max_ts"], r["n"])
+
+    for r in conn.execute(
+        "SELECT id,title,started_at,ended_at,source,model,model_config,"
+        "parent_session_id,end_reason,cwd FROM sessions "
+        "WHERE source='chatgpt-export' ORDER BY started_at,id"
+    ):
+        min_ts, max_ts, n = msg_range.get(r["id"], (None, None, 0))
+        started_at = r["started_at"]
+        if started_at is not None:
+            minute_counts[int(float(started_at)//60)*60] += 1
+        alignment.append({
+            "session_id": r["id"],
+            "id_date": session_id_date(r["id"]),
+            "title": r["title"],
+            "started_at": started_at,
+            "started_taipei": iso_taipei(started_at),
+            "ended_at": r["ended_at"],
+            "ended_taipei": iso_taipei(r["ended_at"]),
+            "message_count_actual": n,
+            "message_min_timestamp": min_ts,
+            "message_min_taipei": iso_taipei(min_ts),
+            "message_max_timestamp": max_ts,
+            "message_max_taipei": iso_taipei(max_ts),
+            "started_minus_message_min_s": (
+                float(started_at)-float(min_ts)
+                if started_at is not None and min_ts is not None else ""
+            ),
+            "ended_minus_message_max_s": (
+                float(r["ended_at"])-float(max_ts)
+                if r["ended_at"] is not None and max_ts is not None else ""
+            ),
+            "model": r["model"],
+            "model_config": r["model_config"],
+        })
+    write_tsv(out/"chatgpt_export_time_alignment.tsv", alignment)
+
+    clusters = [{
+        "minute_epoch": minute,
+        "minute_taipei": iso_taipei(minute),
+        "session_count": count,
+    } for minute, count in minute_counts.most_common()]
+    write_tsv(out/"chatgpt_export_started_at_minute_clusters.tsv", clusters)
+
+    for r in conn.execute(
+        "SELECT role,COUNT(*) AS n,"
+        "SUM(CASE WHEN tool_name IS NOT NULL AND tool_name<>'' THEN 1 ELSE 0 END) AS with_tool_name,"
+        "SUM(CASE WHEN tool_calls IS NOT NULL AND tool_calls<>'' THEN 1 ELSE 0 END) AS with_tool_calls,"
+        "SUM(CASE WHEN tool_call_id IS NOT NULL AND tool_call_id<>'' THEN 1 ELSE 0 END) AS with_tool_call_id "
+        "FROM messages WHERE session_id IN "
+        "(SELECT id FROM sessions WHERE source='chatgpt-export') GROUP BY role ORDER BY n DESC"
+    ):
+        role_counts[r["role"]] = r["n"]
+    role_profile = [dict(r) for r in conn.execute(
+        "SELECT role,COUNT(*) AS message_count,"
+        "SUM(CASE WHEN tool_name IS NOT NULL AND tool_name<>'' THEN 1 ELSE 0 END) AS with_tool_name,"
+        "SUM(CASE WHEN tool_calls IS NOT NULL AND tool_calls<>'' THEN 1 ELSE 0 END) AS with_tool_calls,"
+        "SUM(CASE WHEN tool_call_id IS NOT NULL AND tool_call_id<>'' THEN 1 ELSE 0 END) AS with_tool_call_id "
+        "FROM messages WHERE session_id IN "
+        "(SELECT id FROM sessions WHERE source='chatgpt-export') GROUP BY role ORDER BY message_count DESC"
+    )]
+    write_tsv(out/"chatgpt_export_message_role_profile.tsv", role_profile)
+
+    # 3) Build exact content-hash index for chatgpt-export messages.
+    chat_hash = defaultdict(list)
+    for r in conn.execute(
+        "SELECT m.id,m.session_id,m.role,m.content,m.timestamp "
+        "FROM messages m JOIN sessions s ON s.id=m.session_id "
+        "WHERE s.source='chatgpt-export'"
+    ):
+        content = norm(r["content"])
+        # Ignore tiny boilerplate/common messages: they create noisy many-to-many
+        # crossmatches and are weak provenance evidence.
+        if len(content.strip()) < 40:
+            continue
+        h = hashlib.sha256(content.encode("utf-8", errors="replace")).hexdigest()
+        chat_hash[h].append((r["session_id"], r["id"], r["role"], r["timestamp"]))
+
+    # 4) Cross-match all pre-Hermes non-chatgpt rows against chatgpt-export exact content.
+    match_rows = []
+    summary = defaultdict(lambda: {"total": 0, "matched": 0, "targets": Counter()})
+    anomaly_matches = []
+
+    for r in conn.execute(
+        "SELECT m.id AS message_id,m.session_id,m.role,m.content,m.timestamp,"
+        "s.source,s.title,s.started_at,s.parent_session_id,s.end_reason "
+        "FROM messages m JOIN sessions s ON s.id=m.session_id "
+        "WHERE s.source<>'chatgpt-export' AND s.started_at < ? ORDER BY m.id",
+        (PRE_HERMES_CUTOFF,),
+    ):
+        sid = r["session_id"]
+        summary[sid]["total"] += 1
+        content = norm(r["content"])
+        if len(content.strip()) < 40:
+            continue
+        h = hashlib.sha256(content.encode("utf-8", errors="replace")).hexdigest()
+        targets = chat_hash.get(h, ())
+        # Very common repeated blobs are not useful provenance evidence.
+        if len(targets) > 20:
+            continue
+        if not targets:
+            continue
+        summary[sid]["matched"] += 1
+        for target_sid, target_mid, target_role, target_ts in targets[:20]:
+            summary[sid]["targets"][target_sid] += 1
+            row = {
+                "prehermes_session_id": sid,
+                "prehermes_source": r["source"],
+                "prehermes_title": r["title"],
+                "prehermes_message_id": r["message_id"],
+                "prehermes_role": r["role"],
+                "prehermes_timestamp": r["timestamp"],
+                "prehermes_time_taipei": iso_taipei(r["timestamp"]),
+                "chatgpt_session_id": target_sid,
+                "chatgpt_message_id": target_mid,
+                "chatgpt_role": target_role,
+                "chatgpt_timestamp": target_ts,
+                "chatgpt_time_taipei": iso_taipei(target_ts),
+                "same_timestamp": int(
+                    r["timestamp"] is not None and target_ts is not None
+                    and abs(float(r["timestamp"])-float(target_ts)) < 1e-6
+                ),
+                "content_sha256": h,
+                "content_excerpt": clip(content, 900),
+            }
+            match_rows.append(row)
+            if sid in ANOMALY_IDS:
+                anomaly_matches.append(row)
+    write_tsv(out/"prehermes_chatgpt_exact_message_matches.tsv", match_rows)
+    write_tsv(out/"anomaly_chatgpt_exact_message_matches.tsv", anomaly_matches)
+
+    summary_rows = []
+    for sid, data in summary.items():
+        meta = session_meta.get(sid, {})
+        top_sid, top_count = ("", 0)
+        if data["targets"]:
+            top_sid, top_count = data["targets"].most_common(1)[0]
+        total = data["total"]
+        matched = data["matched"]
+        summary_rows.append({
+            "prehermes_session_id": sid,
+            "source": meta.get("source"),
+            "title": meta.get("title"),
+            "started_at": meta.get("started_at"),
+            "started_taipei": iso_taipei(meta.get("started_at")),
+            "parent_session_id": meta.get("parent_session_id"),
+            "end_reason": meta.get("end_reason"),
+            "message_count": total,
+            "matched_message_count": matched,
+            "matched_fraction": (matched/total if total else 0),
+            "top_chatgpt_session_id": top_sid,
+            "top_chatgpt_match_count": top_count,
+        })
+    summary_rows.sort(key=lambda r: (-float(r["matched_fraction"]),
+                                     -int(r["matched_message_count"]),
+                                     r["prehermes_session_id"]))
+    write_tsv(out/"prehermes_chatgpt_crossmatch_summary.tsv", summary_rows)
+
+    # 5) Dump strongest whole-DB keyword candidates + any ChatGPT source sessions
+    # implicated by anomaly exact-content matches.
+    dump_ids = []
+    for r in ranked:
+        if int(r["score"]) >= 12 or int(r["distinct_terms"]) >= 2:
+            dump_ids.append(r["session_id"])
+        if len(dump_ids) >= 24:
+            break
+    implicated = Counter(r["chatgpt_session_id"] for r in anomaly_matches)
+    for sid, _ in implicated.most_common(12):
+        if sid not in dump_ids:
+            dump_ids.append(sid)
+    dump_ids = dump_ids[:36]
+
+    td = out/"transcripts"
+    td.mkdir()
+    for sid in dump_ids:
+        dump_transcript(conn, sid, td/f"{sid}.md")
+
+    # A small locator table for all sessions around the dominant import-start minute.
+    around_rows = []
+    if clusters:
+        dominant = int(clusters[0]["minute_epoch"])
+        lo, hi = dominant - 6*3600, dominant + 6*3600
+        for r in conn.execute(
+            "SELECT id,title,source,started_at,ended_at,model,parent_session_id,end_reason,model_config "
+            "FROM sessions WHERE started_at BETWEEN ? AND ? ORDER BY started_at,id",
+            (lo, hi),
+        ):
+            row = dict(r)
+            row["started_taipei"] = iso_taipei(r["started_at"])
+            row["ended_taipei"] = iso_taipei(r["ended_at"])
+            around_rows.append(row)
+    write_tsv(out/"sessions_around_dominant_chatgpt_import_cluster.tsv", around_rows)
+
+    conn.close()
+
+    identity_after = file_identity(args.db)
+    sha_after = sha256_file(args.db)
+    if identity_after != identity_before or sha_after != actual_sha:
+        raise SystemExit("REFUSE: frozen DB identity/hash changed during extraction")
+
+    manifest = {
+        "issue": 60,
+        "stage": 2,
+        "source": {
+            "path": str(args.db),
+            "sha256": actual_sha,
+            "sidecars": sidecars,
+            "identity_before": identity_before,
+            "identity_after": identity_after,
+            "opened_mode": "mode=ro&immutable=1 + PRAGMA query_only=ON",
+            "mutations_performed": False,
+        },
+        "counts": counts,
+        "prehermes_cutoff_taipei": datetime.fromtimestamp(
+            PRE_HERMES_CUTOFF, TAIPEI
+        ).isoformat(),
+        "whole_db_keyword_hit_rows": len(hits),
+        "whole_db_candidate_sessions": len(ranked),
+        "dumped_transcripts": dump_ids,
+        "chatgpt_export_sessions": len(alignment),
+        "prehermes_exact_match_rows": len(match_rows),
+        "anomaly_exact_match_rows": len(anomaly_matches),
+        "elapsed_s": time.monotonic()-started,
+        "generated_at_utc": datetime.now(timezone.utc).isoformat(),
+    }
+    (out/"manifest.json").write_text(
+        json.dumps(manifest, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    (out/"README.md").write_text(
+        "# Issue #60 stage-2 evidence\n\n"
+        "This pass deliberately searches the whole frozen DB after stage 1 disproved "
+        "the assumed `source='chatgpt-export' AND id LIKE '20260616_%'` target.\n\n"
+        "High-value outputs:\n\n"
+        "- `all_source_import_candidate_sessions.tsv` + `transcripts/`: importer/merge discussion candidates across every source.\n"
+        "- `chatgpt_export_time_alignment.tsv`: session id/start/end vs actual message-time ranges.\n"
+        "- `chatgpt_export_started_at_minute_clusters.tsv`: insertion/start-time clustering.\n"
+        "- `prehermes_chatgpt_crossmatch_summary.tsv`: exact-content overlap between pre-Hermes non-chatgpt rows and chatgpt-export rows.\n"
+        "- `anomaly_chatgpt_exact_message_matches.tsv`: exact overlap for the 15-session May-30 anomaly lineage.\n"
+        "- `sessions_around_dominant_chatgpt_import_cluster.tsv`: all-source locator around the dominant cluster.\n\n"
+        "Evidence only; do not interpret exact-content absence as proof of unrelated provenance.\n",
+        encoding="utf-8",
+    )
+
+    archive = out.with_suffix(".tar.gz")
+    with tarfile.open(archive, "w:gz") as tf:
+        tf.add(out, arcname=out.name)
+
+    print(f"evidence_dir={out}")
+    print(f"archive={archive}")
+    print(f"sha256={actual_sha}")
+    print(f"counts={json.dumps(counts, sort_keys=True)}")
+    print(f"whole_db_candidate_sessions={len(ranked)}")
+    print(f"dumped_transcripts={len(dump_ids)}")
+    print(f"prehermes_exact_match_rows={len(match_rows)}")
+    print(f"anomaly_exact_match_rows={len(anomaly_matches)}")
+    print(f"elapsed_s={time.monotonic()-started:.3f}")
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/research/chatgpt-import/extract_issue60_stage3.py
+++ b/research/chatgpt-import/extract_issue60_stage3.py
@@ -1,11 +1,20 @@
 #!/usr/bin/env python3
-"""Issue #60 stage-3 read-only provenance shape explorer.
+"""Issue #60 stage-3 read-only merge-boundary explorer.
 
-Goal:
-- distinguish pre-2026-06-16 Hermes-shaped rows from the later ChatGPT import;
-- use insertion-order proxies (messages.id), tool-call fingerprints, platform ID
-  shapes, and session field distributions;
-- recover cross-session-search edges that demonstrate live session-store use.
+Corrected ground truth:
+- Hermes runtime was already active from 2026-05-29.
+- 2026-06-16 is the ChatGPT export import/merge date, NOT Hermes adoption.
+
+This stage therefore does NOT treat May-29..Jun-15 Hermes rows as anomalous.
+It targets the actual remaining provenance questions:
+1. dump the June-15 "GPT記憶與偏好遷移" neighborhood that sits beside a
+   23-row chatgpt-export import-time cluster;
+2. profile those early/partial-import rows and all final chatgpt-export rows
+   for time-shape and fields the final importer does not write;
+3. use messages.id as an insertion-order proxy around the first imported row;
+4. find native-only fingerprints inside rows whose final source is
+   chatgpt-export (possible earlier importer behavior or source-rewrite collision);
+5. list only genuinely pre-2026-05-29 non-chatgpt rows as provenance anomalies.
 
 Safety:
 - pins the authoritative frozen DB SHA-256;
@@ -36,25 +45,33 @@ AUTHORITATIVE_PATH = Path(
 )
 AUTHORITATIVE_SHA256 = "23cfa3c8adb94ed403058329ae7e252e1d4c4bc01ead76e22ac7d0ff99948104"
 EXPECTED_COUNTS = {"sessions": 7268, "messages": 231513, "gateway_routing": 78}
-TAIPEI = ZoneInfo("Asia/Taipei")
-CUTOFF = datetime(2026, 6, 16, 0, 0, 0, tzinfo=TAIPEI).timestamp()
 
-SESSION_ID_RE = re.compile(r"\b(?:\d{8}_\d{6}_[A-Za-z0-9]+|cron_[A-Za-z0-9_]+)\b")
-SNOWFLAKE_RE = re.compile(r"^\d{15,22}$")
+TAIPEI = ZoneInfo("Asia/Taipei")
+UTC = timezone.utc
+HERMES_START = datetime(2026, 5, 29, 0, 0, 0, tzinfo=TAIPEI).timestamp()
+IMPORT_DATE = datetime(2026, 6, 16, 0, 0, 0, tzinfo=TAIPEI).timestamp()
+
+TARGET_SESSIONS = (
+    "20260615_045753_a3ff257e",  # immediate pre-cluster live Hermes context
+    "20260615_050051_06bd07d3",  # GPT記憶與偏好遷移 — highest-value target
+    "20260615_050419_d651d799",  # nearby follow-up / recap candidate
+)
+
 UUID_RE = re.compile(
     r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-"
     r"[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
 )
+DECIMAL_ID_RE = re.compile(r"^\d{15,22}$")
 
 
 def sha256_file(path: Path, chunk: int = 8 * 1024 * 1024) -> str:
     h = hashlib.sha256()
     with path.open("rb") as f:
         while True:
-            b = f.read(chunk)
-            if not b:
+            block = f.read(chunk)
+            if not block:
                 break
-            h.update(b)
+            h.update(block)
     return h.hexdigest()
 
 
@@ -73,7 +90,10 @@ def sidecar_receipt(path: Path) -> dict[str, dict[str, int | bool]]:
     out = {}
     for suffix in ("-wal", "-shm", "-journal"):
         p = Path(str(path) + suffix)
-        out[suffix] = {"exists": p.exists(), "size": p.stat().st_size if p.exists() else 0}
+        out[suffix] = {
+            "exists": p.exists(),
+            "size": p.stat().st_size if p.exists() else 0,
+        }
     return out
 
 
@@ -83,7 +103,11 @@ def enforce_safe_source(path: Path, expected_sha: str) -> tuple[str, dict]:
     if not path.is_file():
         raise SystemExit(f"REFUSE: database is not a regular file: {path}")
     sidecars = sidecar_receipt(path)
-    dirty = {k: v for k, v in sidecars.items() if v["exists"] and int(v["size"]) > 0}
+    dirty = {
+        k: v
+        for k, v in sidecars.items()
+        if v["exists"] and int(v["size"]) > 0
+    }
     if dirty:
         raise SystemExit(f"REFUSE: frozen source has non-empty SQLite sidecars: {dirty}")
     actual = sha256_file(path)
@@ -106,6 +130,10 @@ def open_immutable(path: Path) -> sqlite3.Connection:
     return conn
 
 
+def table_columns(conn: sqlite3.Connection, table: str) -> set[str]:
+    return {str(r["name"]) for r in conn.execute(f"PRAGMA table_info({table})")}
+
+
 def normalize(value: object) -> str:
     if value is None:
         return ""
@@ -118,9 +146,64 @@ def taipei(epoch: object) -> str:
     if epoch is None or epoch == "":
         return ""
     try:
-        return datetime.fromtimestamp(float(epoch), tz=timezone.utc).astimezone(TAIPEI).isoformat()
+        return datetime.fromtimestamp(float(epoch), tz=UTC).astimezone(TAIPEI).isoformat()
     except (ValueError, TypeError, OSError):
         return ""
+
+
+def utc_stamp(epoch: object) -> str:
+    if epoch is None or epoch == "":
+        return ""
+    try:
+        return datetime.fromtimestamp(float(epoch), tz=UTC).strftime("%Y%m%d_%H%M%S")
+    except (ValueError, TypeError, OSError):
+        return ""
+
+
+def scalar(conn: sqlite3.Connection, sql: str, params: tuple = ()) -> object:
+    row = conn.execute(sql, params).fetchone()
+    return row[0] if row else None
+
+
+def json_obj(value: object) -> dict:
+    text = normalize(value).strip()
+    if not text:
+        return {}
+    try:
+        obj = json.loads(text)
+    except Exception:
+        return {}
+    return obj if isinstance(obj, dict) else {}
+
+
+def conv_id_from_model_config(value: object) -> str:
+    obj = json_obj(value)
+    v = obj.get("chatgpt_conversation_id")
+    return normalize(v).strip()
+
+
+def platform_shape(value: object) -> str:
+    text = normalize(value).strip()
+    if not text:
+        return "empty"
+    if UUID_RE.fullmatch(text):
+        return "uuid"
+    if DECIMAL_ID_RE.fullmatch(text):
+        return "discord_snowflake_like"
+    if text.startswith("call_"):
+        return "call_id"
+    return f"other_len_{len(text)}"
+
+
+def sha12(value: object) -> str:
+    text = normalize(value)
+    if not text:
+        return ""
+    return hashlib.sha256(text.encode("utf-8", errors="replace")).hexdigest()[:12]
+
+
+def safe_filename(text: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_.-]+", "_", text)[:180] or "unnamed"
 
 
 def write_tsv(path: Path, rows: list[dict], fieldnames: list[str] | None = None) -> None:
@@ -129,86 +212,99 @@ def write_tsv(path: Path, rows: list[dict], fieldnames: list[str] | None = None)
         fieldnames = []
         seen = set()
         for row in rows:
-            for k in row:
-                if k not in seen:
-                    seen.add(k)
-                    fieldnames.append(k)
+            for key in row:
+                if key not in seen:
+                    seen.add(key)
+                    fieldnames.append(key)
     with path.open("w", encoding="utf-8", newline="") as f:
-        w = csv.DictWriter(f, fieldnames=fieldnames, delimiter="\t", extrasaction="ignore")
-        w.writeheader()
+        writer = csv.DictWriter(
+            f, fieldnames=fieldnames, delimiter="\t", extrasaction="ignore"
+        )
+        writer.writeheader()
         for row in rows:
-            w.writerow(
+            writer.writerow(
                 {
-                    k: normalize(v).replace("\t", "\\t").replace("\r", "\\r").replace("\n", "\\n")
+                    k: normalize(v)
+                    .replace("\t", "\\t")
+                    .replace("\r", "\\r")
+                    .replace("\n", "\\n")
                     for k, v in row.items()
                 }
             )
 
 
-def table_columns(conn: sqlite3.Connection, table: str) -> set[str]:
-    return {str(r["name"]) for r in conn.execute(f"PRAGMA table_info({table})")}
+def dump_transcript(
+    conn: sqlite3.Connection,
+    out: Path,
+    session_id: str,
+    session_cols: set[str],
+    message_cols: set[str],
+) -> bool:
+    wanted_s = [
+        c
+        for c in (
+            "id", "title", "display_name", "source", "model", "started_at",
+            "ended_at", "end_reason", "parent_session_id", "message_count",
+            "model_config", "cwd", "session_key", "chat_id", "chat_type",
+            "thread_id", "origin_json",
+        )
+        if c in session_cols
+    ]
+    row = conn.execute(
+        f"SELECT {', '.join(wanted_s)} FROM sessions WHERE id=?",
+        (session_id,),
+    ).fetchone()
+    if not row:
+        return False
 
+    wanted_m = [
+        c
+        for c in (
+            "id", "role", "content", "timestamp", "model", "tool_name",
+            "tool_call_id", "tool_calls", "reasoning", "reasoning_content",
+            "platform_message_id", "finish_reason", "metadata",
+        )
+        if c in message_cols
+    ]
+    messages = conn.execute(
+        f"SELECT {', '.join(wanted_m)} FROM messages "
+        "WHERE session_id=? ORDER BY id",
+        (session_id,),
+    ).fetchall()
 
-def scalar(conn: sqlite3.Connection, sql: str, params: tuple = ()) -> object:
-    row = conn.execute(sql, params).fetchone()
-    return row[0] if row else None
-
-
-def percentile_int(values: list[int], q: float) -> int | None:
-    if not values:
-        return None
-    xs = sorted(values)
-    idx = round((len(xs) - 1) * q)
-    return xs[idx]
-
-
-def extract_tool_names(raw: object) -> list[str]:
-    text = normalize(raw).strip()
-    if not text:
-        return []
-    try:
-        value = json.loads(text)
-        if isinstance(value, str):
-            value = json.loads(value)
-    except Exception:
-        return []
-    if isinstance(value, dict) and "tool_calls" in value:
-        value = value["tool_calls"]
-        if isinstance(value, str):
-            try:
-                value = json.loads(value)
-            except Exception:
-                return []
-    if not isinstance(value, list):
-        return []
-    names = []
-    for item in value:
-        if not isinstance(item, dict):
-            continue
-        fn = item.get("function")
-        if isinstance(fn, dict) and fn.get("name"):
-            names.append(str(fn["name"]))
-        elif item.get("name"):
-            names.append(str(item["name"]))
-    return names
-
-
-def platform_shape(value: object) -> str:
-    s = normalize(value).strip()
-    if not s:
-        return "empty"
-    if SNOWFLAKE_RE.fullmatch(s):
-        return "decimal_15_22"
-    if UUID_RE.fullmatch(s):
-        return "uuid"
-    if s.startswith("call_"):
-        return "call_id"
-    return f"other_len_{len(s)}"
-
-
-def sha_prefix(value: object) -> str:
-    s = normalize(value)
-    return hashlib.sha256(s.encode("utf-8", errors="replace")).hexdigest()[:12] if s else ""
+    title = normalize(row["title"]) if "title" in row.keys() else ""
+    p = out / "transcripts" / f"{safe_filename(session_id)}.md"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    with p.open("w", encoding="utf-8") as f:
+        f.write(f"# Session {session_id}\n\n")
+        f.write(f"- title: {title}\n")
+        for c in wanted_s:
+            if c in ("id", "title"):
+                continue
+            value = row[c]
+            if c in ("started_at", "ended_at") and value not in (None, ""):
+                f.write(f"- {c}: {normalize(value)} ({taipei(value)})\n")
+            else:
+                f.write(f"- {c}: {normalize(value)}\n")
+        f.write(f"- actual_message_rows: {len(messages)}\n\n")
+        for i, m in enumerate(messages, 1):
+            role = normalize(m["role"]) if "role" in m.keys() else ""
+            mid = normalize(m["id"]) if "id" in m.keys() else ""
+            ts = m["timestamp"] if "timestamp" in m.keys() else None
+            f.write(f"## {i}. {role} — id={mid} — timestamp={normalize(ts)}")
+            if ts not in (None, ""):
+                f.write(f" ({taipei(ts)})")
+            f.write("\n\n")
+            for c in wanted_m:
+                if c in ("id", "role", "timestamp", "content"):
+                    continue
+                value = m[c]
+                if value not in (None, ""):
+                    f.write(f"**{c}:**\n\n```text\n{normalize(value)}\n```\n\n")
+            if "content" in m.keys():
+                f.write(normalize(m["content"]))
+                f.write("\n\n")
+    return True
 
 
 def main() -> int:
@@ -219,15 +315,14 @@ def main() -> int:
     args = ap.parse_args()
 
     started = time.time()
-    db = args.db
-    before_sha, sidecars = enforce_safe_source(db, args.expected_sha256)
-    before_identity = file_identity(db)
+    before_sha, sidecars = enforce_safe_source(args.db, args.expected_sha256)
+    before_identity = file_identity(args.db)
 
     stamp = datetime.now(TAIPEI).strftime("%Y%m%d-%H%M%S")
     out = args.output_dir or Path(f"issue60-stage3-evidence-{stamp}")
     out.mkdir(parents=True, exist_ok=False)
 
-    conn = open_immutable(db)
+    conn = open_immutable(args.db)
     try:
         counts = {
             table: int(scalar(conn, f"SELECT COUNT(*) FROM {table}") or 0)
@@ -235,456 +330,491 @@ def main() -> int:
         }
         if counts != EXPECTED_COUNTS:
             raise SystemExit(f"REFUSE: canonical row counts changed: {counts}")
-
         quick_check = normalize(scalar(conn, "PRAGMA quick_check"))
         fk_violations = len(conn.execute("PRAGMA foreign_key_check").fetchall())
 
         scols = table_columns(conn, "sessions")
+        mcols = table_columns(conn, "messages")
 
-        # 1) Pre-cutoff source/model/end_reason/lineage distribution.
-        source_rows = []
-        for r in conn.execute(
-            """
-            SELECT s.source,
-                   COUNT(*) AS session_count,
-                   MIN(s.started_at) AS min_started_at,
-                   MAX(s.started_at) AS max_started_at,
-                   SUM(CASE WHEN s.parent_session_id IS NOT NULL AND s.parent_session_id <> '' THEN 1 ELSE 0 END) AS with_parent,
-                   SUM(CASE WHEN s.end_reason = 'compression' THEN 1 ELSE 0 END) AS compression_ended,
-                   SUM(COALESCE(s.message_count, 0)) AS declared_message_count
-            FROM sessions s
-            WHERE s.started_at < ?
-            GROUP BY s.source
-            ORDER BY session_count DESC, s.source
-            """,
-            (CUTOFF,),
-        ):
-            d = dict(r)
-            d["min_started_taipei"] = taipei(d["min_started_at"])
-            d["max_started_taipei"] = taipei(d["max_started_at"])
-            source_rows.append(d)
-        write_tsv(out / "precutoff_source_profile.tsv", source_rows)
+        # A) Dump the high-value June-15 live-Hermes transcripts.
+        dumped = []
+        for sid in TARGET_SESSIONS:
+            if dump_transcript(conn, out, sid, scols, mcols):
+                dumped.append(sid)
 
-        model_rows = [
-            dict(r)
+        # Also list the ±15 minute neighborhood around the key session.
+        key_started = scalar(
+            conn, "SELECT started_at FROM sessions WHERE id=?",
+            ("20260615_050051_06bd07d3",),
+        )
+        neighborhood = []
+        if key_started not in (None, ""):
             for r in conn.execute(
                 """
-                SELECT source, COALESCE(model, '') AS model, COUNT(*) AS session_count
+                SELECT id, title, source, model, started_at, ended_at,
+                       parent_session_id, end_reason, message_count
                 FROM sessions
-                WHERE started_at < ?
-                GROUP BY source, COALESCE(model, '')
-                ORDER BY session_count DESC, source, model
+                WHERE started_at BETWEEN ? AND ?
+                ORDER BY started_at, id
                 """,
-                (CUTOFF,),
-            )
-        ]
-        write_tsv(out / "precutoff_model_profile.tsv", model_rows)
-
-        end_rows = [
-            dict(r)
-            for r in conn.execute(
-                """
-                SELECT source, COALESCE(end_reason, '') AS end_reason, COUNT(*) AS session_count
-                FROM sessions
-                WHERE started_at < ?
-                GROUP BY source, COALESCE(end_reason, '')
-                ORDER BY session_count DESC, source, end_reason
-                """,
-                (CUTOFF,),
-            )
-        ]
-        write_tsv(out / "precutoff_end_reason_profile.tsv", end_rows)
-
-        # 2) Message INTEGER PK as an insertion-order proxy.
-        groups = [
-            ("chatgpt_export_all", "s.source = 'chatgpt-export'", ()),
-            ("precutoff_non_chatgpt", "s.started_at < ? AND s.source <> 'chatgpt-export'", (CUTOFF,)),
-            ("precutoff_discord", "s.started_at < ? AND s.source = 'discord'", (CUTOFF,)),
-            ("precutoff_cli", "s.started_at < ? AND s.source = 'cli'", (CUTOFF,)),
-            ("precutoff_cron", "s.started_at < ? AND s.source = 'cron'", (CUTOFF,)),
-        ]
-        insertion_rows = []
-        group_ids: dict[str, list[int]] = {}
-        for name, clause, params in groups:
-            ids = [
-                int(r[0])
-                for r in conn.execute(
-                    f"""
-                    SELECT m.id
-                    FROM messages m
-                    JOIN sessions s ON s.id = m.session_id
-                    WHERE {clause}
-                    ORDER BY m.id
-                    """,
-                    params,
-                )
-            ]
-            group_ids[name] = ids
-            insertion_rows.append(
-                {
-                    "group": name,
-                    "message_rows": len(ids),
-                    "min_id": min(ids) if ids else "",
-                    "p05_id": percentile_int(ids, 0.05) or "",
-                    "p25_id": percentile_int(ids, 0.25) or "",
-                    "median_id": percentile_int(ids, 0.50) or "",
-                    "p75_id": percentile_int(ids, 0.75) or "",
-                    "p95_id": percentile_int(ids, 0.95) or "",
-                    "max_id": max(ids) if ids else "",
-                }
-            )
-        chatgpt_min_id = min(group_ids["chatgpt_export_all"]) if group_ids["chatgpt_export_all"] else None
-        if chatgpt_min_id is not None:
-            pre_ids = group_ids["precutoff_non_chatgpt"]
-            insertion_rows.append(
-                {
-                    "group": "precutoff_non_chatgpt_vs_first_chatgpt",
-                    "message_rows": len(pre_ids),
-                    "min_id": "",
-                    "p05_id": "",
-                    "p25_id": "",
-                    "median_id": "",
-                    "p75_id": "",
-                    "p95_id": "",
-                    "max_id": "",
-                    "before_first_chatgpt_id": sum(i < chatgpt_min_id for i in pre_ids),
-                    "at_or_after_first_chatgpt_id": sum(i >= chatgpt_min_id for i in pre_ids),
-                    "first_chatgpt_message_id": chatgpt_min_id,
-                }
-            )
-        write_tsv(out / "message_id_insertion_profile.tsv", insertion_rows)
-
-        boundary_rows = []
-        if chatgpt_min_id is not None:
-            for r in conn.execute(
-                """
-                SELECT m.id AS message_id, m.session_id, s.source, s.title, s.started_at,
-                       m.role, m.timestamp, m.tool_name, m.platform_message_id
-                FROM messages m
-                JOIN sessions s ON s.id = m.session_id
-                WHERE m.id BETWEEN ? AND ?
-                ORDER BY m.id
-                """,
-                (max(1, chatgpt_min_id - 25), chatgpt_min_id + 25),
+                (float(key_started) - 900, float(key_started) + 900),
             ):
                 d = dict(r)
-                d["session_started_taipei"] = taipei(d["started_at"])
-                d["message_taipei"] = taipei(d["timestamp"])
-                d["platform_id_shape"] = platform_shape(d["platform_message_id"])
-                d["platform_id_sha12"] = sha_prefix(d["platform_message_id"])
-                d.pop("platform_message_id", None)
-                boundary_rows.append(d)
-        write_tsv(out / "first_chatgpt_message_id_boundary.tsv", boundary_rows)
+                d["started_taipei"] = taipei(d.get("started_at"))
+                d["ended_taipei"] = taipei(d.get("ended_at"))
+                neighborhood.append(d)
+        write_tsv(out / "june15_key_session_neighborhood.tsv", neighborhood)
 
-        # 3) Per-session shape/fingerprint table for pre-cutoff non-ChatGPT rows.
-        selected_session_cols = [
-            c
-            for c in (
-                "id", "source", "title", "model", "started_at", "ended_at", "end_reason",
-                "parent_session_id", "model_config", "session_key", "chat_id", "chat_type",
-                "thread_id", "origin_json", "display_name", "cwd"
-            )
-            if c in scols
+        # B) June-15 05:00–05:01 UTC chatgpt-export cluster.
+        session_fields = [
+            c for c in (
+                "id", "title", "display_name", "source", "model", "started_at",
+                "ended_at", "parent_session_id", "end_reason", "message_count",
+                "model_config", "user_id", "cwd", "session_key", "chat_id",
+                "chat_type", "thread_id", "origin_json",
+            ) if c in scols
         ]
-        session_sql = ", ".join(f"s.{c}" for c in selected_session_cols)
-        session_rows = []
-        sessions = conn.execute(
+        sel = ", ".join(f"s.{c}" for c in session_fields)
+        cluster_rows = []
+        for r in conn.execute(
             f"""
-            SELECT {session_sql},
+            SELECT {sel},
                    COUNT(m.id) AS actual_messages,
                    MIN(m.id) AS min_message_id,
                    MAX(m.id) AS max_message_id,
                    MIN(m.timestamp) AS min_message_timestamp,
                    MAX(m.timestamp) AS max_message_timestamp,
-                   SUM(CASE WHEN m.tool_calls IS NOT NULL AND m.tool_calls <> '' THEN 1 ELSE 0 END) AS tool_call_rows,
-                   SUM(CASE WHEN m.tool_name IS NOT NULL AND m.tool_name <> '' THEN 1 ELSE 0 END) AS named_tool_rows,
-                   SUM(CASE WHEN m.platform_message_id IS NOT NULL AND m.platform_message_id <> '' THEN 1 ELSE 0 END) AS platform_id_rows
+                   SUM(CASE WHEN COALESCE(m.tool_name,'') <> '' THEN 1 ELSE 0 END) AS tool_name_rows,
+                   SUM(CASE WHEN COALESCE(m.tool_calls,'') <> '' THEN 1 ELSE 0 END) AS tool_call_rows,
+                   SUM(CASE WHEN COALESCE(m.platform_message_id,'') <> '' THEN 1 ELSE 0 END) AS platform_id_rows
             FROM sessions s
-            LEFT JOIN messages m ON m.session_id = s.id
-            WHERE s.started_at < ? AND s.source <> 'chatgpt-export'
+            LEFT JOIN messages m ON m.session_id=s.id
+            WHERE s.source='chatgpt-export'
+              AND s.id >= '20260615_050000_'
+              AND s.id <  '20260615_050200_'
             GROUP BY s.id
-            ORDER BY s.started_at, s.id
-            """,
-            (CUTOFF,),
+            ORDER BY s.id
+            """
+        ):
+            d = dict(r)
+            cid = conv_id_from_model_config(d.get("model_config"))
+            d["conversation_id"] = cid
+            d["conversation_prefix_matches_id_suffix"] = int(
+                bool(cid) and d["id"].split("_")[-1] == cid[:8]
+            )
+            d["started_taipei"] = taipei(d.get("started_at"))
+            d["ended_taipei"] = taipei(d.get("ended_at"))
+            d["message_min_taipei"] = taipei(d.get("min_message_timestamp"))
+            d["message_max_taipei"] = taipei(d.get("max_message_timestamp"))
+            if d.get("started_at") not in (None, "") and d.get("min_message_timestamp") not in (None, ""):
+                d["started_minus_message_min_s"] = (
+                    float(d["started_at"]) - float(d["min_message_timestamp"])
+                )
+            else:
+                d["started_minus_message_min_s"] = ""
+            cluster_rows.append(d)
+        write_tsv(out / "june15_chatgpt_import_time_cluster.tsv", cluster_rows)
+
+        # C) Time-shape anomalies across all final chatgpt-export rows.
+        # First-message time is an observable proxy, not a claim about create_time.
+        time_rows = []
+        all_chatgpt_rows = conn.execute(
+            f"""
+            SELECT {sel},
+                   COUNT(m.id) AS actual_messages,
+                   MIN(m.id) AS min_message_id,
+                   MAX(m.id) AS max_message_id,
+                   MIN(m.timestamp) AS min_message_timestamp,
+                   MAX(m.timestamp) AS max_message_timestamp
+            FROM sessions s
+            LEFT JOIN messages m ON m.session_id=s.id
+            WHERE s.source='chatgpt-export'
+            GROUP BY s.id
+            ORDER BY s.id
+            """
         ).fetchall()
-        for r in sessions:
+
+        for r in all_chatgpt_rows:
+            d = dict(r)
+            cid = conv_id_from_model_config(d.get("model_config"))
+            started_at = d.get("started_at")
+            min_ts = d.get("min_message_timestamp")
+            delta = None
+            if started_at not in (None, "") and min_ts not in (None, ""):
+                delta = float(started_at) - float(min_ts)
+            expected_from_first_message = ""
+            if cid and min_ts not in (None, ""):
+                expected_from_first_message = f"{utc_stamp(min_ts)}_{cid[:8]}"
+            collision = None
+            if expected_from_first_message and expected_from_first_message != d["id"]:
+                collision = conn.execute(
+                    "SELECT id, source, title, started_at FROM sessions WHERE id=?",
+                    (expected_from_first_message,),
+                ).fetchone()
+
+            if delta is not None and abs(delta) >= 86400:
+                time_rows.append(
+                    {
+                        "session_id": d["id"],
+                        "title": d.get("title"),
+                        "started_at": started_at,
+                        "started_taipei": taipei(started_at),
+                        "min_message_timestamp": min_ts,
+                        "min_message_taipei": taipei(min_ts),
+                        "started_minus_message_min_s": delta,
+                        "conversation_id": cid,
+                        "actual_id_suffix": d["id"].split("_")[-1],
+                        "conv_id_prefix": cid[:8] if cid else "",
+                        "suffix_matches_conv_prefix": int(
+                            bool(cid) and d["id"].split("_")[-1] == cid[:8]
+                        ),
+                        "first_message_proxy_expected_id": expected_from_first_message,
+                        "proxy_expected_id_exists": int(collision is not None),
+                        "proxy_expected_id_source": collision["source"] if collision else "",
+                        "proxy_expected_id_title": collision["title"] if collision else "",
+                    }
+                )
+        time_rows.sort(
+            key=lambda r: abs(float(r["started_minus_message_min_s"])),
+            reverse=True,
+        )
+        write_tsv(out / "chatgpt_export_time_anomalies.tsv", time_rows)
+
+        # D) Field/fingerprint audit for rows whose final source is chatgpt-export.
+        field_counts = Counter()
+        fingerprint_rows = []
+        platform_shape_counts = Counter()
+        chatgpt_message_min_id = None
+
+        agg = {}
+        for r in conn.execute(
+            """
+            SELECT s.id AS session_id,
+                   COUNT(m.id) AS actual_messages,
+                   MIN(m.id) AS min_message_id,
+                   MAX(m.id) AS max_message_id,
+                   SUM(CASE WHEN COALESCE(m.tool_name,'') <> '' THEN 1 ELSE 0 END) AS tool_name_rows,
+                   SUM(CASE WHEN COALESCE(m.tool_calls,'') <> '' THEN 1 ELSE 0 END) AS tool_call_rows
+            FROM sessions s
+            LEFT JOIN messages m ON m.session_id=s.id
+            WHERE s.source='chatgpt-export'
+            GROUP BY s.id
+            """
+        ):
+            agg[r["session_id"]] = dict(r)
+            mid = r["min_message_id"]
+            if mid is not None:
+                mid = int(mid)
+                chatgpt_message_min_id = (
+                    mid if chatgpt_message_min_id is None
+                    else min(chatgpt_message_min_id, mid)
+                )
+
+        suspicious_platform = {}
+        for r in conn.execute(
+            """
+            SELECT m.id AS message_id, m.session_id, m.role, m.platform_message_id
+            FROM messages m
+            JOIN sessions s ON s.id=m.session_id
+            WHERE s.source='chatgpt-export'
+              AND COALESCE(m.platform_message_id,'') <> ''
+            ORDER BY m.id
+            """
+        ):
+            shape = platform_shape(r["platform_message_id"])
+            platform_shape_counts[shape] += 1
+            if shape != "uuid" and r["session_id"] not in suspicious_platform:
+                suspicious_platform[r["session_id"]] = {
+                    "message_id": r["message_id"],
+                    "shape": shape,
+                    "platform_id_sha12": sha12(r["platform_message_id"]),
+                }
+
+        for r in all_chatgpt_rows:
+            d = dict(r)
+            sid = d["id"]
+            a = agg.get(sid, {})
+            cid = conv_id_from_model_config(d.get("model_config"))
+            native_fields = {}
+            for c in (
+                "display_name", "parent_session_id", "end_reason", "cwd",
+                "session_key", "chat_id", "chat_type", "thread_id", "origin_json",
+            ):
+                if c in d and d[c] not in (None, ""):
+                    field_counts[c] += 1
+                    native_fields[c] = d[c]
+
+            score = 0
+            reasons = []
+            if native_fields:
+                score += len(native_fields) * 2
+                reasons.extend(f"session_field:{c}" for c in native_fields)
+            if int(a.get("tool_name_rows") or 0):
+                score += 5
+                reasons.append("message_tool_name")
+            if int(a.get("tool_call_rows") or 0):
+                score += 5
+                reasons.append("message_tool_calls")
+            if sid in suspicious_platform:
+                score += 6
+                reasons.append(f"platform_id:{suspicious_platform[sid]['shape']}")
+            if not cid:
+                score += 4
+                reasons.append("missing_chatgpt_conversation_id")
+            elif sid.split("_")[-1] != cid[:8]:
+                score += 4
+                reasons.append("id_suffix_mismatch_conversation_id")
+
+            if score:
+                row = {
+                    "score": score,
+                    "reasons": ",".join(reasons),
+                    "session_id": sid,
+                    "title": d.get("title"),
+                    "started_at": d.get("started_at"),
+                    "started_taipei": taipei(d.get("started_at")),
+                    "ended_at": d.get("ended_at"),
+                    "ended_taipei": taipei(d.get("ended_at")),
+                    "model": d.get("model"),
+                    "conversation_id": cid,
+                    "actual_messages": a.get("actual_messages"),
+                    "min_message_id": a.get("min_message_id"),
+                    "max_message_id": a.get("max_message_id"),
+                    "tool_name_rows": a.get("tool_name_rows"),
+                    "tool_call_rows": a.get("tool_call_rows"),
+                    "suspicious_platform_shape": suspicious_platform.get(sid, {}).get("shape", ""),
+                    "suspicious_platform_message_id": suspicious_platform.get(sid, {}).get("message_id", ""),
+                }
+                for c, v in native_fields.items():
+                    if c in ("session_key", "chat_id", "thread_id", "origin_json"):
+                        row[f"{c}_present"] = 1
+                        row[f"{c}_sha12"] = sha12(v)
+                    else:
+                        row[c] = v
+                fingerprint_rows.append(row)
+
+        fingerprint_rows.sort(
+            key=lambda r: (-int(r["score"]), int(r.get("min_message_id") or 10**18))
+        )
+        write_tsv(out / "chatgpt_export_native_fingerprint_candidates.tsv", fingerprint_rows)
+        write_tsv(
+            out / "chatgpt_export_field_presence.tsv",
+            [
+                {"field": field, "nonempty_sessions": count}
+                for field, count in sorted(field_counts.items())
+            ],
+        )
+        write_tsv(
+            out / "chatgpt_export_platform_id_shapes.tsv",
+            [
+                {"shape": shape, "message_rows": count}
+                for shape, count in platform_shape_counts.most_common()
+            ],
+        )
+
+        # E) messages.id insertion-order proxy around the first ChatGPT-imported row.
+        boundary_rows = []
+        native_before_counts = []
+        if chatgpt_message_min_id is not None:
+            low = max(1, chatgpt_message_min_id - 75)
+            high = chatgpt_message_min_id + 75
+            for r in conn.execute(
+                """
+                SELECT m.id AS message_id, m.session_id, s.source, s.title,
+                       s.started_at, m.role, m.timestamp, m.tool_name,
+                       m.platform_message_id
+                FROM messages m
+                JOIN sessions s ON s.id=m.session_id
+                WHERE m.id BETWEEN ? AND ?
+                ORDER BY m.id
+                """,
+                (low, high),
+            ):
+                d = dict(r)
+                d["session_started_taipei"] = taipei(d.get("started_at"))
+                d["message_taipei"] = taipei(d.get("timestamp"))
+                d["platform_id_shape"] = platform_shape(d.get("platform_message_id"))
+                d["platform_id_sha12"] = sha12(d.get("platform_message_id"))
+                d.pop("platform_message_id", None)
+                boundary_rows.append(d)
+
+            for r in conn.execute(
+                """
+                SELECT s.source, COUNT(*) AS message_rows,
+                       COUNT(DISTINCT s.id) AS distinct_sessions
+                FROM messages m
+                JOIN sessions s ON s.id=m.session_id
+                WHERE m.id < ?
+                GROUP BY s.source
+                ORDER BY message_rows DESC, s.source
+                """,
+                (chatgpt_message_min_id,),
+            ):
+                native_before_counts.append(dict(r))
+        write_tsv(out / "first_chatgpt_message_id_boundary.tsv", boundary_rows)
+        write_tsv(out / "messages_before_first_chatgpt_by_source.tsv", native_before_counts)
+
+        # F) Three time strata with the corrected May-29 boundary.
+        strata = [
+            ("true_pre_hermes", 0, HERMES_START),
+            ("hermes_before_chatgpt_merge", HERMES_START, IMPORT_DATE),
+            ("post_import_date", IMPORT_DATE, float("inf")),
+        ]
+        stratum_rows = []
+        for name, lo, hi in strata:
+            if hi == float("inf"):
+                sql = """
+                    SELECT source, COUNT(*) AS sessions,
+                           MIN(started_at) AS min_started_at,
+                           MAX(started_at) AS max_started_at,
+                           SUM(CASE WHEN COALESCE(parent_session_id,'') <> '' THEN 1 ELSE 0 END) AS with_parent,
+                           SUM(CASE WHEN end_reason='compression' THEN 1 ELSE 0 END) AS compression_ended
+                    FROM sessions
+                    WHERE started_at >= ?
+                    GROUP BY source
+                """
+                params = (lo,)
+            else:
+                sql = """
+                    SELECT source, COUNT(*) AS sessions,
+                           MIN(started_at) AS min_started_at,
+                           MAX(started_at) AS max_started_at,
+                           SUM(CASE WHEN COALESCE(parent_session_id,'') <> '' THEN 1 ELSE 0 END) AS with_parent,
+                           SUM(CASE WHEN end_reason='compression' THEN 1 ELSE 0 END) AS compression_ended
+                    FROM sessions
+                    WHERE started_at >= ? AND started_at < ?
+                    GROUP BY source
+                """
+                params = (lo, hi)
+            for r in conn.execute(sql, params):
+                d = dict(r)
+                d["stratum"] = name
+                d["min_started_taipei"] = taipei(d.get("min_started_at"))
+                d["max_started_taipei"] = taipei(d.get("max_started_at"))
+                stratum_rows.append(d)
+        write_tsv(out / "corrected_time_strata_source_profile.tsv", stratum_rows)
+
+        # True pre-Hermes non-chatgpt rows only.
+        true_pre_rows = []
+        for r in conn.execute(
+            """
+            SELECT id, title, source, model, started_at, ended_at,
+                   parent_session_id, end_reason, message_count,
+                   display_name, cwd
+            FROM sessions
+            WHERE started_at < ?
+              AND source <> 'chatgpt-export'
+            ORDER BY started_at, id
+            """,
+            (HERMES_START,),
+        ):
             d = dict(r)
             d["started_taipei"] = taipei(d.get("started_at"))
             d["ended_taipei"] = taipei(d.get("ended_at"))
-            d["min_message_taipei"] = taipei(d.get("min_message_timestamp"))
-            d["max_message_taipei"] = taipei(d.get("max_message_timestamp"))
-            for sensitive in ("chat_id", "thread_id", "session_key", "origin_json"):
-                if sensitive in d:
-                    raw = normalize(d[sensitive])
-                    d[f"{sensitive}_present"] = int(bool(raw))
-                    d[f"{sensitive}_sha12"] = sha_prefix(raw)
-                    d.pop(sensitive, None)
-            session_rows.append(d)
-        write_tsv(out / "precutoff_session_fingerprints.tsv", session_rows)
-
-        # 4) Tool-call fingerprint distribution and earliest occurrences.
-        tool_counter: Counter[tuple[str, str]] = Counter()
-        occurrences = []
-        for r in conn.execute(
-            """
-            SELECT m.id AS message_id, m.session_id, s.source, s.title, s.started_at,
-                   m.timestamp, m.role, m.tool_calls, m.tool_name
-            FROM messages m
-            JOIN sessions s ON s.id = m.session_id
-            WHERE s.started_at < ?
-              AND s.source <> 'chatgpt-export'
-              AND (
-                    (m.tool_calls IS NOT NULL AND m.tool_calls <> '')
-                 OR (m.tool_name IS NOT NULL AND m.tool_name <> '')
-              )
-            ORDER BY m.id
-            """,
-            (CUTOFF,),
-        ):
-            d = dict(r)
-            names = extract_tool_names(d["tool_calls"])
-            if d["tool_name"]:
-                names.append(normalize(d["tool_name"]))
-            names = sorted(set(n for n in names if n))
-            for name in names:
-                tool_counter[(normalize(d["source"]), name)] += 1
-                occurrences.append(
-                    {
-                        "message_id": d["message_id"],
-                        "session_id": d["session_id"],
-                        "source": d["source"],
-                        "title": d["title"],
-                        "session_started_taipei": taipei(d["started_at"]),
-                        "message_taipei": taipei(d["timestamp"]),
-                        "role": d["role"],
-                        "tool_name": name,
-                    }
-                )
-        tool_profile = [
-            {"source": src, "tool_name": name, "occurrences": count}
-            for (src, name), count in sorted(
-                tool_counter.items(), key=lambda kv: (-kv[1], kv[0][0], kv[0][1])
-            )
-        ]
-        write_tsv(out / "precutoff_tool_name_profile.tsv", tool_profile)
-        write_tsv(out / "precutoff_tool_occurrences.tsv", occurrences[:2000])
-
-        # 5) Platform message ID *shape* only; never emit raw platform IDs.
-        shape_counter: Counter[tuple[str, str, str]] = Counter()
-        shape_examples = {}
-        for r in conn.execute(
-            """
-            SELECT m.id AS message_id, m.session_id, s.source, s.title, s.started_at,
-                   m.role, m.timestamp, m.platform_message_id
-            FROM messages m
-            JOIN sessions s ON s.id = m.session_id
-            WHERE s.started_at < ?
-              AND s.source <> 'chatgpt-export'
-              AND m.platform_message_id IS NOT NULL
-              AND m.platform_message_id <> ''
-            ORDER BY m.id
-            """,
-            (CUTOFF,),
-        ):
-            d = dict(r)
-            shape = platform_shape(d["platform_message_id"])
-            key = (normalize(d["source"]), normalize(d["role"]), shape)
-            shape_counter[key] += 1
-            shape_examples.setdefault(
-                key,
-                {
-                    "source": d["source"],
-                    "role": d["role"],
-                    "shape": shape,
-                    "message_id": d["message_id"],
-                    "session_id": d["session_id"],
-                    "title": d["title"],
-                    "session_started_taipei": taipei(d["started_at"]),
-                    "message_taipei": taipei(d["timestamp"]),
-                    "platform_id_sha12": sha_prefix(d["platform_message_id"]),
-                    "platform_id_length": len(normalize(d["platform_message_id"])),
-                },
-            )
-        shape_profile = [
-            {"source": src, "role": role, "shape": shape, "count": count}
-            for (src, role, shape), count in sorted(
-                shape_counter.items(), key=lambda kv: (-kv[1], kv[0])
-            )
-        ]
-        write_tsv(out / "platform_message_id_shape_profile.tsv", shape_profile)
-        write_tsv(out / "platform_message_id_shape_examples.tsv", list(shape_examples.values()))
-
-        # 6) Cross-session search edges. This is deliberately narrow: tool rows
-        # whose tool_name names session_search, plus JSON-ish outputs containing
-        # "session_id". Emit session IDs but not message contents.
-        known_sessions = {r[0] for r in conn.execute("SELECT id FROM sessions")}
-        edges = []
-        edge_seen = set()
-        for r in conn.execute(
-            """
-            SELECT m.id AS message_id, m.session_id, s.source, s.title, s.started_at,
-                   m.timestamp, m.tool_name, m.content
-            FROM messages m
-            JOIN sessions s ON s.id = m.session_id
-            WHERE s.started_at < ?
-              AND s.source <> 'chatgpt-export'
-              AND (
-                    LOWER(COALESCE(m.tool_name, '')) LIKE '%session%search%'
-                 OR m.content LIKE '%"session_id"%'
-              )
-            ORDER BY m.id
-            """,
-            (CUTOFF,),
-        ):
-            d = dict(r)
-            refs = sorted(set(SESSION_ID_RE.findall(normalize(d["content"]))))
-            for ref in refs:
-                if ref == d["session_id"] or ref not in known_sessions:
-                    continue
-                key = (d["message_id"], d["session_id"], ref)
-                if key in edge_seen:
-                    continue
-                edge_seen.add(key)
-                target = conn.execute(
-                    "SELECT source, title, started_at FROM sessions WHERE id = ?",
-                    (ref,),
-                ).fetchone()
-                edges.append(
-                    {
-                        "message_id": d["message_id"],
-                        "from_session_id": d["session_id"],
-                        "from_source": d["source"],
-                        "from_title": d["title"],
-                        "from_started_taipei": taipei(d["started_at"]),
-                        "message_taipei": taipei(d["timestamp"]),
-                        "tool_name": d["tool_name"],
-                        "to_session_id": ref,
-                        "to_source": target["source"] if target else "",
-                        "to_title": target["title"] if target else "",
-                        "to_started_taipei": taipei(target["started_at"]) if target else "",
-                    }
-                )
-        write_tsv(out / "precutoff_session_search_edges.tsv", edges)
-
-        # 7) Earliest high-signal rows: tool usage and lineage.
-        write_tsv(out / "earliest_precutoff_tool_fingerprints.tsv", occurrences[:100])
-
-        parent_rows = []
-        for r in conn.execute(
-            """
-            SELECT s.id, s.source, s.title, s.started_at, s.parent_session_id, s.end_reason,
-                   p.source AS parent_source, p.title AS parent_title, p.started_at AS parent_started_at
-            FROM sessions s
-            LEFT JOIN sessions p ON p.id = s.parent_session_id
-            WHERE s.started_at < ?
-              AND s.parent_session_id IS NOT NULL
-              AND s.parent_session_id <> ''
-            ORDER BY s.started_at, s.id
-            """,
-            (CUTOFF,),
-        ):
-            d = dict(r)
-            d["started_taipei"] = taipei(d["started_at"])
-            d["parent_started_taipei"] = taipei(d["parent_started_at"])
-            parent_rows.append(d)
-        write_tsv(out / "precutoff_parent_edges.tsv", parent_rows)
-
-        first_chatgpt = None
-        if chatgpt_min_id is not None:
-            r = conn.execute(
-                """
-                SELECT m.id AS message_id, m.session_id, s.title, s.started_at,
-                       m.timestamp, m.role, m.platform_message_id
-                FROM messages m JOIN sessions s ON s.id=m.session_id
-                WHERE m.id=?
-                """,
-                (chatgpt_min_id,),
-            ).fetchone()
-            if r:
-                first_chatgpt = dict(r)
-                first_chatgpt["session_started_taipei"] = taipei(first_chatgpt["started_at"])
-                first_chatgpt["message_taipei"] = taipei(first_chatgpt["timestamp"])
-                first_chatgpt["platform_id_shape"] = platform_shape(first_chatgpt["platform_message_id"])
-                first_chatgpt["platform_id_sha12"] = sha_prefix(first_chatgpt["platform_message_id"])
-                first_chatgpt.pop("platform_message_id", None)
+            true_pre_rows.append(d)
+        write_tsv(out / "true_prehermes_non_chatgpt_sessions.tsv", true_pre_rows)
 
         summary = {
-            "cutoff_taipei": datetime.fromtimestamp(CUTOFF, tz=timezone.utc).astimezone(TAIPEI).isoformat(),
-            "chatgpt_min_message_id": chatgpt_min_id,
-            "precutoff_non_chatgpt_messages": len(group_ids["precutoff_non_chatgpt"]),
-            "precutoff_non_chatgpt_before_first_chatgpt_message_id": (
-                sum(i < chatgpt_min_id for i in group_ids["precutoff_non_chatgpt"])
-                if chatgpt_min_id is not None else None
-            ),
-            "precutoff_non_chatgpt_at_or_after_first_chatgpt_message_id": (
-                sum(i >= chatgpt_min_id for i in group_ids["precutoff_non_chatgpt"])
-                if chatgpt_min_id is not None else None
-            ),
-            "distinct_precutoff_tool_names": len({name for _, name in tool_counter}),
-            "precutoff_tool_occurrences": len(occurrences),
-            "cross_session_edges": len(edges),
-            "precutoff_parent_edges": len(parent_rows),
-            "first_chatgpt_message": first_chatgpt,
-        }
-
-        (out / "README.md").write_text(
-            "# Issue #60 stage-3 provenance-shape evidence\n\n"
-            "Purpose: distinguish pre-2026-06-16 Hermes-shaped rows from the later "
-            "ChatGPT import using insertion-order proxies and runtime fingerprints.\n\n"
-            "Key outputs:\n\n"
-            "- `message_id_insertion_profile.tsv`: SQLite message PK distributions; "
-            "`messages.id` is used only as an insertion-order proxy, not a historical timestamp.\n"
-            "- `first_chatgpt_message_id_boundary.tsv`: rows around the first final "
-            "`chatgpt-export` message ID.\n"
-            "- `precutoff_tool_name_profile.tsv` / `precutoff_tool_occurrences.tsv`: "
-            "tool-call fingerprints before the cutoff.\n"
-            "- `platform_message_id_shape_profile.tsv`: only shape categories; raw "
-            "platform IDs are never emitted.\n"
-            "- `precutoff_session_search_edges.tsv`: cross-session references emitted "
-            "without message bodies.\n"
-            "- `precutoff_parent_edges.tsv`: session lineage already present before cutoff.\n"
-            "- `precutoff_session_fingerprints.tsv`: bounded field/message summaries.\n\n"
-            "Interpretation discipline:\n\n"
-            "- Low message IDs relative to the first `chatgpt-export` row are evidence "
-            "about insertion order only.\n"
-            "- Tool names / platform-ID shapes are fingerprints, not by themselves proof "
-            "of which program produced a row.\n"
-            "- Cross-session references and multiple independent fingerprints together "
-            "can support a stronger provenance conclusion.\n",
-            encoding="utf-8",
-        )
-
-        after_identity = file_identity(db)
-        after_sha = sha256_file(db)
-        if after_identity != before_identity:
-            raise SystemExit(f"REFUSE: source identity changed during extraction: {before_identity} -> {after_identity}")
-        if after_sha != before_sha:
-            raise SystemExit(f"REFUSE: source SHA changed during extraction: {before_sha} -> {after_sha}")
-
-        manifest = {
-            "source": {
-                "path": str(db),
-                "sha256": before_sha,
-                "before_identity": before_identity,
-                "after_identity": after_identity,
-                "sidecars": sidecars,
-                "opened_mode": "mode=ro&immutable=1; PRAGMA query_only=ON",
-                "mutations_performed": 0,
+            "ground_truth": {
+                "hermes_runtime_start_taipei": "2026-05-29",
+                "chatgpt_import_merge_date_taipei": "2026-06-16",
+                "note": "June 16 is import/merge date, not Hermes adoption",
             },
-            "counts": counts,
-            "quick_check": quick_check,
-            "foreign_key_violations": fk_violations,
-            "cutoff_epoch": CUTOFF,
-            "cutoff_taipei": datetime.fromtimestamp(CUTOFF, tz=timezone.utc).astimezone(TAIPEI).isoformat(),
-            "summary": summary,
-            "elapsed_s": round(time.time() - started, 3),
+            "canonical_db": {
+                "path": str(args.db),
+                "sha256": before_sha,
+                "counts": counts,
+                "quick_check": quick_check,
+                "foreign_key_violations": fk_violations,
+                "opened_mode": "mode=ro&immutable=1 + PRAGMA query_only=ON",
+                "mutations_performed": False,
+            },
+            "target_transcripts_dumped": dumped,
+            "june15_cluster_sessions": len(cluster_rows),
+            "chatgpt_export_time_anomalies_ge_1d": len(time_rows),
+            "chatgpt_export_native_fingerprint_candidates": len(fingerprint_rows),
+            "chatgpt_export_field_presence": dict(field_counts),
+            "chatgpt_export_platform_id_shapes": dict(platform_shape_counts),
+            "first_chatgpt_message_id": chatgpt_message_min_id,
+            "true_prehermes_non_chatgpt_sessions": len(true_pre_rows),
+            "output_files": sorted(
+                str(p.relative_to(out))
+                for p in out.rglob("*")
+                if p.is_file()
+            ),
         }
         (out / "manifest.json").write_text(
-            json.dumps(manifest, ensure_ascii=False, indent=2) + "\n",
+            json.dumps(summary, ensure_ascii=False, indent=2) + "\n",
             encoding="utf-8",
         )
+
+        readme = """# Issue #60 stage-3 evidence
+
+Corrected ground truth:
+
+```text
+2026-05-29 = Hermes runtime start
+2026-06-16 = ChatGPT history import/merge into existing Hermes DB
+```
+
+This stage does **not** treat May-29..Jun-15 Hermes rows as anomalous.
+
+High-value outputs:
+
+- `transcripts/20260615_050051_06bd07d3.md` — full `GPT記憶與偏好遷移` session.
+- `june15_chatgpt_import_time_cluster.tsv` — the nearby early/partial-import cluster.
+- `chatgpt_export_time_anomalies.tsv` — final imported rows whose session start differs from first-message time by >= 1 day.
+- `chatgpt_export_native_fingerprint_candidates.tsv` — rows whose final source is `chatgpt-export` but contain fields/message shapes not written by the final importer.
+- `first_chatgpt_message_id_boundary.tsv` and `messages_before_first_chatgpt_by_source.tsv` — insertion-order proxy around the first imported message.
+- `corrected_time_strata_source_profile.tsv` — source/lineage shape using the real May-29 boundary.
+- `true_prehermes_non_chatgpt_sessions.tsv` — only rows that genuinely precede May 29.
+
+Interpretation discipline:
+
+- `messages.id` is an insertion-order proxy, not a wall-clock timestamp.
+- first-message timestamp is a useful observable proxy for conversation start, not proof of ChatGPT `create_time`.
+- a native fingerprint inside `source='chatgpt-export'` is a candidate for earlier-import behavior or source-rewrite collision; it is not proof by itself.
+"""
+        (out / "README.md").write_text(readme, encoding="utf-8")
+
     finally:
         conn.close()
+
+    after_identity = file_identity(args.db)
+    after_sha = sha256_file(args.db)
+    after_sidecars = sidecar_receipt(args.db)
+    if after_identity != before_identity:
+        raise SystemExit(
+            f"REFUSE: DB identity changed during extraction: "
+            f"before={before_identity} after={after_identity}"
+        )
+    if after_sha != before_sha:
+        raise SystemExit(
+            f"REFUSE: DB SHA changed during extraction: before={before_sha} after={after_sha}"
+        )
+    dirty_after = {
+        k: v
+        for k, v in after_sidecars.items()
+        if v["exists"] and int(v["size"]) > 0
+    }
+    if dirty_after:
+        raise SystemExit(f"REFUSE: non-empty SQLite sidecar appeared: {dirty_after}")
+
+    manifest_path = out / "manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["source_receipt"] = {
+        "before_identity": before_identity,
+        "after_identity": after_identity,
+        "before_sha256": before_sha,
+        "after_sha256": after_sha,
+        "sidecars_before": sidecars,
+        "sidecars_after": after_sidecars,
+    }
+    manifest["elapsed_s"] = round(time.time() - started, 3)
+    manifest_path.write_text(
+        json.dumps(manifest, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
 
     archive = Path(str(out) + ".tar.gz")
     with tarfile.open(archive, "w:gz") as tf:
@@ -692,21 +822,14 @@ def main() -> int:
 
     print(f"evidence_dir={out}")
     print(f"archive={archive}")
-    print(f"sha256={before_sha}")
-    print(f"counts={json.dumps(counts, sort_keys=True)}")
-    print(f"chatgpt_min_message_id={summary['chatgpt_min_message_id']}")
-    print(
-        "precutoff_non_chatgpt_before_first_chatgpt="
-        f"{summary['precutoff_non_chatgpt_before_first_chatgpt_message_id']}"
-    )
-    print(
-        "precutoff_non_chatgpt_at_or_after_first_chatgpt="
-        f"{summary['precutoff_non_chatgpt_at_or_after_first_chatgpt_message_id']}"
-    )
-    print(f"distinct_precutoff_tool_names={summary['distinct_precutoff_tool_names']}")
-    print(f"cross_session_edges={summary['cross_session_edges']}")
-    print(f"precutoff_parent_edges={summary['precutoff_parent_edges']}")
-    print(f"elapsed_s={time.time() - started:.3f}")
+    print(f"sha256={after_sha}")
+    print(f"counts={json.dumps(EXPECTED_COUNTS, sort_keys=True)}")
+    print(f"target_transcripts={len(manifest['target_transcripts_dumped'])}")
+    print(f"june15_cluster_sessions={manifest['june15_cluster_sessions']}")
+    print(f"time_anomalies={manifest['chatgpt_export_time_anomalies_ge_1d']}")
+    print(f"native_fingerprint_candidates={manifest['chatgpt_export_native_fingerprint_candidates']}")
+    print(f"true_prehermes_non_chatgpt={manifest['true_prehermes_non_chatgpt_sessions']}")
+    print(f"elapsed_s={manifest['elapsed_s']}")
     return 0
 
 

--- a/research/chatgpt-import/extract_issue60_stage3.py
+++ b/research/chatgpt-import/extract_issue60_stage3.py
@@ -1,0 +1,714 @@
+#!/usr/bin/env python3
+"""Issue #60 stage-3 read-only provenance shape explorer.
+
+Goal:
+- distinguish pre-2026-06-16 Hermes-shaped rows from the later ChatGPT import;
+- use insertion-order proxies (messages.id), tool-call fingerprints, platform ID
+  shapes, and session field distributions;
+- recover cross-session-search edges that demonstrate live session-store use.
+
+Safety:
+- pins the authoritative frozen DB SHA-256;
+- refuses symlinks and non-empty SQLite sidecars;
+- opens mode=ro&immutable=1 with PRAGMA query_only=ON;
+- performs no schema/temp/journal/FTS/VACUUM writes;
+- verifies file identity + SHA-256 again after extraction.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import re
+import sqlite3
+import stat
+import tarfile
+import time
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from urllib.parse import quote
+from zoneinfo import ZoneInfo
+
+AUTHORITATIVE_PATH = Path(
+    "/home/skywind/hermes-recovery/runs/20260807-081043/state.recovered.patched.db"
+)
+AUTHORITATIVE_SHA256 = "23cfa3c8adb94ed403058329ae7e252e1d4c4bc01ead76e22ac7d0ff99948104"
+EXPECTED_COUNTS = {"sessions": 7268, "messages": 231513, "gateway_routing": 78}
+TAIPEI = ZoneInfo("Asia/Taipei")
+CUTOFF = datetime(2026, 6, 16, 0, 0, 0, tzinfo=TAIPEI).timestamp()
+
+SESSION_ID_RE = re.compile(r"\b(?:\d{8}_\d{6}_[A-Za-z0-9]+|cron_[A-Za-z0-9_]+)\b")
+SNOWFLAKE_RE = re.compile(r"^\d{15,22}$")
+UUID_RE = re.compile(
+    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-"
+    r"[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+)
+
+
+def sha256_file(path: Path, chunk: int = 8 * 1024 * 1024) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        while True:
+            b = f.read(chunk)
+            if not b:
+                break
+            h.update(b)
+    return h.hexdigest()
+
+
+def file_identity(path: Path) -> dict[str, int]:
+    st = path.stat()
+    return {
+        "size": st.st_size,
+        "mtime_ns": st.st_mtime_ns,
+        "inode": st.st_ino,
+        "device": st.st_dev,
+        "mode": stat.S_IMODE(st.st_mode),
+    }
+
+
+def sidecar_receipt(path: Path) -> dict[str, dict[str, int | bool]]:
+    out = {}
+    for suffix in ("-wal", "-shm", "-journal"):
+        p = Path(str(path) + suffix)
+        out[suffix] = {"exists": p.exists(), "size": p.stat().st_size if p.exists() else 0}
+    return out
+
+
+def enforce_safe_source(path: Path, expected_sha: str) -> tuple[str, dict]:
+    if path.is_symlink():
+        raise SystemExit(f"REFUSE: database path is a symlink: {path}")
+    if not path.is_file():
+        raise SystemExit(f"REFUSE: database is not a regular file: {path}")
+    sidecars = sidecar_receipt(path)
+    dirty = {k: v for k, v in sidecars.items() if v["exists"] and int(v["size"]) > 0}
+    if dirty:
+        raise SystemExit(f"REFUSE: frozen source has non-empty SQLite sidecars: {dirty}")
+    actual = sha256_file(path)
+    if actual.lower() != expected_sha.lower():
+        raise SystemExit(
+            "REFUSE: SHA-256 mismatch\n"
+            f" expected={expected_sha}\n actual={actual}\n path={path}"
+        )
+    return actual, sidecars
+
+
+def open_immutable(path: Path) -> sqlite3.Connection:
+    uri = "file:" + quote(str(path.resolve()), safe="/:\\") + "?mode=ro&immutable=1"
+    conn = sqlite3.connect(uri, uri=True, isolation_level=None)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA query_only=ON")
+    if int(conn.execute("PRAGMA query_only").fetchone()[0]) != 1:
+        conn.close()
+        raise RuntimeError("failed to enable PRAGMA query_only")
+    return conn
+
+
+def normalize(value: object) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return str(value)
+
+
+def taipei(epoch: object) -> str:
+    if epoch is None or epoch == "":
+        return ""
+    try:
+        return datetime.fromtimestamp(float(epoch), tz=timezone.utc).astimezone(TAIPEI).isoformat()
+    except (ValueError, TypeError, OSError):
+        return ""
+
+
+def write_tsv(path: Path, rows: list[dict], fieldnames: list[str] | None = None) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if fieldnames is None:
+        fieldnames = []
+        seen = set()
+        for row in rows:
+            for k in row:
+                if k not in seen:
+                    seen.add(k)
+                    fieldnames.append(k)
+    with path.open("w", encoding="utf-8", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=fieldnames, delimiter="\t", extrasaction="ignore")
+        w.writeheader()
+        for row in rows:
+            w.writerow(
+                {
+                    k: normalize(v).replace("\t", "\\t").replace("\r", "\\r").replace("\n", "\\n")
+                    for k, v in row.items()
+                }
+            )
+
+
+def table_columns(conn: sqlite3.Connection, table: str) -> set[str]:
+    return {str(r["name"]) for r in conn.execute(f"PRAGMA table_info({table})")}
+
+
+def scalar(conn: sqlite3.Connection, sql: str, params: tuple = ()) -> object:
+    row = conn.execute(sql, params).fetchone()
+    return row[0] if row else None
+
+
+def percentile_int(values: list[int], q: float) -> int | None:
+    if not values:
+        return None
+    xs = sorted(values)
+    idx = round((len(xs) - 1) * q)
+    return xs[idx]
+
+
+def extract_tool_names(raw: object) -> list[str]:
+    text = normalize(raw).strip()
+    if not text:
+        return []
+    try:
+        value = json.loads(text)
+        if isinstance(value, str):
+            value = json.loads(value)
+    except Exception:
+        return []
+    if isinstance(value, dict) and "tool_calls" in value:
+        value = value["tool_calls"]
+        if isinstance(value, str):
+            try:
+                value = json.loads(value)
+            except Exception:
+                return []
+    if not isinstance(value, list):
+        return []
+    names = []
+    for item in value:
+        if not isinstance(item, dict):
+            continue
+        fn = item.get("function")
+        if isinstance(fn, dict) and fn.get("name"):
+            names.append(str(fn["name"]))
+        elif item.get("name"):
+            names.append(str(item["name"]))
+    return names
+
+
+def platform_shape(value: object) -> str:
+    s = normalize(value).strip()
+    if not s:
+        return "empty"
+    if SNOWFLAKE_RE.fullmatch(s):
+        return "decimal_15_22"
+    if UUID_RE.fullmatch(s):
+        return "uuid"
+    if s.startswith("call_"):
+        return "call_id"
+    return f"other_len_{len(s)}"
+
+
+def sha_prefix(value: object) -> str:
+    s = normalize(value)
+    return hashlib.sha256(s.encode("utf-8", errors="replace")).hexdigest()[:12] if s else ""
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--db", type=Path, default=AUTHORITATIVE_PATH)
+    ap.add_argument("--expected-sha256", default=AUTHORITATIVE_SHA256)
+    ap.add_argument("--output-dir", type=Path)
+    args = ap.parse_args()
+
+    started = time.time()
+    db = args.db
+    before_sha, sidecars = enforce_safe_source(db, args.expected_sha256)
+    before_identity = file_identity(db)
+
+    stamp = datetime.now(TAIPEI).strftime("%Y%m%d-%H%M%S")
+    out = args.output_dir or Path(f"issue60-stage3-evidence-{stamp}")
+    out.mkdir(parents=True, exist_ok=False)
+
+    conn = open_immutable(db)
+    try:
+        counts = {
+            table: int(scalar(conn, f"SELECT COUNT(*) FROM {table}") or 0)
+            for table in EXPECTED_COUNTS
+        }
+        if counts != EXPECTED_COUNTS:
+            raise SystemExit(f"REFUSE: canonical row counts changed: {counts}")
+
+        quick_check = normalize(scalar(conn, "PRAGMA quick_check"))
+        fk_violations = len(conn.execute("PRAGMA foreign_key_check").fetchall())
+
+        scols = table_columns(conn, "sessions")
+
+        # 1) Pre-cutoff source/model/end_reason/lineage distribution.
+        source_rows = []
+        for r in conn.execute(
+            """
+            SELECT s.source,
+                   COUNT(*) AS session_count,
+                   MIN(s.started_at) AS min_started_at,
+                   MAX(s.started_at) AS max_started_at,
+                   SUM(CASE WHEN s.parent_session_id IS NOT NULL AND s.parent_session_id <> '' THEN 1 ELSE 0 END) AS with_parent,
+                   SUM(CASE WHEN s.end_reason = 'compression' THEN 1 ELSE 0 END) AS compression_ended,
+                   SUM(COALESCE(s.message_count, 0)) AS declared_message_count
+            FROM sessions s
+            WHERE s.started_at < ?
+            GROUP BY s.source
+            ORDER BY session_count DESC, s.source
+            """,
+            (CUTOFF,),
+        ):
+            d = dict(r)
+            d["min_started_taipei"] = taipei(d["min_started_at"])
+            d["max_started_taipei"] = taipei(d["max_started_at"])
+            source_rows.append(d)
+        write_tsv(out / "precutoff_source_profile.tsv", source_rows)
+
+        model_rows = [
+            dict(r)
+            for r in conn.execute(
+                """
+                SELECT source, COALESCE(model, '') AS model, COUNT(*) AS session_count
+                FROM sessions
+                WHERE started_at < ?
+                GROUP BY source, COALESCE(model, '')
+                ORDER BY session_count DESC, source, model
+                """,
+                (CUTOFF,),
+            )
+        ]
+        write_tsv(out / "precutoff_model_profile.tsv", model_rows)
+
+        end_rows = [
+            dict(r)
+            for r in conn.execute(
+                """
+                SELECT source, COALESCE(end_reason, '') AS end_reason, COUNT(*) AS session_count
+                FROM sessions
+                WHERE started_at < ?
+                GROUP BY source, COALESCE(end_reason, '')
+                ORDER BY session_count DESC, source, end_reason
+                """,
+                (CUTOFF,),
+            )
+        ]
+        write_tsv(out / "precutoff_end_reason_profile.tsv", end_rows)
+
+        # 2) Message INTEGER PK as an insertion-order proxy.
+        groups = [
+            ("chatgpt_export_all", "s.source = 'chatgpt-export'", ()),
+            ("precutoff_non_chatgpt", "s.started_at < ? AND s.source <> 'chatgpt-export'", (CUTOFF,)),
+            ("precutoff_discord", "s.started_at < ? AND s.source = 'discord'", (CUTOFF,)),
+            ("precutoff_cli", "s.started_at < ? AND s.source = 'cli'", (CUTOFF,)),
+            ("precutoff_cron", "s.started_at < ? AND s.source = 'cron'", (CUTOFF,)),
+        ]
+        insertion_rows = []
+        group_ids: dict[str, list[int]] = {}
+        for name, clause, params in groups:
+            ids = [
+                int(r[0])
+                for r in conn.execute(
+                    f"""
+                    SELECT m.id
+                    FROM messages m
+                    JOIN sessions s ON s.id = m.session_id
+                    WHERE {clause}
+                    ORDER BY m.id
+                    """,
+                    params,
+                )
+            ]
+            group_ids[name] = ids
+            insertion_rows.append(
+                {
+                    "group": name,
+                    "message_rows": len(ids),
+                    "min_id": min(ids) if ids else "",
+                    "p05_id": percentile_int(ids, 0.05) or "",
+                    "p25_id": percentile_int(ids, 0.25) or "",
+                    "median_id": percentile_int(ids, 0.50) or "",
+                    "p75_id": percentile_int(ids, 0.75) or "",
+                    "p95_id": percentile_int(ids, 0.95) or "",
+                    "max_id": max(ids) if ids else "",
+                }
+            )
+        chatgpt_min_id = min(group_ids["chatgpt_export_all"]) if group_ids["chatgpt_export_all"] else None
+        if chatgpt_min_id is not None:
+            pre_ids = group_ids["precutoff_non_chatgpt"]
+            insertion_rows.append(
+                {
+                    "group": "precutoff_non_chatgpt_vs_first_chatgpt",
+                    "message_rows": len(pre_ids),
+                    "min_id": "",
+                    "p05_id": "",
+                    "p25_id": "",
+                    "median_id": "",
+                    "p75_id": "",
+                    "p95_id": "",
+                    "max_id": "",
+                    "before_first_chatgpt_id": sum(i < chatgpt_min_id for i in pre_ids),
+                    "at_or_after_first_chatgpt_id": sum(i >= chatgpt_min_id for i in pre_ids),
+                    "first_chatgpt_message_id": chatgpt_min_id,
+                }
+            )
+        write_tsv(out / "message_id_insertion_profile.tsv", insertion_rows)
+
+        boundary_rows = []
+        if chatgpt_min_id is not None:
+            for r in conn.execute(
+                """
+                SELECT m.id AS message_id, m.session_id, s.source, s.title, s.started_at,
+                       m.role, m.timestamp, m.tool_name, m.platform_message_id
+                FROM messages m
+                JOIN sessions s ON s.id = m.session_id
+                WHERE m.id BETWEEN ? AND ?
+                ORDER BY m.id
+                """,
+                (max(1, chatgpt_min_id - 25), chatgpt_min_id + 25),
+            ):
+                d = dict(r)
+                d["session_started_taipei"] = taipei(d["started_at"])
+                d["message_taipei"] = taipei(d["timestamp"])
+                d["platform_id_shape"] = platform_shape(d["platform_message_id"])
+                d["platform_id_sha12"] = sha_prefix(d["platform_message_id"])
+                d.pop("platform_message_id", None)
+                boundary_rows.append(d)
+        write_tsv(out / "first_chatgpt_message_id_boundary.tsv", boundary_rows)
+
+        # 3) Per-session shape/fingerprint table for pre-cutoff non-ChatGPT rows.
+        selected_session_cols = [
+            c
+            for c in (
+                "id", "source", "title", "model", "started_at", "ended_at", "end_reason",
+                "parent_session_id", "model_config", "session_key", "chat_id", "chat_type",
+                "thread_id", "origin_json", "display_name", "cwd"
+            )
+            if c in scols
+        ]
+        session_sql = ", ".join(f"s.{c}" for c in selected_session_cols)
+        session_rows = []
+        sessions = conn.execute(
+            f"""
+            SELECT {session_sql},
+                   COUNT(m.id) AS actual_messages,
+                   MIN(m.id) AS min_message_id,
+                   MAX(m.id) AS max_message_id,
+                   MIN(m.timestamp) AS min_message_timestamp,
+                   MAX(m.timestamp) AS max_message_timestamp,
+                   SUM(CASE WHEN m.tool_calls IS NOT NULL AND m.tool_calls <> '' THEN 1 ELSE 0 END) AS tool_call_rows,
+                   SUM(CASE WHEN m.tool_name IS NOT NULL AND m.tool_name <> '' THEN 1 ELSE 0 END) AS named_tool_rows,
+                   SUM(CASE WHEN m.platform_message_id IS NOT NULL AND m.platform_message_id <> '' THEN 1 ELSE 0 END) AS platform_id_rows
+            FROM sessions s
+            LEFT JOIN messages m ON m.session_id = s.id
+            WHERE s.started_at < ? AND s.source <> 'chatgpt-export'
+            GROUP BY s.id
+            ORDER BY s.started_at, s.id
+            """,
+            (CUTOFF,),
+        ).fetchall()
+        for r in sessions:
+            d = dict(r)
+            d["started_taipei"] = taipei(d.get("started_at"))
+            d["ended_taipei"] = taipei(d.get("ended_at"))
+            d["min_message_taipei"] = taipei(d.get("min_message_timestamp"))
+            d["max_message_taipei"] = taipei(d.get("max_message_timestamp"))
+            for sensitive in ("chat_id", "thread_id", "session_key", "origin_json"):
+                if sensitive in d:
+                    raw = normalize(d[sensitive])
+                    d[f"{sensitive}_present"] = int(bool(raw))
+                    d[f"{sensitive}_sha12"] = sha_prefix(raw)
+                    d.pop(sensitive, None)
+            session_rows.append(d)
+        write_tsv(out / "precutoff_session_fingerprints.tsv", session_rows)
+
+        # 4) Tool-call fingerprint distribution and earliest occurrences.
+        tool_counter: Counter[tuple[str, str]] = Counter()
+        occurrences = []
+        for r in conn.execute(
+            """
+            SELECT m.id AS message_id, m.session_id, s.source, s.title, s.started_at,
+                   m.timestamp, m.role, m.tool_calls, m.tool_name
+            FROM messages m
+            JOIN sessions s ON s.id = m.session_id
+            WHERE s.started_at < ?
+              AND s.source <> 'chatgpt-export'
+              AND (
+                    (m.tool_calls IS NOT NULL AND m.tool_calls <> '')
+                 OR (m.tool_name IS NOT NULL AND m.tool_name <> '')
+              )
+            ORDER BY m.id
+            """,
+            (CUTOFF,),
+        ):
+            d = dict(r)
+            names = extract_tool_names(d["tool_calls"])
+            if d["tool_name"]:
+                names.append(normalize(d["tool_name"]))
+            names = sorted(set(n for n in names if n))
+            for name in names:
+                tool_counter[(normalize(d["source"]), name)] += 1
+                occurrences.append(
+                    {
+                        "message_id": d["message_id"],
+                        "session_id": d["session_id"],
+                        "source": d["source"],
+                        "title": d["title"],
+                        "session_started_taipei": taipei(d["started_at"]),
+                        "message_taipei": taipei(d["timestamp"]),
+                        "role": d["role"],
+                        "tool_name": name,
+                    }
+                )
+        tool_profile = [
+            {"source": src, "tool_name": name, "occurrences": count}
+            for (src, name), count in sorted(
+                tool_counter.items(), key=lambda kv: (-kv[1], kv[0][0], kv[0][1])
+            )
+        ]
+        write_tsv(out / "precutoff_tool_name_profile.tsv", tool_profile)
+        write_tsv(out / "precutoff_tool_occurrences.tsv", occurrences[:2000])
+
+        # 5) Platform message ID *shape* only; never emit raw platform IDs.
+        shape_counter: Counter[tuple[str, str, str]] = Counter()
+        shape_examples = {}
+        for r in conn.execute(
+            """
+            SELECT m.id AS message_id, m.session_id, s.source, s.title, s.started_at,
+                   m.role, m.timestamp, m.platform_message_id
+            FROM messages m
+            JOIN sessions s ON s.id = m.session_id
+            WHERE s.started_at < ?
+              AND s.source <> 'chatgpt-export'
+              AND m.platform_message_id IS NOT NULL
+              AND m.platform_message_id <> ''
+            ORDER BY m.id
+            """,
+            (CUTOFF,),
+        ):
+            d = dict(r)
+            shape = platform_shape(d["platform_message_id"])
+            key = (normalize(d["source"]), normalize(d["role"]), shape)
+            shape_counter[key] += 1
+            shape_examples.setdefault(
+                key,
+                {
+                    "source": d["source"],
+                    "role": d["role"],
+                    "shape": shape,
+                    "message_id": d["message_id"],
+                    "session_id": d["session_id"],
+                    "title": d["title"],
+                    "session_started_taipei": taipei(d["started_at"]),
+                    "message_taipei": taipei(d["timestamp"]),
+                    "platform_id_sha12": sha_prefix(d["platform_message_id"]),
+                    "platform_id_length": len(normalize(d["platform_message_id"])),
+                },
+            )
+        shape_profile = [
+            {"source": src, "role": role, "shape": shape, "count": count}
+            for (src, role, shape), count in sorted(
+                shape_counter.items(), key=lambda kv: (-kv[1], kv[0])
+            )
+        ]
+        write_tsv(out / "platform_message_id_shape_profile.tsv", shape_profile)
+        write_tsv(out / "platform_message_id_shape_examples.tsv", list(shape_examples.values()))
+
+        # 6) Cross-session search edges. This is deliberately narrow: tool rows
+        # whose tool_name names session_search, plus JSON-ish outputs containing
+        # "session_id". Emit session IDs but not message contents.
+        known_sessions = {r[0] for r in conn.execute("SELECT id FROM sessions")}
+        edges = []
+        edge_seen = set()
+        for r in conn.execute(
+            """
+            SELECT m.id AS message_id, m.session_id, s.source, s.title, s.started_at,
+                   m.timestamp, m.tool_name, m.content
+            FROM messages m
+            JOIN sessions s ON s.id = m.session_id
+            WHERE s.started_at < ?
+              AND s.source <> 'chatgpt-export'
+              AND (
+                    LOWER(COALESCE(m.tool_name, '')) LIKE '%session%search%'
+                 OR m.content LIKE '%"session_id"%'
+              )
+            ORDER BY m.id
+            """,
+            (CUTOFF,),
+        ):
+            d = dict(r)
+            refs = sorted(set(SESSION_ID_RE.findall(normalize(d["content"]))))
+            for ref in refs:
+                if ref == d["session_id"] or ref not in known_sessions:
+                    continue
+                key = (d["message_id"], d["session_id"], ref)
+                if key in edge_seen:
+                    continue
+                edge_seen.add(key)
+                target = conn.execute(
+                    "SELECT source, title, started_at FROM sessions WHERE id = ?",
+                    (ref,),
+                ).fetchone()
+                edges.append(
+                    {
+                        "message_id": d["message_id"],
+                        "from_session_id": d["session_id"],
+                        "from_source": d["source"],
+                        "from_title": d["title"],
+                        "from_started_taipei": taipei(d["started_at"]),
+                        "message_taipei": taipei(d["timestamp"]),
+                        "tool_name": d["tool_name"],
+                        "to_session_id": ref,
+                        "to_source": target["source"] if target else "",
+                        "to_title": target["title"] if target else "",
+                        "to_started_taipei": taipei(target["started_at"]) if target else "",
+                    }
+                )
+        write_tsv(out / "precutoff_session_search_edges.tsv", edges)
+
+        # 7) Earliest high-signal rows: tool usage and lineage.
+        write_tsv(out / "earliest_precutoff_tool_fingerprints.tsv", occurrences[:100])
+
+        parent_rows = []
+        for r in conn.execute(
+            """
+            SELECT s.id, s.source, s.title, s.started_at, s.parent_session_id, s.end_reason,
+                   p.source AS parent_source, p.title AS parent_title, p.started_at AS parent_started_at
+            FROM sessions s
+            LEFT JOIN sessions p ON p.id = s.parent_session_id
+            WHERE s.started_at < ?
+              AND s.parent_session_id IS NOT NULL
+              AND s.parent_session_id <> ''
+            ORDER BY s.started_at, s.id
+            """,
+            (CUTOFF,),
+        ):
+            d = dict(r)
+            d["started_taipei"] = taipei(d["started_at"])
+            d["parent_started_taipei"] = taipei(d["parent_started_at"])
+            parent_rows.append(d)
+        write_tsv(out / "precutoff_parent_edges.tsv", parent_rows)
+
+        first_chatgpt = None
+        if chatgpt_min_id is not None:
+            r = conn.execute(
+                """
+                SELECT m.id AS message_id, m.session_id, s.title, s.started_at,
+                       m.timestamp, m.role, m.platform_message_id
+                FROM messages m JOIN sessions s ON s.id=m.session_id
+                WHERE m.id=?
+                """,
+                (chatgpt_min_id,),
+            ).fetchone()
+            if r:
+                first_chatgpt = dict(r)
+                first_chatgpt["session_started_taipei"] = taipei(first_chatgpt["started_at"])
+                first_chatgpt["message_taipei"] = taipei(first_chatgpt["timestamp"])
+                first_chatgpt["platform_id_shape"] = platform_shape(first_chatgpt["platform_message_id"])
+                first_chatgpt["platform_id_sha12"] = sha_prefix(first_chatgpt["platform_message_id"])
+                first_chatgpt.pop("platform_message_id", None)
+
+        summary = {
+            "cutoff_taipei": datetime.fromtimestamp(CUTOFF, tz=timezone.utc).astimezone(TAIPEI).isoformat(),
+            "chatgpt_min_message_id": chatgpt_min_id,
+            "precutoff_non_chatgpt_messages": len(group_ids["precutoff_non_chatgpt"]),
+            "precutoff_non_chatgpt_before_first_chatgpt_message_id": (
+                sum(i < chatgpt_min_id for i in group_ids["precutoff_non_chatgpt"])
+                if chatgpt_min_id is not None else None
+            ),
+            "precutoff_non_chatgpt_at_or_after_first_chatgpt_message_id": (
+                sum(i >= chatgpt_min_id for i in group_ids["precutoff_non_chatgpt"])
+                if chatgpt_min_id is not None else None
+            ),
+            "distinct_precutoff_tool_names": len({name for _, name in tool_counter}),
+            "precutoff_tool_occurrences": len(occurrences),
+            "cross_session_edges": len(edges),
+            "precutoff_parent_edges": len(parent_rows),
+            "first_chatgpt_message": first_chatgpt,
+        }
+
+        (out / "README.md").write_text(
+            "# Issue #60 stage-3 provenance-shape evidence\n\n"
+            "Purpose: distinguish pre-2026-06-16 Hermes-shaped rows from the later "
+            "ChatGPT import using insertion-order proxies and runtime fingerprints.\n\n"
+            "Key outputs:\n\n"
+            "- `message_id_insertion_profile.tsv`: SQLite message PK distributions; "
+            "`messages.id` is used only as an insertion-order proxy, not a historical timestamp.\n"
+            "- `first_chatgpt_message_id_boundary.tsv`: rows around the first final "
+            "`chatgpt-export` message ID.\n"
+            "- `precutoff_tool_name_profile.tsv` / `precutoff_tool_occurrences.tsv`: "
+            "tool-call fingerprints before the cutoff.\n"
+            "- `platform_message_id_shape_profile.tsv`: only shape categories; raw "
+            "platform IDs are never emitted.\n"
+            "- `precutoff_session_search_edges.tsv`: cross-session references emitted "
+            "without message bodies.\n"
+            "- `precutoff_parent_edges.tsv`: session lineage already present before cutoff.\n"
+            "- `precutoff_session_fingerprints.tsv`: bounded field/message summaries.\n\n"
+            "Interpretation discipline:\n\n"
+            "- Low message IDs relative to the first `chatgpt-export` row are evidence "
+            "about insertion order only.\n"
+            "- Tool names / platform-ID shapes are fingerprints, not by themselves proof "
+            "of which program produced a row.\n"
+            "- Cross-session references and multiple independent fingerprints together "
+            "can support a stronger provenance conclusion.\n",
+            encoding="utf-8",
+        )
+
+        after_identity = file_identity(db)
+        after_sha = sha256_file(db)
+        if after_identity != before_identity:
+            raise SystemExit(f"REFUSE: source identity changed during extraction: {before_identity} -> {after_identity}")
+        if after_sha != before_sha:
+            raise SystemExit(f"REFUSE: source SHA changed during extraction: {before_sha} -> {after_sha}")
+
+        manifest = {
+            "source": {
+                "path": str(db),
+                "sha256": before_sha,
+                "before_identity": before_identity,
+                "after_identity": after_identity,
+                "sidecars": sidecars,
+                "opened_mode": "mode=ro&immutable=1; PRAGMA query_only=ON",
+                "mutations_performed": 0,
+            },
+            "counts": counts,
+            "quick_check": quick_check,
+            "foreign_key_violations": fk_violations,
+            "cutoff_epoch": CUTOFF,
+            "cutoff_taipei": datetime.fromtimestamp(CUTOFF, tz=timezone.utc).astimezone(TAIPEI).isoformat(),
+            "summary": summary,
+            "elapsed_s": round(time.time() - started, 3),
+        }
+        (out / "manifest.json").write_text(
+            json.dumps(manifest, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+    finally:
+        conn.close()
+
+    archive = Path(str(out) + ".tar.gz")
+    with tarfile.open(archive, "w:gz") as tf:
+        tf.add(out, arcname=out.name)
+
+    print(f"evidence_dir={out}")
+    print(f"archive={archive}")
+    print(f"sha256={before_sha}")
+    print(f"counts={json.dumps(counts, sort_keys=True)}")
+    print(f"chatgpt_min_message_id={summary['chatgpt_min_message_id']}")
+    print(
+        "precutoff_non_chatgpt_before_first_chatgpt="
+        f"{summary['precutoff_non_chatgpt_before_first_chatgpt_message_id']}"
+    )
+    print(
+        "precutoff_non_chatgpt_at_or_after_first_chatgpt="
+        f"{summary['precutoff_non_chatgpt_at_or_after_first_chatgpt_message_id']}"
+    )
+    print(f"distinct_precutoff_tool_names={summary['distinct_precutoff_tool_names']}")
+    print(f"cross_session_edges={summary['cross_session_edges']}")
+    print(f"precutoff_parent_edges={summary['precutoff_parent_edges']}")
+    print(f"elapsed_s={time.time() - started:.3f}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/research/chatgpt-import/extract_issue60_stage4.py
+++ b/research/chatgpt-import/extract_issue60_stage4.py
@@ -1,0 +1,575 @@
+#!/usr/bin/env python3
+"""Issue #60 stage-4 read-only provenance classifier.
+
+Purpose:
+- classify final chatgpt-export rows by model_config field shape;
+- measure stored message_count drift versus actual message rows;
+- check full generated-session-ID consistency against started_at + conversation_id;
+- locate the two known empty/non-UUID platform_message_id cases;
+- further reduce the residual native-session collision/relabel hypothesis.
+
+This extractor is deliberately DB-only. It does not need the original ChatGPT ZIP.
+It opens the canonical recovered DB immutable + query_only and fails closed on
+SHA/count/sidecar changes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import sqlite3
+import tarfile
+import time
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+AUTHORITATIVE_PATH = Path(
+    "/home/skywind/hermes-recovery/runs/20260807-081043/state.recovered.patched.db"
+)
+AUTHORITATIVE_SHA256 = "23cfa3c8adb94ed403058329ae7e252e1d4c4bc01ead76e22ac7d0ff99948104"
+EXPECTED_COUNTS = {
+    "sessions": 7268,
+    "messages": 231513,
+    "gateway_routing": 78,
+}
+
+FINAL_IMPORTER_KEYS = {
+    "chatgpt_conversation_id",
+    "chatgpt_gpt_id",
+    "chatgpt_is_archived",
+    "chatgpt_is_starred",
+}
+# Historical transcript explicitly records the first 57 test imports writing
+# chatgpt_memory_scope, then backfilling chatgpt_conversation_id.
+EARLY_TEST_SIGNATURE_KEY = "chatgpt_memory_scope"
+
+JUNE15_CLUSTER_LO = "20260615_050000_"
+JUNE15_CLUSTER_HI = "20260615_050200_"
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(8 * 1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def file_identity(path: Path) -> dict[str, Any]:
+    st = path.stat()
+    return {
+        "dev": st.st_dev,
+        "ino": st.st_ino,
+        "size": st.st_size,
+        "mtime_ns": st.st_mtime_ns,
+    }
+
+
+def sidecar_receipt(path: Path) -> dict[str, dict[str, Any]]:
+    out = {}
+    for suffix in ("-wal", "-shm", "-journal"):
+        p = Path(str(path) + suffix)
+        if p.exists():
+            st = p.stat()
+            out[suffix] = {"exists": True, "size": st.st_size, "mtime_ns": st.st_mtime_ns}
+        else:
+            out[suffix] = {"exists": False, "size": 0, "mtime_ns": None}
+    return out
+
+
+def enforce_safe_source(path: Path, expected_sha: str):
+    if not path.is_file():
+        raise SystemExit(f"REFUSE: canonical DB missing: {path}")
+    before_sha = sha256_file(path)
+    if before_sha != expected_sha:
+        raise SystemExit(
+            f"REFUSE: canonical SHA mismatch: expected={expected_sha} actual={before_sha}"
+        )
+    sidecars = sidecar_receipt(path)
+    dirty = {k: v for k, v in sidecars.items() if v["exists"] and int(v["size"]) > 0}
+    if dirty:
+        raise SystemExit(f"REFUSE: non-empty SQLite sidecar present: {dirty}")
+    return before_sha, sidecars
+
+
+def open_immutable(path: Path) -> sqlite3.Connection:
+    uri = f"file:{path}?mode=ro&immutable=1"
+    conn = sqlite3.connect(uri, uri=True)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA query_only=ON")
+    return conn
+
+
+def scalar(conn: sqlite3.Connection, sql: str, params=()):
+    row = conn.execute(sql, params).fetchone()
+    return None if row is None else row[0]
+
+
+def normalize(v: Any) -> str:
+    if v is None:
+        return ""
+    if isinstance(v, bytes):
+        return v.hex()
+    return str(v).replace("\r\n", "\n").replace("\r", "\n")
+
+
+def write_tsv(path: Path, rows: list[dict[str, Any]]) -> None:
+    if not rows:
+        path.write_text("", encoding="utf-8")
+        return
+    fields = []
+    seen = set()
+    for row in rows:
+        for k in row:
+            if k not in seen:
+                seen.add(k)
+                fields.append(k)
+    with path.open("w", encoding="utf-8", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=fields, delimiter="\t", lineterminator="\n")
+        w.writeheader()
+        for row in rows:
+            w.writerow({k: normalize(row.get(k)) for k in fields})
+
+
+def model_config_obj(raw: Any) -> dict[str, Any]:
+    if raw in (None, ""):
+        return {}
+    try:
+        obj = json.loads(raw)
+    except (TypeError, json.JSONDecodeError):
+        return {"__invalid_json__": True}
+    return obj if isinstance(obj, dict) else {"__non_object_json__": True}
+
+
+def conv_id(mc: dict[str, Any]) -> str:
+    v = mc.get("chatgpt_conversation_id")
+    return v if isinstance(v, str) else ""
+
+
+def utc_session_prefix(ts: Any) -> str:
+    if ts in (None, ""):
+        return ""
+    try:
+        return datetime.fromtimestamp(float(ts), tz=timezone.utc).strftime("%Y%m%d_%H%M%S")
+    except (TypeError, ValueError, OSError):
+        return ""
+
+
+def uuid_shape(value: Any) -> str:
+    s = normalize(value)
+    if not s:
+        return "empty"
+    parts = s.split("-")
+    if len(parts) == 5 and [len(x) for x in parts] == [8, 4, 4, 4, 12]:
+        try:
+            int("".join(parts), 16)
+            return "uuid"
+        except ValueError:
+            pass
+    return "other"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--db", type=Path, default=AUTHORITATIVE_PATH)
+    ap.add_argument("--expected-sha256", default=AUTHORITATIVE_SHA256)
+    ap.add_argument("--output-dir", type=Path)
+    args = ap.parse_args()
+
+    started = time.time()
+    before_sha, sidecars_before = enforce_safe_source(args.db, args.expected_sha256)
+    identity_before = file_identity(args.db)
+
+    stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    out = args.output_dir or Path(f"issue60-stage4-evidence-{stamp}")
+    out.mkdir(parents=True, exist_ok=False)
+
+    conn = open_immutable(args.db)
+    try:
+        counts = {
+            table: int(scalar(conn, f"SELECT COUNT(*) FROM {table}") or 0)
+            for table in EXPECTED_COUNTS
+        }
+        if counts != EXPECTED_COUNTS:
+            raise SystemExit(f"REFUSE: canonical row counts changed: {counts}")
+        quick_check = normalize(scalar(conn, "PRAGMA quick_check"))
+        fk_violations = len(conn.execute("PRAGMA foreign_key_check").fetchall())
+
+        msg_agg = {}
+        for r in conn.execute(
+            """
+            SELECT s.id AS session_id,
+                   COUNT(m.id) AS actual_messages,
+                   MIN(m.id) AS min_message_id,
+                   MAX(m.id) AS max_message_id,
+                   MIN(m.timestamp) AS min_message_timestamp,
+                   MAX(m.timestamp) AS max_message_timestamp,
+                   SUM(CASE WHEN COALESCE(m.platform_message_id,'')='' THEN 1 ELSE 0 END)
+                       AS empty_platform_ids,
+                   SUM(CASE WHEN COALESCE(m.tool_name,'')<>'' THEN 1 ELSE 0 END)
+                       AS tool_name_rows,
+                   SUM(CASE WHEN COALESCE(m.tool_calls,'')<>'' THEN 1 ELSE 0 END)
+                       AS tool_call_rows
+            FROM sessions s
+            LEFT JOIN messages m ON m.session_id=s.id
+            WHERE s.source='chatgpt-export'
+            GROUP BY s.id
+            """
+        ):
+            msg_agg[r["session_id"]] = dict(r)
+
+        sessions = conn.execute(
+            """
+            SELECT id, title, source, user_id, model, model_config,
+                   started_at, ended_at, message_count,
+                   display_name, parent_session_id, end_reason, cwd,
+                   session_key, chat_id, chat_type, thread_id, origin_json
+            FROM sessions
+            WHERE source='chatgpt-export'
+            ORDER BY id
+            """
+        ).fetchall()
+
+        key_counts = Counter()
+        profile_counts = Counter()
+        legacy_extra_key_counts = Counter()
+        profile_examples: dict[str, list[str]] = {}
+        early_signature_rows = []
+        drift_rows = []
+        id_mismatch_rows = []
+        residual_rows = []
+        june15_rows = []
+
+        for r in sessions:
+            d = dict(r)
+            sid = d["id"]
+            mc = model_config_obj(d.get("model_config"))
+            keys = sorted(mc.keys())
+            key_profile = ",".join(keys)
+            profile_counts[key_profile] += 1
+            profile_examples.setdefault(key_profile, [])
+            if len(profile_examples[key_profile]) < 5:
+                profile_examples[key_profile].append(sid)
+            for k in keys:
+                key_counts[k] += 1
+
+            extra_keys = sorted(k for k in keys if k not in FINAL_IMPORTER_KEYS)
+            for k in extra_keys:
+                legacy_extra_key_counts[k] += 1
+
+            cid = conv_id(mc)
+            prefix = utc_session_prefix(d.get("started_at"))
+            expected_id = f"{prefix}_{cid[:8]}" if cid and prefix else ""
+            full_id_matches = bool(expected_id) and sid == expected_id
+            user_id_matches = bool(cid) and d.get("user_id") == cid
+            a = msg_agg.get(sid, {})
+            stored_count = int(d.get("message_count") or 0)
+            actual_count = int(a.get("actual_messages") or 0)
+            drift = actual_count - stored_count
+
+            if EARLY_TEST_SIGNATURE_KEY in mc:
+                early_signature_rows.append(
+                    {
+                        "session_id": sid,
+                        "title": d.get("title"),
+                        "model_config_keys": key_profile,
+                        "stored_message_count": stored_count,
+                        "actual_messages": actual_count,
+                        "message_count_delta": drift,
+                        "min_message_id": a.get("min_message_id"),
+                        "max_message_id": a.get("max_message_id"),
+                        "full_generated_id_matches": int(full_id_matches),
+                        "user_id_matches_conv_id": int(user_id_matches),
+                    }
+                )
+
+            if drift != 0:
+                drift_rows.append(
+                    {
+                        "session_id": sid,
+                        "title": d.get("title"),
+                        "stored_message_count": stored_count,
+                        "actual_messages": actual_count,
+                        "message_count_delta": drift,
+                        "min_message_id": a.get("min_message_id"),
+                        "max_message_id": a.get("max_message_id"),
+                        "model_config_keys": key_profile,
+                        "legacy_extra_keys": ",".join(extra_keys),
+                        "full_generated_id_matches": int(full_id_matches),
+                    }
+                )
+
+            if not full_id_matches:
+                id_mismatch_rows.append(
+                    {
+                        "session_id": sid,
+                        "title": d.get("title"),
+                        "started_at": d.get("started_at"),
+                        "conversation_id": cid,
+                        "expected_generated_id": expected_id,
+                        "model_config_keys": key_profile,
+                    }
+                )
+
+            native_fields = [
+                name for name in (
+                    "display_name", "parent_session_id", "end_reason", "cwd",
+                    "session_key", "chat_id", "chat_type", "thread_id", "origin_json",
+                )
+                if d.get(name) not in (None, "")
+            ]
+            residual_reasons = []
+            if not cid:
+                residual_reasons.append("missing_conversation_id")
+            if not full_id_matches:
+                residual_reasons.append("generated_id_mismatch")
+            if cid and not user_id_matches:
+                residual_reasons.append("user_id_mismatch")
+            if native_fields:
+                residual_reasons.append("native_session_fields:" + ",".join(native_fields))
+            if int(a.get("tool_name_rows") or 0):
+                residual_reasons.append("message_tool_name")
+            if int(a.get("tool_call_rows") or 0):
+                residual_reasons.append("message_tool_calls")
+            if residual_reasons:
+                residual_rows.append(
+                    {
+                        "session_id": sid,
+                        "title": d.get("title"),
+                        "reasons": ";".join(residual_reasons),
+                        "conversation_id": cid,
+                        "expected_generated_id": expected_id,
+                        "model_config_keys": key_profile,
+                        "stored_message_count": stored_count,
+                        "actual_messages": actual_count,
+                        "min_message_id": a.get("min_message_id"),
+                        "max_message_id": a.get("max_message_id"),
+                    }
+                )
+
+            if JUNE15_CLUSTER_LO <= sid < JUNE15_CLUSTER_HI:
+                june15_rows.append(
+                    {
+                        "session_id": sid,
+                        "title": d.get("title"),
+                        "model_config_keys": key_profile,
+                        "legacy_extra_keys": ",".join(extra_keys),
+                        "has_memory_scope_signature": int(EARLY_TEST_SIGNATURE_KEY in mc),
+                        "stored_message_count": stored_count,
+                        "actual_messages": actual_count,
+                        "message_count_delta": drift,
+                        "min_message_id": a.get("min_message_id"),
+                        "max_message_id": a.get("max_message_id"),
+                        "full_generated_id_matches": int(full_id_matches),
+                        "user_id_matches_conv_id": int(user_id_matches),
+                    }
+                )
+
+        profile_rows = []
+        for profile, n in profile_counts.most_common():
+            keys = [k for k in profile.split(",") if k]
+            profile_rows.append(
+                {
+                    "model_config_keys": profile,
+                    "sessions": n,
+                    "legacy_extra_keys": ",".join(
+                        k for k in keys if k not in FINAL_IMPORTER_KEYS
+                    ),
+                    "example_session_ids": ",".join(profile_examples.get(profile, [])),
+                }
+            )
+
+        write_tsv(
+            out / "chatgpt_model_config_key_counts.tsv",
+            [{"key": k, "sessions": n} for k, n in key_counts.most_common()],
+        )
+        write_tsv(out / "chatgpt_model_config_profiles.tsv", profile_rows)
+        write_tsv(
+            out / "legacy_extra_key_counts.tsv",
+            [{"key": k, "sessions": n} for k, n in legacy_extra_key_counts.most_common()],
+        )
+        write_tsv(out / "memory_scope_signature_sessions.tsv", early_signature_rows)
+        drift_rows.sort(key=lambda x: (-abs(int(x["message_count_delta"])), x["session_id"]))
+        write_tsv(out / "message_count_drift.tsv", drift_rows)
+        write_tsv(out / "generated_session_id_mismatches.tsv", id_mismatch_rows)
+        write_tsv(out / "collision_relabel_residual_candidates.tsv", residual_rows)
+        write_tsv(out / "june15_cluster_pass_profile.tsv", june15_rows)
+
+        platform_rows = []
+        platform_shape_counts = Counter()
+        for r in conn.execute(
+            """
+            SELECT m.id AS message_id, m.session_id, m.role, m.timestamp,
+                   m.platform_message_id
+            FROM messages m
+            JOIN sessions s ON s.id=m.session_id
+            WHERE s.source='chatgpt-export'
+            ORDER BY m.id
+            """
+        ):
+            shape = uuid_shape(r["platform_message_id"])
+            platform_shape_counts[shape] += 1
+            if shape != "uuid":
+                platform_rows.append(
+                    {
+                        "message_id": r["message_id"],
+                        "session_id": r["session_id"],
+                        "role": r["role"],
+                        "timestamp": r["timestamp"],
+                        "platform_id_shape": shape,
+                        "platform_message_id": r["platform_message_id"],
+                    }
+                )
+        write_tsv(
+            out / "platform_message_id_shapes.tsv",
+            [{"shape": k, "message_rows": n} for k, n in platform_shape_counts.most_common()],
+        )
+        write_tsv(out / "non_uuid_or_empty_platform_message_ids.tsv", platform_rows)
+
+        duplicate_platform_rows = []
+        for r in conn.execute(
+            """
+            SELECT m.platform_message_id, COUNT(*) AS copies,
+                   COUNT(DISTINCT m.session_id) AS sessions,
+                   MIN(m.id) AS min_message_id, MAX(m.id) AS max_message_id
+            FROM messages m
+            JOIN sessions s ON s.id=m.session_id
+            WHERE s.source='chatgpt-export'
+              AND COALESCE(m.platform_message_id,'')<>''
+            GROUP BY m.platform_message_id
+            HAVING COUNT(*) > 1
+            ORDER BY copies DESC, min_message_id
+            """
+        ):
+            duplicate_platform_rows.append(dict(r))
+        write_tsv(out / "duplicate_platform_message_ids.tsv", duplicate_platform_rows)
+
+        summary = {
+            "canonical_db": {
+                "path": str(args.db),
+                "sha256": before_sha,
+                "counts": counts,
+                "quick_check": quick_check,
+                "foreign_key_violations": fk_violations,
+                "opened_mode": "mode=ro&immutable=1 + PRAGMA query_only=ON",
+                "mutations_performed": False,
+            },
+            "chatgpt_export_sessions": len(sessions),
+            "model_config_key_counts": dict(key_counts),
+            "model_config_profile_count": len(profile_counts),
+            "legacy_extra_key_counts": dict(legacy_extra_key_counts),
+            "memory_scope_signature_sessions": len(early_signature_rows),
+            "message_count_drift_sessions": len(drift_rows),
+            "generated_session_id_mismatches": len(id_mismatch_rows),
+            "collision_relabel_residual_candidates": len(residual_rows),
+            "june15_cluster_sessions": len(june15_rows),
+            "platform_message_id_shapes": dict(platform_shape_counts),
+            "non_uuid_or_empty_platform_message_ids": len(platform_rows),
+            "duplicate_platform_message_ids": len(duplicate_platform_rows),
+            "interpretation": {
+                "memory_scope_signature": (
+                    "Historical transcript proves the first 57 test imports wrote "
+                    "chatgpt_memory_scope and later backfilled conversation_id. "
+                    "Presence is a pass-shape fingerprint, not by itself unique proof "
+                    "that a row is one of those exact 57."
+                ),
+                "final_importer_keys": sorted(FINAL_IMPORTER_KEYS),
+                "generated_id_check": (
+                    "Uses UTC started_at because the historical importer ran on the VM "
+                    "whose timestamp-prefixed session IDs correspond to UTC."
+                ),
+                "collision_residual": (
+                    "A zero residual count would strongly reduce, not logically eliminate, "
+                    "the possibility that IntegrityError->UPDATE source hit a native row."
+                ),
+            },
+        }
+        (out / "manifest.json").write_text(
+            json.dumps(summary, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+        )
+        (out / "README.md").write_text(
+            """# Issue #60 stage-4 evidence
+
+This is a narrow pass-classification/collision audit over the canonical recovered DB.
+
+High-value outputs:
+
+- `chatgpt_model_config_key_counts.tsv` / `chatgpt_model_config_profiles.tsv`
+  classify surviving importer generations by field shape.
+- `memory_scope_signature_sessions.tsv` locates the historical early-test signature
+  documented in the June-16 transcript.
+- `message_count_drift.tsv` identifies sessions later appended/changed without the
+  stored session-level count being refreshed.
+- `generated_session_id_mismatches.tsv` checks the complete
+  `UTC(started_at) + conversation_id[:8]` identity relation.
+- `collision_relabel_residual_candidates.tsv` combines ID/user/native-field/tool
+  fingerprints into the remaining source-relabel collision candidates.
+- `non_uuid_or_empty_platform_message_ids.tsv` explains the tiny gap between total
+  imported messages and non-empty UUID platform IDs.
+- `duplicate_platform_message_ids.tsv` checks whether a ChatGPT message UUID appears
+  more than once in the final imported corpus.
+- `june15_cluster_pass_profile.tsv` revisits the 23-row June-15 cluster using pass
+  fingerprints instead of treating `started_at` as insertion time.
+
+`messages.id` remains only an insertion-order proxy.
+No write/migration/rebuild/VACUUM is performed.
+""",
+            encoding="utf-8",
+        )
+    finally:
+        conn.close()
+
+    identity_after = file_identity(args.db)
+    after_sha = sha256_file(args.db)
+    sidecars_after = sidecar_receipt(args.db)
+    if identity_after != identity_before:
+        raise SystemExit(
+            f"REFUSE: DB identity changed: before={identity_before} after={identity_after}"
+        )
+    if after_sha != before_sha:
+        raise SystemExit(f"REFUSE: DB SHA changed: before={before_sha} after={after_sha}")
+    dirty_after = {
+        k: v for k, v in sidecars_after.items() if v["exists"] and int(v["size"]) > 0
+    }
+    if dirty_after:
+        raise SystemExit(f"REFUSE: non-empty SQLite sidecar appeared: {dirty_after}")
+
+    manifest_path = out / "manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["source_receipt"] = {
+        "before_identity": identity_before,
+        "after_identity": identity_after,
+        "before_sha256": before_sha,
+        "after_sha256": after_sha,
+        "sidecars_before": sidecars_before,
+        "sidecars_after": sidecars_after,
+    }
+    manifest["elapsed_s"] = round(time.time() - started, 3)
+    manifest_path.write_text(
+        json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+    )
+
+    archive = Path(str(out) + ".tar.gz")
+    with tarfile.open(archive, "w:gz") as tf:
+        tf.add(out, arcname=out.name)
+
+    print(f"evidence_dir={out}")
+    print(f"archive={archive}")
+    print(f"sha256={after_sha}")
+    print(f"counts={json.dumps(EXPECTED_COUNTS, sort_keys=True)}")
+    print(f"memory_scope_signature_sessions={manifest['memory_scope_signature_sessions']}")
+    print(f"message_count_drift_sessions={manifest['message_count_drift_sessions']}")
+    print(f"generated_id_mismatches={manifest['generated_session_id_mismatches']}")
+    print(f"collision_residual_candidates={manifest['collision_relabel_residual_candidates']}")
+    print(f"non_uuid_or_empty_platform_ids={manifest['non_uuid_or_empty_platform_message_ids']}")
+    print(f"duplicate_platform_message_ids={manifest['duplicate_platform_message_ids']}")
+    print(f"elapsed_s={manifest['elapsed_s']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/research/chatgpt-import/extract_issue60_stage5.py
+++ b/research/chatgpt-import/extract_issue60_stage5.py
@@ -1,0 +1,415 @@
+#!/usr/bin/env python3
+"""Issue #60 stage-5 DB-only closure audit.
+
+Narrow goals after Stage 4:
+1. prove the 4,655 `user_id` mismatches are an importer-generation partition,
+   not native collision fingerprints;
+2. explain all `message_count` drift as repeated message insertion/replay;
+3. classify duplicate ChatGPT message UUIDs as within-session replay vs
+   cross-session exact clones/conflicts;
+4. inspect the repaired v1 orphan without publishing raw private content;
+5. summarize surviving imported message-field shape for the final fidelity note.
+
+No original ChatGPT export is required. The canonical DB is opened immutable +
+query_only and SHA/count/sidecar identity is checked before and after.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import sqlite3
+import tarfile
+import time
+from collections import Counter, defaultdict
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+AUTHORITATIVE_PATH = Path(
+    "/home/skywind/hermes-recovery/runs/20260807-081043/state.recovered.patched.db"
+)
+AUTHORITATIVE_SHA256 = "23cfa3c8adb94ed403058329ae7e252e1d4c4bc01ead76e22ac7d0ff99948104"
+EXPECTED_COUNTS = {"sessions": 7268, "messages": 231513, "gateway_routing": 78}
+ORPHAN_SESSION = "20231013_125540_0041efa3"
+FINAL_IMPORTER_KEYS = {
+    "chatgpt_conversation_id", "chatgpt_gpt_id", "chatgpt_is_archived", "chatgpt_is_starred"
+}
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(8 * 1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def sha12(value: Any) -> str:
+    if value in (None, ""):
+        return ""
+    if isinstance(value, bytes):
+        value = value.hex()
+    return hashlib.sha256(str(value).encode("utf-8", errors="replace")).hexdigest()[:12]
+
+
+def file_identity(path: Path) -> dict[str, Any]:
+    st = path.stat()
+    return {"dev": st.st_dev, "ino": st.st_ino, "size": st.st_size, "mtime_ns": st.st_mtime_ns}
+
+
+def sidecars(path: Path) -> dict[str, dict[str, Any]]:
+    out = {}
+    for suffix in ("-wal", "-shm", "-journal"):
+        p = Path(str(path) + suffix)
+        out[suffix] = {
+            "exists": p.exists(),
+            "size": p.stat().st_size if p.exists() else 0,
+            "mtime_ns": p.stat().st_mtime_ns if p.exists() else None,
+        }
+    return out
+
+
+def enforce_safe_source(path: Path, expected_sha: str):
+    if path.is_symlink() or not path.is_file():
+        raise SystemExit(f"REFUSE: canonical DB path is not a regular file: {path}")
+    dirty = {k: v for k, v in sidecars(path).items() if v["exists"] and int(v["size"]) > 0}
+    if dirty:
+        raise SystemExit(f"REFUSE: non-empty SQLite sidecar present: {dirty}")
+    actual = sha256_file(path)
+    if actual != expected_sha:
+        raise SystemExit(f"REFUSE: SHA mismatch: expected={expected_sha} actual={actual}")
+    return actual
+
+
+def open_immutable(path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(f"file:{path}?mode=ro&immutable=1", uri=True)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA query_only=ON")
+    return conn
+
+
+def scalar(conn: sqlite3.Connection, sql: str, params=()):
+    row = conn.execute(sql, params).fetchone()
+    return None if row is None else row[0]
+
+
+def mc_obj(raw: Any) -> dict[str, Any]:
+    if raw in (None, ""):
+        return {}
+    try:
+        obj = json.loads(raw)
+    except Exception:
+        return {"__invalid__": True}
+    return obj if isinstance(obj, dict) else {"__non_object__": True}
+
+
+def normalize(v: Any) -> str:
+    if v is None:
+        return ""
+    if isinstance(v, bytes):
+        return v.hex()
+    return str(v).replace("\r\n", "\n").replace("\r", "\n")
+
+
+def write_tsv(path: Path, rows: list[dict[str, Any]]) -> None:
+    if not rows:
+        path.write_text("", encoding="utf-8")
+        return
+    fields, seen = [], set()
+    for row in rows:
+        for k in row:
+            if k not in seen:
+                seen.add(k); fields.append(k)
+    with path.open("w", encoding="utf-8", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=fields, delimiter="\t", lineterminator="\n")
+        w.writeheader()
+        for row in rows:
+            w.writerow({k: normalize(row.get(k)) for k in fields})
+
+
+def message_signature(row: dict[str, Any]) -> tuple:
+    """Fields expected to remain identical when the same ChatGPT node is cloned/shared."""
+    return (
+        normalize(row.get("role")),
+        normalize(row.get("timestamp")),
+        sha12(row.get("content")),
+        sha12(row.get("reasoning")),
+        sha12(row.get("reasoning_content")),
+        normalize(row.get("finish_reason")),
+    )
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--db", type=Path, default=AUTHORITATIVE_PATH)
+    ap.add_argument("--expected-sha256", default=AUTHORITATIVE_SHA256)
+    ap.add_argument("--output-dir", type=Path)
+    args = ap.parse_args()
+
+    started = time.time()
+    before_sha = enforce_safe_source(args.db, args.expected_sha256)
+    before_identity = file_identity(args.db)
+    before_sidecars = sidecars(args.db)
+    stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    out = args.output_dir or Path(f"issue60-stage5-evidence-{stamp}")
+    out.mkdir(parents=True, exist_ok=False)
+
+    conn = open_immutable(args.db)
+    try:
+        counts = {t: int(scalar(conn, f"SELECT COUNT(*) FROM {t}") or 0) for t in EXPECTED_COUNTS}
+        if counts != EXPECTED_COUNTS:
+            raise SystemExit(f"REFUSE: canonical row counts changed: {counts}")
+        quick_check = normalize(scalar(conn, "PRAGMA quick_check"))
+        fk_violations = len(conn.execute("PRAGMA foreign_key_check").fetchall())
+
+        # A) Surviving importer-generation partition.
+        generation_counts = Counter()
+        generation_profiles = Counter()
+        generation_rows = []
+        session_counts = {}
+        stored_total = 0
+        actual_total = 0
+        drift_excess = 0
+        drift_ratio_counts = Counter()
+
+        for r in conn.execute("""
+            SELECT s.id, s.user_id, s.model_config, s.message_count,
+                   COUNT(m.id) AS actual_messages
+            FROM sessions s LEFT JOIN messages m ON m.session_id=s.id
+            WHERE s.source='chatgpt-export'
+            GROUP BY s.id
+            ORDER BY s.id
+        """):
+            mc = mc_obj(r["model_config"])
+            cid = mc.get("chatgpt_conversation_id") if isinstance(mc.get("chatgpt_conversation_id"), str) else ""
+            user_match = bool(cid) and r["user_id"] == cid
+            legacy_keys = sorted(k for k in mc if k not in FINAL_IMPORTER_KEYS)
+            generation = "final_user_id_shape" if user_match else "pre_final_user_id_shape"
+            generation_counts[generation] += 1
+            generation_profiles[(generation, ",".join(sorted(mc)), ",".join(legacy_keys))] += 1
+            stored = int(r["message_count"] or 0)
+            actual = int(r["actual_messages"] or 0)
+            session_counts[r["id"]] = (stored, actual)
+            stored_total += stored
+            actual_total += actual
+            if actual != stored:
+                drift_excess += actual - stored
+                if stored > 0 and actual % stored == 0:
+                    drift_ratio_counts[actual // stored] += 1
+                else:
+                    drift_ratio_counts["non_integer"] += 1
+
+        for (generation, profile, legacy), n in generation_profiles.most_common():
+            generation_rows.append({
+                "generation_shape": generation,
+                "model_config_keys": profile,
+                "legacy_extra_keys": legacy,
+                "sessions": n,
+            })
+        write_tsv(out / "generation_partition.tsv", generation_rows)
+
+        # B) Duplicate UUID members, exact-clone/conflict classification.
+        dup_ids = [r[0] for r in conn.execute("""
+            SELECT m.platform_message_id
+            FROM messages m JOIN sessions s ON s.id=m.session_id
+            WHERE s.source='chatgpt-export' AND COALESCE(m.platform_message_id,'')<>''
+            GROUP BY m.platform_message_id HAVING COUNT(*) > 1
+        """)]
+        dup_groups: dict[str, list[dict[str, Any]]] = defaultdict(list)
+        if dup_ids:
+            # Avoid SQLite variable limits by scanning the already-bounded imported corpus once.
+            dup_set = set(dup_ids)
+            for r in conn.execute("""
+                SELECT m.id AS message_id, m.session_id, s.title,
+                       m.role, m.timestamp, m.platform_message_id,
+                       m.content, m.reasoning, m.reasoning_content, m.finish_reason
+                FROM messages m JOIN sessions s ON s.id=m.session_id
+                WHERE s.source='chatgpt-export' AND COALESCE(m.platform_message_id,'')<>''
+                ORDER BY m.id
+            """):
+                pid = r["platform_message_id"]
+                if pid in dup_set:
+                    dup_groups[pid].append(dict(r))
+
+        dup_summary_rows = []
+        sample_member_rows = []
+        duplicate_class_counts = Counter()
+        within_session_excess = 0
+        cross_session_excess = 0
+        conflicting_uuid_groups = 0
+
+        for pid, members in dup_groups.items():
+            sessions = {m["session_id"] for m in members}
+            signatures = {message_signature(m) for m in members}
+            copies = len(members)
+            session_n = len(sessions)
+            within_extra = copies - session_n
+            cross_extra = session_n - 1
+            within_session_excess += within_extra
+            cross_session_excess += cross_extra
+            if session_n == 1:
+                cls = "within_session_replay"
+            elif len(signatures) == 1:
+                cls = "cross_session_exact_clone" if copies == session_n else "cross_session_exact_clone_plus_replay"
+            else:
+                cls = "cross_session_conflict"
+                conflicting_uuid_groups += 1
+            duplicate_class_counts[cls] += 1
+            dup_summary_rows.append({
+                "platform_message_id": pid,
+                "class": cls,
+                "copies": copies,
+                "distinct_sessions": session_n,
+                "distinct_signatures": len(signatures),
+                "within_session_excess": within_extra,
+                "cross_session_excess": cross_extra,
+                "min_message_id": min(int(m["message_id"]) for m in members),
+                "max_message_id": max(int(m["message_id"]) for m in members),
+            })
+
+        dup_summary_rows.sort(key=lambda x: (-int(x["copies"]), x["platform_message_id"]))
+        write_tsv(out / "duplicate_uuid_classification.tsv", dup_summary_rows)
+
+        # Publish only bounded hashes/metadata for representative multi-session duplicate groups.
+        for group in [g for g in dup_summary_rows if int(g["distinct_sessions"]) > 1][:100]:
+            pid = group["platform_message_id"]
+            for m in dup_groups[pid]:
+                sample_member_rows.append({
+                    "platform_message_id": pid,
+                    "class": group["class"],
+                    "message_id": m["message_id"],
+                    "session_id": m["session_id"],
+                    "title": m["title"],
+                    "role": m["role"],
+                    "timestamp": m["timestamp"],
+                    "content_sha12": sha12(m["content"]),
+                    "reasoning_sha12": sha12(m["reasoning"]),
+                    "reasoning_content_sha12": sha12(m["reasoning_content"]),
+                    "finish_reason": m["finish_reason"],
+                })
+        write_tsv(out / "cross_session_duplicate_samples.tsv", sample_member_rows)
+
+        # C) Orphan detailed shape, still privacy-safe.
+        orphan_rows = []
+        for r in conn.execute("""
+            SELECT id AS message_id, role, timestamp, platform_message_id,
+                   content, reasoning, reasoning_content, finish_reason,
+                   tool_name, tool_calls
+            FROM messages WHERE session_id=? ORDER BY id
+        """, (ORPHAN_SESSION,)):
+            orphan_rows.append({
+                "message_id": r["message_id"],
+                "role": r["role"],
+                "timestamp": r["timestamp"],
+                "platform_message_id": r["platform_message_id"],
+                "content_sha12": sha12(r["content"]),
+                "content_len": len(normalize(r["content"])),
+                "reasoning_sha12": sha12(r["reasoning"]),
+                "reasoning_content_sha12": sha12(r["reasoning_content"]),
+                "finish_reason": r["finish_reason"],
+                "tool_name_present": int(r["tool_name"] not in (None, "")),
+                "tool_calls_present": int(r["tool_calls"] not in (None, "")),
+            })
+        write_tsv(out / "orphan_0041efa3_messages.tsv", orphan_rows)
+
+        # D) Final imported message-field shape.
+        field_row = dict(conn.execute("""
+            SELECT COUNT(*) AS messages,
+                   SUM(CASE WHEN COALESCE(content,'')='' THEN 1 ELSE 0 END) AS empty_content,
+                   SUM(CASE WHEN reasoning IS NOT NULL AND reasoning<>'' THEN 1 ELSE 0 END) AS reasoning_nonempty,
+                   SUM(CASE WHEN reasoning_content IS NOT NULL AND reasoning_content<>'' THEN 1 ELSE 0 END) AS reasoning_content_nonempty,
+                   SUM(CASE WHEN COALESCE(finish_reason,'')<>'' THEN 1 ELSE 0 END) AS finish_reason_nonempty,
+                   SUM(CASE WHEN COALESCE(tool_name,'')<>'' THEN 1 ELSE 0 END) AS tool_name_nonempty,
+                   SUM(CASE WHEN COALESCE(tool_calls,'')<>'' THEN 1 ELSE 0 END) AS tool_calls_nonempty,
+                   SUM(CASE WHEN COALESCE(platform_message_id,'')='' THEN 1 ELSE 0 END) AS platform_id_empty
+            FROM messages m JOIN sessions s ON s.id=m.session_id
+            WHERE s.source='chatgpt-export'
+        """).fetchone())
+        role_rows = [dict(r) for r in conn.execute("""
+            SELECT m.role, COUNT(*) AS messages
+            FROM messages m JOIN sessions s ON s.id=m.session_id
+            WHERE s.source='chatgpt-export'
+            GROUP BY m.role ORDER BY messages DESC, m.role
+        """)]
+        write_tsv(out / "imported_message_field_presence.tsv", [field_row])
+        write_tsv(out / "imported_message_roles.tsv", role_rows)
+
+        summary = {
+            "canonical_db": {
+                "path": str(args.db), "sha256": before_sha, "counts": counts,
+                "quick_check": quick_check, "foreign_key_violations": fk_violations,
+                "opened_mode": "mode=ro&immutable=1 + PRAGMA query_only=ON",
+                "mutations_performed": False,
+            },
+            "generation_shape_counts": dict(generation_counts),
+            "stored_message_count_sum": stored_total,
+            "actual_imported_message_rows": actual_total,
+            "message_count_drift_excess": drift_excess,
+            "drift_integer_ratio_counts": {str(k): v for k, v in drift_ratio_counts.items()},
+            "duplicate_uuid_groups": len(dup_groups),
+            "duplicate_uuid_class_counts": dict(duplicate_class_counts),
+            "within_session_duplicate_uuid_excess": within_session_excess,
+            "cross_session_shared_uuid_excess": cross_session_excess,
+            "conflicting_uuid_groups": conflicting_uuid_groups,
+            "orphan_message_rows": len(orphan_rows),
+            "message_field_presence": field_row,
+            "interpretation_guards": {
+                "generation_partition": "Exact counts matching the final-run 792 inserts vs 4,654 existing IDs + 1 repaired orphan are strong pass-provenance evidence; identity of every row remains an inference without a before-snapshot/list of inserted IDs.",
+                "cross_session_uuid": "Same ChatGPT message UUID in multiple sessions may represent shared/cloned conversation ancestry. Exact signatures support that interpretation; conflicts would require separate investigation.",
+                "stored_message_count": "Session-level stored message_count is historical importer state, not an authoritative deduplicated count after later replay inserts.",
+            },
+        }
+        (out / "manifest.json").write_text(json.dumps(summary, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+        (out / "README.md").write_text("""# Issue #60 stage-5 evidence
+
+Final DB-only closure pass for importer-generation and message-replay provenance.
+
+Key outputs:
+- `generation_partition.tsv`
+- `duplicate_uuid_classification.tsv`
+- `cross_session_duplicate_samples.tsv`
+- `orphan_0041efa3_messages.tsv`
+- `imported_message_field_presence.tsv`
+- `imported_message_roles.tsv`
+
+Raw private message content is not emitted; only hashes/lengths and bounded metadata are used.
+""", encoding="utf-8")
+    finally:
+        conn.close()
+
+    after_identity = file_identity(args.db)
+    after_sha = sha256_file(args.db)
+    after_sidecars = sidecars(args.db)
+    if after_identity != before_identity or after_sha != before_sha:
+        raise SystemExit("REFUSE: canonical DB identity/SHA changed during extraction")
+    dirty = {k: v for k, v in after_sidecars.items() if v["exists"] and int(v["size"]) > 0}
+    if dirty:
+        raise SystemExit(f"REFUSE: non-empty SQLite sidecar appeared: {dirty}")
+
+    mp = out / "manifest.json"
+    manifest = json.loads(mp.read_text(encoding="utf-8"))
+    manifest["source_receipt"] = {
+        "before_identity": before_identity, "after_identity": after_identity,
+        "before_sha256": before_sha, "after_sha256": after_sha,
+        "sidecars_before": before_sidecars, "sidecars_after": after_sidecars,
+    }
+    manifest["elapsed_s"] = round(time.time() - started, 3)
+    mp.write_text(json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    archive = Path(str(out) + ".tar.gz")
+    with tarfile.open(archive, "w:gz") as tf:
+        tf.add(out, arcname=out.name)
+    print(f"evidence_dir={out}")
+    print(f"archive={archive}")
+    print(f"generation_shape_counts={json.dumps(manifest['generation_shape_counts'], sort_keys=True)}")
+    print(f"drift_excess={manifest['message_count_drift_excess']}")
+    print(f"duplicate_uuid_groups={manifest['duplicate_uuid_groups']}")
+    print(f"conflicting_uuid_groups={manifest['conflicting_uuid_groups']}")
+    print(f"elapsed_s={manifest['elapsed_s']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/research/chatgpt-import/issue60/README.md
+++ b/research/chatgpt-import/issue60/README.md
@@ -1,0 +1,178 @@
+# Issue #60 — ChatGPT → Hermes import provenance
+
+This directory is the durable, public research record for #60.
+
+Full raw historical transcripts are **not committed** because this repository is public and the raw bundle contains unrelated/private historical context. Exact locators and cryptographic hashes are preserved instead.
+
+## Evidence base
+
+Canonical frozen DB:
+
+- path: `/home/skywind/hermes-recovery/runs/20260807-081043/state.recovered.patched.db`
+- SHA-256: `23cfa3c8adb94ed403058329ae7e252e1d4c4bc01ead76e22ac7d0ff99948104`
+- opened by the evidence extractor as `mode=ro&immutable=1 + PRAGMA query_only=ON`
+- mutations performed: `False`
+- counts: sessions=7268, messages=231513, gateway_routing=78
+
+Stage-2 extraction found:
+
+- `chatgpt-export` sessions: 5447
+- whole-DB keyword hit rows: 32264
+- whole-DB candidate sessions: 2898
+- pre-Hermes exact ChatGPT-message match rows: 0
+- targeted anomaly exact-match rows: 0
+
+## Corrected historical session boundary
+
+### PROVEN — origin/intake
+
+The migration request begins in `20260616_054313_151a9806` (`ChatGPT数据整合计划`), at message `90307`.
+
+At message `90416` the user changes topic to the oversized ZIP / Windows C: drive investigation. The remainder of that long session must **not** be treated as importer evidence.
+
+### PROVEN — implementation session
+
+The high-value implementation session is `20260616_100300_58622e7c` (`ChatGPT搬遷討論回顧`).
+
+It contains the final exact importer source and exact execution output, recovered into:
+
+- `recovered-import_final.py`
+- `import-final-run-output.txt`
+
+See `evidence-locators.md` for precise historical message IDs.
+
+## PROVEN — final importer behavior
+
+The exact recovered script implements:
+
+```text
+ChatGPT conversation
+    ↓
+current_node
+    ↓
+walk mapping[node].parent backward
+    ↓
+skip null/non-message nodes
+    ↓
+reverse
+    ↓
+one linear active-branch Hermes session
+```
+
+### Session field mapping in the final script
+
+| Hermes field | ChatGPT source / derivation | Confidence |
+|---|---|---|
+| `id` | `datetime(create_time)` + first 8 chars of `conversation_id` | PROVEN |
+| `title` | `conversation.title` | PROVEN |
+| `started_at` | `conversation.create_time` | PROVEN |
+| `ended_at` | `conversation.update_time` | PROVEN |
+| `source` | inserted as temporary `chatgpt-export-new`, then normalized to `chatgpt-export` | PROVEN |
+| `user_id` | full `conversation_id` | PROVEN |
+| `model` | `default_model_slug` | PROVEN |
+| `model_config.chatgpt_conversation_id` | full `conversation_id` | PROVEN |
+| `model_config.chatgpt_gpt_id` | `conversation_template_id`, when present | PROVEN |
+| `model_config.chatgpt_is_archived` | `is_archived`, when present | PROVEN |
+| `model_config.chatgpt_is_starred` | `is_starred`, when present | PROVEN |
+| `message_count` | number of extracted active-branch message nodes | PROVEN |
+| `display_name` | not written by final importer | PROVEN about script behavior |
+| `parent_session_id` | not written by final importer | PROVEN about script behavior |
+| `end_reason` | not written by final importer | PROVEN about script behavior |
+| `cwd` | not written by final importer | PROVEN about script behavior |
+
+“Not written” does not by itself prove the final DB value if later/default behavior could modify it; final-row claims still require DB evidence.
+
+### Message field mapping in the final script
+
+| Hermes field | ChatGPT source / derivation | Confidence |
+|---|---|---|
+| `session_id` | generated session ID above | PROVEN |
+| `role` | `message.author.role` (with the script's literal `role == "role" → "user"` special case) | PROVEN |
+| `content` | newline-join of **string** entries in `content.parts` | PROVEN |
+| `timestamp` | `message.create_time` | PROVEN |
+| `platform_message_id` | ChatGPT message `id` | PROVEN |
+| `finish_reason` | `message.metadata.model_slug` (despite the Hermes column name) | PROVEN |
+| `reasoning` | joined `thoughts[].content` for `content_type == "thoughts"` | PROVEN |
+| `reasoning_content` | `content.content` for `content_type == "reasoning_recap"` | PROVEN |
+
+The final script does not preserve arbitrary non-string `content.parts`, `content_references`, all alternate branches, or every possible tool/content structure.
+
+## PROVEN — merge / dedup behavior
+
+The final script:
+
+1. loads every `conversations-*.json` file under `/tmp/chatgpt-export`;
+2. builds an existing set from `model_config.chatgpt_conversation_id`;
+3. attempts to repair existing imported sessions missing that ID using `user_id`;
+4. imports only conversation IDs absent from that set;
+5. commits in batches of 10;
+6. catches session `sqlite3.IntegrityError`, marks that generated session ID as `chatgpt-export`, and skips inserting its messages;
+7. ignores per-message `sqlite3.IntegrityError`;
+8. converts `chatgpt-export-new` to `chatgpt-export` after the import;
+9. verifies duplicate/missing conversation IDs and counts.
+
+This is direct SQL into `~/.hermes/state.db`; it is not using a high-level Hermes session-storage API.
+
+## PROVEN — final recorded run
+
+The exact recorded run says:
+
+```text
+Loaded conversations:          5,447
+Existing conversation IDs:     4,654
+Conversations considered missing: 793
+New sessions actually imported:   792
+New messages inserted:          3,322
+
+Final chatgpt-export sessions:  5,447
+Final imported messages:       89,434
+Duplicate conversation IDs:     0
+Sessions without conv_id:        1
+```
+
+The one remaining row without a conversation ID is reported as:
+
+`20231013_125540_0041efa3`
+
+The transcript subsequently investigates that orphan. Do not silently rewrite the historical run output to “all 5,447 had conv_id”; the exact run artifact above says one remained at that point.
+
+## STRONG INFERENCE / historical summary context
+
+The context-compaction handoff in the main implementation session reports earlier exploration including:
+
+- an approximately 892 MB ChatGPT export;
+- 55 `conversations-*.json` chunks;
+- 5,447 conversations;
+- representative/small import tests before the final pass;
+- field/content-type audits;
+- failed full-import attempts, timeout/WAL investigation, and the temporary false hypothesis that title uniqueness caused dropped rows;
+- later schema checks that disproved that title-UNIQUE hypothesis.
+
+These are valuable historical context, but details that exist only in the compaction summary are weaker than the exact recovered final script and terminal results.
+
+## PROVEN negative evidence / OPEN anomaly
+
+Stage 2 found **0** pre-Hermes session rows with any informative exact-content match to the final `chatgpt-export` corpus, and **0** targeted exact-message matches for the anomaly set.
+
+Therefore the simplest theory—
+
+> “the Hermes-shaped pre-Hermes rows are just exact duplicate ChatGPT messages imported again under `discord` / `cli`”
+
+—is not supported by exact-content evidence.
+
+This does **not** explain the historical lineage anomaly. The reason pre-2026-06-16 rows can contain Hermes-shaped `source`, `parent_session_id`, `end_reason='compression'`, etc. remains **OPEN** and should be investigated as a transformation / earlier import / reinsertion / rewrite question.
+
+## Public vs private evidence
+
+Public:
+- this research note;
+- exact final importer;
+- exact final run output;
+- precise evidence locators;
+- evidence hashes.
+
+Private/local:
+- complete stage-1/stage-2 evidence archives;
+- full raw historical transcripts.
+
+See `evidence-manifest.json`.

--- a/research/chatgpt-import/issue60/README.md
+++ b/research/chatgpt-import/issue60/README.md
@@ -4,6 +4,16 @@ This directory is the durable, public research record for #60.
 
 Full raw historical transcripts are **not committed** because this repository is public and the raw bundle contains unrelated/private historical context. Exact locators and cryptographic hashes are preserved instead.
 
+## Corrected timeline — source of truth
+
+**User-confirmed:** Hermes runtime began **2026-05-29**.
+
+**2026-06-16 is the ChatGPT export import/merge date, not Hermes adoption.** The import was performed against an already-populated Hermes `state.db`.
+
+Therefore May-29 through June-15 `discord` / `cli` / `cron` sessions, tool calls, `parent_session_id`, and `end_reason='compression'` are eligible as genuine Hermes-native runtime evidence. Do not treat them as import anomalies merely because they predate June 16.
+
+The May-30 depth-14 lineage used by #54 is inside the Hermes-runtime era.
+
 ## Evidence base
 
 Canonical frozen DB:
@@ -14,36 +24,55 @@ Canonical frozen DB:
 - mutations performed: `False`
 - counts: sessions=7268, messages=231513, gateway_routing=78
 
-Stage-2 extraction found:
+Final `chatgpt-export` corpus: 5,447 sessions.
 
-- `chatgpt-export` sessions: 5447
-- whole-DB keyword hit rows: 32264
-- whole-DB candidate sessions: 2898
-- pre-Hermes exact ChatGPT-message match rows: 0
-- targeted anomaly exact-match rows: 0
+## Historical migration session boundary
 
-## Corrected historical session boundary
-
-### PROVEN — origin/intake
+### PROVEN — origin / intake
 
 The migration request begins in `20260616_054313_151a9806` (`ChatGPT数据整合计划`), at message `90307`.
 
 At message `90416` the user changes topic to the oversized ZIP / Windows C: drive investigation. The remainder of that long session must **not** be treated as importer evidence.
 
-### PROVEN — implementation session
+### PROVEN — implementation / reconstruction
 
 The high-value implementation session is `20260616_100300_58622e7c` (`ChatGPT搬遷討論回顧`).
 
-It contains the final exact importer source and exact execution output, recovered into:
-
-- `recovered-import_final.py`
-- `import-final-run-output.txt`
+It contains the exploration, representative imports, bulk-import failures/corrections, final exact importer, orphan repair, and FTS verification.
 
 See `evidence-locators.md` for precise historical message IDs.
 
+## PROVEN — import merged into an existing Hermes DB
+
+At the representative 57-session ChatGPT checkpoint, the historical transcript records:
+
+```text
+discord:        620
+cron:           252
+cli:             15
+chatgpt-export:  57
+-------------------
+total:          944
+```
+
+So **887 non-ChatGPT Hermes sessions were already present** before the bulk ChatGPT migration finished.
+
+The exact final run later reports:
+
+```text
+chatgpt-export: 5447
+discord:         621
+cron:            253
+cli:              15
+```
+
+This is an existing-DB merge, not an empty-DB import.
+
 ## PROVEN — final importer behavior
 
-The exact recovered script implements:
+The exact recovered script is `recovered-import_final.py`, reconstructed from historical message `188425` (`write_file` payload for `/tmp/chatgpt-export/import_final.py`).
+
+It implements:
 
 ```text
 ChatGPT conversation
@@ -61,13 +90,13 @@ one linear active-branch Hermes session
 
 ### Session field mapping in the final script
 
-| Hermes field | ChatGPT source / derivation | Confidence |
+| Hermes field | Final-script source / derivation | Confidence |
 |---|---|---|
-| `id` | `datetime(create_time)` + first 8 chars of `conversation_id` | PROVEN |
+| `id` | UTC `datetime(create_time)` + first 8 chars of `conversation_id` | PROVEN |
 | `title` | `conversation.title` | PROVEN |
-| `started_at` | `conversation.create_time` | PROVEN |
-| `ended_at` | `conversation.update_time` | PROVEN |
-| `source` | inserted as temporary `chatgpt-export-new`, then normalized to `chatgpt-export` | PROVEN |
+| `started_at` | `conversation.create_time` | PROVEN **for the final script** |
+| `ended_at` | `conversation.update_time` | PROVEN **for the final script** |
+| `source` | temporary `chatgpt-export-new`, then normalized to `chatgpt-export` | PROVEN |
 | `user_id` | full `conversation_id` | PROVEN |
 | `model` | `default_model_slug` | PROVEN |
 | `model_config.chatgpt_conversation_id` | full `conversation_id` | PROVEN |
@@ -75,19 +104,19 @@ one linear active-branch Hermes session
 | `model_config.chatgpt_is_archived` | `is_archived`, when present | PROVEN |
 | `model_config.chatgpt_is_starred` | `is_starred`, when present | PROVEN |
 | `message_count` | number of extracted active-branch message nodes | PROVEN |
-| `display_name` | not written by final importer | PROVEN about script behavior |
-| `parent_session_id` | not written by final importer | PROVEN about script behavior |
-| `end_reason` | not written by final importer | PROVEN about script behavior |
-| `cwd` | not written by final importer | PROVEN about script behavior |
+| `display_name` | not written by final importer | PROVEN about final-script behavior |
+| `parent_session_id` | not written by final importer | PROVEN about final-script behavior |
+| `end_reason` | not written by final importer | PROVEN about final-script behavior |
+| `cwd` | not written by final importer | PROVEN about final-script behavior |
 
-“Not written” does not by itself prove the final DB value if later/default behavior could modify it; final-row claims still require DB evidence.
+**Important:** final-script behavior is not automatically the behavior of every row in the final corpus, because thousands of conversations already existed from earlier test/partial import passes and were deduplicated rather than rewritten by the final pass.
 
 ### Message field mapping in the final script
 
 | Hermes field | ChatGPT source / derivation | Confidence |
 |---|---|---|
 | `session_id` | generated session ID above | PROVEN |
-| `role` | `message.author.role` (with the script's literal `role == "role" → "user"` special case) | PROVEN |
+| `role` | `message.author.role` (including the script's literal `role == "role" → "user"` special case) | PROVEN |
 | `content` | newline-join of **string** entries in `content.parts` | PROVEN |
 | `timestamp` | `message.create_time` | PROVEN |
 | `platform_message_id` | ChatGPT message `id` | PROVEN |
@@ -106,61 +135,93 @@ The final script:
 3. attempts to repair existing imported sessions missing that ID using `user_id`;
 4. imports only conversation IDs absent from that set;
 5. commits in batches of 10;
-6. catches session `sqlite3.IntegrityError`, marks that generated session ID as `chatgpt-export`, and skips inserting its messages;
+6. on session `sqlite3.IntegrityError`, executes `UPDATE sessions SET source='chatgpt-export' WHERE id=?` and skips inserting that conversation's messages;
 7. ignores per-message `sqlite3.IntegrityError`;
 8. converts `chatgpt-export-new` to `chatgpt-export` after the import;
 9. verifies duplicate/missing conversation IDs and counts.
 
 This is direct SQL into `~/.hermes/state.db`; it is not using a high-level Hermes session-storage API.
 
-## PROVEN — final recorded run
+The `IntegrityError → source rewrite` path is now a high-value audit target: determine whether it ever hit a pre-existing Hermes-native row or only an earlier ChatGPT-import row.
 
-The exact recorded run says:
+## PROVEN — final recorded run and orphan repair
+
+`import-final-run-output.txt` records:
 
 ```text
-Loaded conversations:          5,447
-Existing conversation IDs:     4,654
-Conversations considered missing: 793
-New sessions actually imported:   792
-New messages inserted:          3,322
+Loaded conversations:              5,447
+Existing conversation IDs:         4,654
+Conversations considered missing:    793
+New sessions actually imported:      792
+New messages inserted:              3,322
 
-Final chatgpt-export sessions:  5,447
-Final imported messages:       89,434
-Duplicate conversation IDs:     0
-Sessions without conv_id:        1
+Final chatgpt-export sessions:      5,447
+Final imported messages:           89,434
+Duplicate conversation IDs:            0
+Sessions without conv_id:              1
 ```
 
-The one remaining row without a conversation ID is reported as:
+The remaining v1 orphan was:
 
 `20231013_125540_0041efa3`
 
-The transcript subsequently investigates that orphan. Do not silently rewrite the historical run output to “all 5,447 had conv_id”; the exact run artifact above says one remained at that point.
+The same historical session then recovers its original ChatGPT conversation ID:
 
-## STRONG INFERENCE / historical summary context
+`0041efa3-8722-493e-92d3-58c0f9838b23`
 
-The context-compaction handoff in the main implementation session reports earlier exploration including:
+and writes it back into `model_config.chatgpt_conversation_id`.
 
-- an approximately 892 MB ChatGPT export;
-- 55 `conversations-*.json` chunks;
-- 5,447 conversations;
-- representative/small import tests before the final pass;
-- field/content-type audits;
-- failed full-import attempts, timeout/WAL investigation, and the temporary false hypothesis that title uniqueness caused dropped rows;
-- later schema checks that disproved that title-UNIQUE hypothesis.
+## PROVEN — exploration path so far
 
-These are valuable historical context, but details that exist only in the compaction summary are weaker than the exact recovered final script and terminal results.
+The historical implementation session preserves this progression:
 
-## PROVEN negative evidence / OPEN anomaly
+1. inspect the ~892 MB export, 55 JSON chunks, 5,447 conversations;
+2. write `/tmp/chatgpt-export/test_import.py` and dry-run flattening;
+3. write 2 test conversations into the real existing DB and verify FTS/session search;
+4. add GPT-conversation tests;
+5. expand to a representative 57-session sample across all chunks;
+6. attempt bulk/v2 imports;
+7. investigate timeout/WAL behavior;
+8. temporarily form, then disprove, the false `title UNIQUE` hypothesis;
+9. add fail-first/schema/dedup/batch tests;
+10. run the final missing-conversation pass;
+11. repair the one orphan;
+12. verify final counts and FTS.
 
-Stage 2 found **0** pre-Hermes session rows with any informative exact-content match to the final `chatgpt-export` corpus, and **0** targeted exact-message matches for the anomaly set.
+Exact post-compaction scripts visible in the transcript include `test_fail_first.py`, `test_representative.py`, `test_dedup_batch.py`, `test_timeout.py`, `preflight.py`, and `import_final.py`. Earlier `test_import.py` survives only through the compacted historical handoff unless another transcript/tool artifact is recovered.
 
-Therefore the simplest theory—
+## NEW high-value lead — earlier June-15 import shape
 
-> “the Hermes-shaped pre-Hermes rows are just exact duplicate ChatGPT messages imported again under `discord` / `cli`”
+Stage 2 found a tight cluster of **23 `chatgpt-export` sessions whose session IDs / `started_at` fall at 2026-06-15 05:00–05:01 UTC, while their earliest message timestamps are mostly from 2024**.
 
-—is not supported by exact-content evidence.
+Examples include:
 
-This does **not** explain the historical lineage anomaly. The reason pre-2026-06-16 rows can contain Hermes-shaped `source`, `parent_session_id`, `end_reason='compression'`, etc. remains **OPEN** and should be investigated as a transformation / earlier import / reinsertion / rewrite question.
+- `20260615_050044_67060f3b`
+- `20260615_050047_66e2d6cf`
+- `20260615_050049_670be7ed`
+- `20260615_050104_67357525`
+
+This is **not** evidence that all imported rows use import-time `started_at`; most rows align normally with historical timestamps. It is evidence that at least one earlier pass may have used a different session-time/session-ID policy and then survived final dedup.
+
+A nearby Hermes-native session is especially high-value for the next extraction:
+
+- `20260615_050051_06bd07d3` — `GPT記憶與偏好遷移`
+
+The next stage should dump this full transcript and inspect the 23-row cluster together.
+
+## Revised remaining questions
+
+The old question “why do May/early-June rows look Hermes-shaped?” is withdrawn: Hermes was genuinely running from May 29.
+
+Remaining work:
+
+1. recover/locate the June-15 `GPT記憶與偏好遷移` transcript and explain the 23-row import-time cluster;
+2. reconstruct the exact earlier import passes and script variants that produced the 4,654 rows already known to the final importer;
+3. quantify the first ChatGPT insertion boundary using `messages.id` as an insertion-order proxy;
+4. audit imported rows for native-only fingerprints (`parent_session_id`, `end_reason`, `cwd`, chat/thread/session keys, tool rows, Discord-style platform IDs) that could indicate a source-rewrite collision;
+5. determine whether the final importer's `IntegrityError → source='chatgpt-export'` path ever touched a real Hermes-native session;
+6. prove final imported-field fidelity/loss, especially rows created by earlier passes rather than the final script;
+7. inspect only genuine non-ChatGPT runtime-shaped rows with evidence before **2026-05-29**, if any.
 
 ## Public vs private evidence
 

--- a/research/chatgpt-import/issue60/evidence-locators.md
+++ b/research/chatgpt-import/issue60/evidence-locators.md
@@ -1,0 +1,45 @@
+# Issue #60 evidence locators
+
+This file records **where** the migration evidence lives without publishing the full raw historical transcript.
+
+The repository is public, so the full stage-2 transcript bundle is intentionally kept private/local. Its SHA-256 is recorded in `evidence-manifest.json`.
+
+## Origin / intake session
+
+- Session: `20260616_054313_151a9806`
+- Title: `ChatGPT数据整合计划`
+- Source: `discord`
+- Migration thread starts at message **90307**:
+  - user says the ChatGPT data export is ready;
+  - asks to inspect email/data/DB format;
+  - asks for an integration plan / preview.
+- The session **changes topic at message 90416**:
+  - user says the ZIP is huge;
+  - asks to investigate the Windows C: drive;
+  - the following C-drive / meta-thinking / personality work is not importer evidence.
+
+Therefore this long session is an **origin/intake locator only**, not the full importer implementation transcript.
+
+## Main implementation session
+
+- Session: `20260616_100300_58622e7c`
+- Title: `ChatGPT搬遷討論回顧`
+- Source: `discord`
+
+Important evidence inside it:
+
+- message **179210**: context-compaction summary preserving the earlier migration exploration;
+- message **179228–179234**: dedup/field/content-type exploration;
+- message **179242–179267**: failed UNIQUE-title diagnosis, schema verification, and fail-first retrospective;
+- message **185079–185091**: dedup correction, real import timing, and creation of `chatgpt-to-hermes-import` skill;
+- message **188423–188425**: pre-flight DB audit and the `write_file` call containing the final `/tmp/chatgpt-export/import_final.py`;
+- message **188428**: exact final importer execution output;
+- messages **188429–188461**: orphan cleanup / final checks / FTS verification.
+
+## Artifact strength
+
+`recovered-import_final.py` is reconstructed from the exact historical `write_file` tool-call payload, not from a prose summary.
+
+`import-final-run-output.txt` is reconstructed from the exact historical terminal tool result.
+
+The pre-compaction exploration survives partly through a context-compaction summary. Treat claims that exist **only** in that summary as supporting historical context, not as equal in strength to the exact script/tool results.

--- a/research/chatgpt-import/issue60/evidence-manifest.json
+++ b/research/chatgpt-import/issue60/evidence-manifest.json
@@ -1,5 +1,10 @@
 {
   "issue": 60,
+  "interpretation_correction": {
+    "hermes_runtime_start": "2026-05-29",
+    "chatgpt_import_merge_date": "2026-06-16",
+    "note": "Legacy stage-2 keys/files containing the word 'prehermes' used the old, incorrect June-16 cutoff. Preserve their raw counts as extraction artifacts, but do not interpret May-29 through June-15 Hermes runtime rows as pre-Hermes. Issue #60 and README.md are the current source of truth."
+  },
   "canonical_db": {
     "path": "/home/skywind/hermes-recovery/runs/20260807-081043/state.recovered.patched.db",
     "sha256": "23cfa3c8adb94ed403058329ae7e252e1d4c4bc01ead76e22ac7d0ff99948104",
@@ -41,10 +46,11 @@
     "message_id": 188428,
     "sha256": "f17b63778823b1d738630405fb51120c79588ed1f048f1e570a5090580bd087d"
   },
-  "stage2_results": {
+  "stage2_results_raw_legacy_naming": {
     "chatgpt_export_sessions": 5447,
     "prehermes_exact_match_rows": 0,
     "anomaly_exact_match_rows": 0,
-    "verified_nonzero_crossmatch_sessions": 0
+    "verified_nonzero_crossmatch_sessions": 0,
+    "interpretation": "The zero exact-match result is still a valid raw observation for the rows selected by stage 2, but the old label 'prehermes' is not a valid temporal classification after the May-29 correction."
   }
 }

--- a/research/chatgpt-import/issue60/evidence-manifest.json
+++ b/research/chatgpt-import/issue60/evidence-manifest.json
@@ -1,0 +1,50 @@
+{
+  "issue": 60,
+  "canonical_db": {
+    "path": "/home/skywind/hermes-recovery/runs/20260807-081043/state.recovered.patched.db",
+    "sha256": "23cfa3c8adb94ed403058329ae7e252e1d4c4bc01ead76e22ac7d0ff99948104",
+    "counts": {
+      "sessions": 7268,
+      "messages": 231513,
+      "gateway_routing": 78
+    },
+    "opened_mode": "mode=ro&immutable=1 + PRAGMA query_only=ON",
+    "mutations_performed": false
+  },
+  "stage2_archive": {
+    "basename": "issue60-stage2-evidence-20260809-211718.tar.gz",
+    "sha256": "97889244b3fef393338e4c3ffdd3378d415bdbe5904e5026ee36b91919b19ae5"
+  },
+  "stage1_archive": {
+    "basename": "issue60-evidence-20260809-130215.tar.gz",
+    "sha256": "04068a446399695324cfd700ec3aeb3f149fa254187ffe7f695f1a32b900e268"
+  },
+  "main_transcript": {
+    "session_id": "20260616_100300_58622e7c",
+    "sha256": "e0e378f43eeaf5ed597b4248ff20de1759c7602fd1bc60e3d87c66c65002c2b8",
+    "committed_publicly": false,
+    "reason": "public repo; raw transcript contains unrelated/private historical context"
+  },
+  "origin_session": {
+    "session_id": "20260616_054313_151a9806",
+    "migration_start_message_id": 90307,
+    "topic_pivot_message_id": 90416
+  },
+  "recovered_final_importer": {
+    "historical_path": "/tmp/chatgpt-export/import_final.py",
+    "session_id": "20260616_100300_58622e7c",
+    "message_id": 188425,
+    "sha256": "e8f2c22a844f4330a5b2d4bbe1871223940d5f8993f1666e7aedf9b9a85c1192"
+  },
+  "final_run_output": {
+    "session_id": "20260616_100300_58622e7c",
+    "message_id": 188428,
+    "sha256": "f17b63778823b1d738630405fb51120c79588ed1f048f1e570a5090580bd087d"
+  },
+  "stage2_results": {
+    "chatgpt_export_sessions": 5447,
+    "prehermes_exact_match_rows": 0,
+    "anomaly_exact_match_rows": 0,
+    "verified_nonzero_crossmatch_sessions": 0
+  }
+}

--- a/research/chatgpt-import/issue60/import-final-run-output.txt
+++ b/research/chatgpt-import/issue60/import-final-run-output.txt
@@ -1,0 +1,122 @@
+======================================================================
+PHASE 1: FIX EXISTING DB GAPS
+======================================================================
+  Loaded 5447 conversations from export
+  CANNOT FIX: 20231013_125540_0041efa3, user_id=None
+  Existing conv_ids: 4654
+
+======================================================================
+PHASE 2: IMPORT MISSING CONVERSATIONS
+======================================================================
+
+  To import: 793 conversations
+    batch   1:   9 sessions,   17 msgs, 0.15s
+    batch   2:  10 sessions,   19 msgs, 0.17s
+    batch   3:  10 sessions,   34 msgs, 0.98s
+    batch   4:  10 sessions,   44 msgs, 0.40s
+    batch   5:  10 sessions,  172 msgs, 0.55s
+    batch   6:  10 sessions,   28 msgs, 0.05s
+    batch   7:  10 sessions,   73 msgs, 0.06s
+    batch   8:  10 sessions,   54 msgs, 0.05s
+    batch   9:  10 sessions,   36 msgs, 0.03s
+    batch  10:  10 sessions,   48 msgs, 0.34s
+    batch  11:  10 sessions,   90 msgs, 0.62s
+    batch  12:  10 sessions,   58 msgs, 0.12s
+    batch  13:  10 sessions,  321 msgs, 0.63s
+    batch  14:  10 sessions,  108 msgs, 0.18s
+    batch  15:  10 sessions,  157 msgs, 0.40s
+    batch  16:  10 sessions,  346 msgs, 0.36s
+    batch  17:  10 sessions,   28 msgs, 0.12s
+    batch  18:  10 sessions,   28 msgs, 0.05s
+    batch  19:  10 sessions,   20 msgs, 0.02s
+    batch  20:  10 sessions,   25 msgs, 0.07s
+    batch  21:  10 sessions,   20 msgs, 0.08s
+    batch  22:  10 sessions,   20 msgs, 0.04s
+    batch  23:  10 sessions,   28 msgs, 0.15s
+    batch  24:  10 sessions,   50 msgs, 0.13s
+    batch  25:  10 sessions,   20 msgs, 0.04s
+    batch  26:  10 sessions,   21 msgs, 0.02s
+    batch  27:  10 sessions,   20 msgs, 0.02s
+    batch  28:  10 sessions,   20 msgs, 0.01s
+    batch  29:  10 sessions,   40 msgs, 0.04s
+    batch  30:  10 sessions,   90 msgs, 0.11s
+    batch  31:  10 sessions,   32 msgs, 0.04s
+    batch  32:  10 sessions,   44 msgs, 0.03s
+    batch  33:  10 sessions,   31 msgs, 0.04s
+    batch  34:  10 sessions,   22 msgs, 0.02s
+    batch  35:  10 sessions,   29 msgs, 0.07s
+    batch  36:  10 sessions,   18 msgs, 0.03s
+    batch  37:  10 sessions,   20 msgs, 0.01s
+    batch  38:  10 sessions,   22 msgs, 0.02s
+    batch  39:  10 sessions,   21 msgs, 0.02s
+    batch  40:  10 sessions,   24 msgs, 0.02s
+    batch  41:  10 sessions,   19 msgs, 0.04s
+    batch  42:  10 sessions,   29 msgs, 0.02s
+    batch  43:  10 sessions,   18 msgs, 0.01s
+    batch  44:  10 sessions,   19 msgs, 0.01s
+    batch  45:  10 sessions,   19 msgs, 0.01s
+    batch  46:  10 sessions,   40 msgs, 0.03s
+    batch  47:  10 sessions,   22 msgs, 0.05s
+    batch  48:  10 sessions,   19 msgs, 0.02s
+    batch  49:  10 sessions,   45 msgs, 0.06s
+    batch  50:  10 sessions,   18 msgs, 0.15s
+    batch  51:  10 sessions,   23 msgs, 0.03s
+    batch  52:  10 sessions,   31 msgs, 0.07s
+    batch  53:  10 sessions,   20 msgs, 0.05s
+    batch  54:  10 sessions,   24 msgs, 0.01s
+    batch  55:  10 sessions,   20 msgs, 0.01s
+    batch  56:  10 sessions,   20 msgs, 0.03s
+    batch  57:  10 sessions,   20 msgs, 0.02s
+    batch  58:  10 sessions,   19 msgs, 0.01s
+    batch  59:  10 sessions,   23 msgs, 0.03s
+    batch  60:  10 sessions,   24 msgs, 0.02s
+    batch  61:  10 sessions,   20 msgs, 0.01s
+    batch  62:  10 sessions,   73 msgs, 0.06s
+    batch  63:  10 sessions,   27 msgs, 0.01s
+    batch  64:  10 sessions,   22 msgs, 0.01s
+    batch  65:  10 sessions,   19 msgs, 0.07s
+    batch  66:  10 sessions,   24 msgs, 0.03s
+    batch  67:  10 sessions,   43 msgs, 0.04s
+    batch  68:  10 sessions,   30 msgs, 0.03s
+    batch  69:  10 sessions,   20 msgs, 0.01s
+    batch  70:  10 sessions,   26 msgs, 0.01s
+    batch  71:  10 sessions,   35 msgs, 0.06s
+    batch  72:  10 sessions,   19 msgs, 0.02s
+    batch  73:  10 sessions,   29 msgs, 0.01s
+    batch  74:  10 sessions,   22 msgs, 0.02s
+    batch  75:  10 sessions,   30 msgs, 0.02s
+    batch  76:  10 sessions,   39 msgs, 0.07s
+    batch  77:  10 sessions,   19 msgs, 0.01s
+    batch  78:  10 sessions,   21 msgs, 0.02s
+    batch  79:  10 sessions,   28 msgs, 0.02s
+    batch  80:   3 sessions,    6 msgs, 0.00s
+
+  Import complete: 792 sessions, 3322 msgs in 7.5s
+  Rate: 105 sessions/s
+
+======================================================================
+FINAL VERIFICATION
+======================================================================
+
+  Sessions: 5447
+  Messages: 89434
+  Duplicate conv_ids: 0
+  Without conv_id: 1
+
+  Reasoning distribution:
+     62518  no reasoning
+     10551  reasoning_content
+       455  reasoning
+     15910  reasoning+reasoning_content
+
+  '絆線' in new data: 0
+
+  Source breakdown:
+    chatgpt-export             5447
+    discord                     621
+    cron                        253
+    cli                          15
+
+======================================================================
+DONE
+======================================================================

--- a/research/chatgpt-import/issue60/recovered-import_final.py
+++ b/research/chatgpt-import/issue60/recovered-import_final.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""Final import: fix DB gaps + import remaining 793 conversations + verify"""
+import sqlite3, json, os, sys, time
+from collections import Counter
+from datetime import datetime
+
+DB = os.path.expanduser("~/.hermes/state.db")
+ZIP_DIR = "/tmp/chatgpt-export"
+BATCH_SIZE = 10
+
+def get_conn():
+    conn = sqlite3.connect(DB)
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA synchronous=NORMAL")
+    conn.execute("PRAGMA cache_size=-64000")
+    return conn
+
+def load_all():
+    all_convs = []
+    chunk_files = sorted(f for f in os.listdir(ZIP_DIR) if f.startswith("conversations-") and f.endswith(".json"))
+    for cf in chunk_files:
+        with open(os.path.join(ZIP_DIR, cf)) as f:
+            all_convs.extend(json.load(f))
+    return all_convs
+
+def extract_messages(conv):
+    mapping = conv.get("mapping", {})
+    current_node_id = conv.get("current_node")
+    messages = []
+    node_id = current_node_id
+    seen = set()
+    while node_id and node_id not in seen:
+        seen.add(node_id)
+        node = mapping.get(node_id)
+        if not node: break
+        msg = node.get("message")
+        if msg:
+            role = msg.get("author", {}).get("role", "unknown")
+            content_obj = msg.get("content", {})
+            content_type = content_obj.get("content_type", "text")
+            text_parts = []
+            parts = content_obj.get("parts", [])
+            reasoning = None
+            reasoning_content = None
+            for p in parts:
+                if isinstance(p, str):
+                    text_parts.append(p)
+            if content_type == "reasoning_recap":
+                reasoning_content = content_obj.get("content", "")
+            if content_type == "thoughts":
+                thoughts = content_obj.get("thoughts", [])
+                if thoughts:
+                    reasoning = "\n".join(t.get("content","") for t in thoughts if t.get("content"))
+            text = "\n".join(text_parts)
+            messages.append({
+                "role": "user" if role == "role" else role,
+                "content": text,
+                "timestamp": msg.get("create_time", 0),
+                "platform_message_id": msg.get("id", ""),
+                "finish_reason": msg.get("metadata", {}).get("model_slug", ""),
+                "reasoning": reasoning,
+                "reasoning_content": reasoning_content,
+            })
+        node_id = node.get("parent")
+    messages.reverse()
+    return messages
+
+def build_conv_map(all_convs):
+    """Build: conversation_id → conversation"""
+    return {c.get("conversation_id",""): c for c in all_convs if c.get("conversation_id")}
+
+def fix_missing_conv_id(conn, all_convs):
+    """Fix sessions that lack chatgpt_conversation_id in model_config"""
+    cur = conn.cursor()
+    cur.execute("""
+        SELECT id, title, user_id
+        FROM sessions WHERE source='chatgpt-export'
+        AND (json_extract(model_config, '$.chatgpt_conversation_id') IS NULL
+             OR json_extract(model_config, '$.chatgpt_conversation_id') = '')
+    """)
+    rows = cur.fetchall()
+    if not rows:
+        print("  No missing conv_ids to fix")
+        return 0
+    
+    conv_map = build_conv_map(all_convs)
+    fixed = 0
+    for sid, title, user_id in rows:
+        # user_id might contain the conv_id
+        conv = conv_map.get(user_id) if user_id else None
+        if not conv:
+            # Try partial match (user_id might be truncated)
+            for cid, c in conv_map.items():
+                if cid.startswith(user_id) if user_id else False:
+                    conv = c
+                    break
+        if conv:
+            cid = conv.get("conversation_id", "")
+            if cid:
+                cur.execute("""
+                    UPDATE sessions SET model_config = json_set(
+                        COALESCE(model_config, '{}'),
+                        '$.chatgpt_conversation_id', ?
+                    ) WHERE id = ?
+                """, (cid, sid))
+                fixed += 1
+                print(f"  Fixed: {sid} → conv_id={cid[:16]}...")
+        else:
+            print(f"  CANNOT FIX: {sid}, user_id={user_id}")
+    conn.commit()
+    return fixed
+
+def import_missing(conn, all_convs, existing_ids, dry_run=False):
+    """Import missing conversations in batches"""
+    conv_map = build_conv_map(all_convs)
+    
+    missing = []
+    for c in all_convs:
+        cid = c.get("conversation_id", "")
+        if cid and cid not in existing_ids:
+            missing.append(c)
+    
+    print(f"\n  To import: {len(missing)} conversations")
+    if dry_run:
+        print(f"  DRY RUN — no data written")
+        return 0, 0
+    
+    imported = 0
+    total_msgs = 0
+    batch_num = 0
+    t_start = time.time()
+    
+    for i in range(0, len(missing), BATCH_SIZE):
+        batch = missing[i:i+BATCH_SIZE]
+        b_start = time.time()
+        batch_imported = 0
+        batch_msgs = 0
+        
+        for conv in batch:
+            cid = conv.get("conversation_id", "")
+            title = conv.get("title", "")
+            create_time = conv.get("create_time", 0)
+            update_time = conv.get("update_time", 0)
+            model = conv.get("default_model_slug", "")
+            template_id = conv.get("conversation_template_id", "")
+            
+            model_config = {"chatgpt_conversation_id": cid}
+            if template_id:
+                model_config["chatgpt_gpt_id"] = template_id
+            for flag in ["is_archived", "is_starred"]:
+                v = conv.get(flag)
+                if v is not None:
+                    model_config[f"chatgpt_{flag}"] = v
+            
+            messages = extract_messages(conv)
+            
+            date_part = datetime.fromtimestamp(create_time).strftime("%Y%m%d_%H%M%S") if create_time else "unknown"
+            session_id = f"{date_part}_{cid[:8]}"
+            
+            try:
+                conn.execute("""
+                    INSERT INTO sessions (id, source, user_id, model, model_config,
+                                         started_at, ended_at, message_count, title)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """, (session_id, "chatgpt-export-new", cid, model,
+                      json.dumps(model_config), create_time, update_time,
+                      len(messages), title))
+            except sqlite3.IntegrityError as e:
+                # Already exists — update to chatgpt-export
+                conn.execute("UPDATE sessions SET source='chatgpt-export' WHERE id=?", (session_id,))
+                continue
+            
+            msg_count = 0
+            for m in messages:
+                try:
+                    conn.execute("""
+                        INSERT INTO messages (session_id, role, content, timestamp,
+                                             finish_reason, platform_message_id,
+                                             reasoning, reasoning_content)
+                        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    """, (session_id, m["role"], m["content"], m["timestamp"],
+                          m["finish_reason"], m["platform_message_id"],
+                          m["reasoning"], m["reasoning_content"]))
+                    msg_count += 1
+                except sqlite3.IntegrityError:
+                    pass
+            
+            existing_ids.add(cid)
+            batch_imported += 1
+            batch_msgs += msg_count
+        
+        conn.commit()
+        b_elapsed = time.time() - b_start
+        batch_num += 1
+        imported += batch_imported
+        total_msgs += batch_msgs
+        
+        print(f"    batch {batch_num:3d}: {batch_imported:3d} sessions, {batch_msgs:4d} msgs, {b_elapsed:.2f}s")
+    
+    total_time = time.time() - t_start
+    print(f"\n  Import complete: {imported} sessions, {total_msgs} msgs in {total_time:.1f}s")
+    print(f"  Rate: {imported/total_time:.0f} sessions/s" if total_time > 0 else "")
+    return imported, total_msgs
+
+def verify(conn):
+    """Final verification"""
+    print("\n" + "=" * 70)
+    print("FINAL VERIFICATION")
+    print("=" * 70)
+    
+    cur = conn.cursor()
+    
+    # Count
+    cur.execute("SELECT count(*) FROM sessions WHERE source IN ('chatgpt-export', 'chatgpt-export-new')")
+    total_sessions = cur.fetchone()[0]
+    
+    cur.execute("""
+        SELECT count(*) FROM messages m 
+        JOIN sessions s ON m.session_id = s.id
+        WHERE s.source IN ('chatgpt-export', 'chatgpt-export-new')
+    """)
+    total_msgs = cur.fetchone()[0]
+    
+    print(f"\n  Sessions: {total_sessions}")
+    print(f"  Messages: {total_msgs}")
+    
+    # Duplicate check
+    cur.execute("""
+        SELECT json_extract(model_config, '$.chatgpt_conversation_id'), count(*) as c
+        FROM sessions WHERE source IN ('chatgpt-export', 'chatgpt-export-new')
+        AND json_extract(model_config, '$.chatgpt_conversation_id') IS NOT NULL
+        GROUP BY 1 HAVING c > 1
+    """)
+    dupes = cur.fetchall()
+    print(f"  Duplicate conv_ids: {len(dupes)}")
+    if dupes:
+        for cid, cnt in dupes[:5]:
+            print(f"    {cid[:20]}... x{cnt}")
+    
+    # Missing conv_id
+    cur.execute("""
+        SELECT count(*) FROM sessions WHERE source IN ('chatgpt-export', 'chatgpt-export-new')
+        AND json_extract(model_config, '$.chatgpt_conversation_id') IS NULL
+    """)
+    print(f"  Without conv_id: {cur.fetchone()[0]}")
+    
+    # Content type verification
+    cur.execute("""
+        SELECT m.reasoning IS NOT NULL, m.reasoning_content IS NOT NULL, count(*)
+        FROM messages m JOIN sessions s ON m.session_id = s.id
+        WHERE s.source IN ('chatgpt-export', 'chatgpt-export-new')
+        GROUP BY 1, 2
+    """)
+    print(f"\n  Reasoning distribution:")
+    for has_r, has_rc, cnt in cur.fetchall():
+        label = []
+        if has_r: label.append("reasoning")
+        if has_rc: label.append("reasoning_content")
+        label_str = "+".join(label) if label else "no reasoning"
+        print(f"    {cnt:6d}  {label_str}")
+    
+    # Content spot-check: find '絆線' in new data
+    cur.execute("""
+        SELECT COUNT(*) FROM messages m 
+        JOIN sessions s ON m.session_id = s.id
+        WHERE s.source='chatgpt-export-new' AND m.content LIKE '%絆線%'
+    """)
+    print(f"\n  '絆線' in new data: {cur.fetchone()[0]}")
+    
+    # Final source breakdown
+    cur.execute("SELECT source, count(*) FROM sessions GROUP BY source ORDER BY count(*) DESC")
+    print(f"\n  Source breakdown:")
+    for src, cnt in cur.fetchall():
+        print(f"    {src:25s} {cnt:5d}")
+    
+    return total_sessions, total_msgs
+
+
+if __name__ == "__main__":
+    print("=" * 70)
+    print("PHASE 1: FIX EXISTING DB GAPS")
+    print("=" * 70)
+    
+    all_convs = load_all()
+    print(f"  Loaded {len(all_convs)} conversations from export")
+    
+    conn = get_conn()
+    fixed = fix_missing_conv_id(conn, all_convs)
+    
+    # Build existing set
+    cur = conn.cursor()
+    cur.execute("""
+        SELECT DISTINCT json_extract(model_config, '$.chatgpt_conversation_id')
+        FROM sessions WHERE source IN ('chatgpt-export', 'chatgpt-export-new')
+        AND json_extract(model_config, '$.chatgpt_conversation_id') IS NOT NULL
+        AND json_extract(model_config, '$.chatgpt_conversation_id') != ''
+    """)
+    existing_ids = set(row[0] for row in cur.fetchall())
+    print(f"  Existing conv_ids: {len(existing_ids)}")
+    
+    # Phase 2: Import missing
+    print("\n" + "=" * 70)
+    print("PHASE 2: IMPORT MISSING CONVERSATIONS")
+    print("=" * 70)
+    
+    imp, msgs = import_missing(conn, all_convs, existing_ids)
+    
+    # Phase 3: Update source to 'chatgpt-export' for all new ones
+    conn.execute("UPDATE sessions SET source='chatgpt-export' WHERE source='chatgpt-export-new'")
+    conn.commit()
+    
+    # Phase 4: Verify
+    v = verify(conn)
+    
+    print("\n" + "=" * 70)
+    print("DONE")
+    print("=" * 70)
+    
+    conn.close()

--- a/research/chatgpt-import/issue60/stage4-findings.md
+++ b/research/chatgpt-import/issue60/stage4-findings.md
@@ -1,0 +1,36 @@
+# Issue #60 — Stage 4 findings
+
+Evidence archive: `issue60-stage4-evidence-20260809-224319.tar.gz`
+Canonical DB SHA-256: `23cfa3c8adb94ed403058329ae7e252e1d4c4bc01ead76e22ac7d0ff99948104`
+
+## PROVEN
+
+- Safety receipt is clean: canonical counts `sessions=7268/messages=231513/gateway_routing=78`, `quick_check=ok`, FK violations `0`, immutable/query-only access, before/after SHA and file identity unchanged.
+- All **5,447** final `chatgpt-export` sessions have `chatgpt_conversation_id`.
+- All **5,447** satisfy the generated identity relation `session.id == UTC(started_at) + conversation_id[:8]`; mismatches = **0**.
+- Stage 4's **4,655** `collision_relabel_residual_candidates` are not 4,655 native-collision fingerprints: every row has exactly one reason, `user_id_mismatch`. There are **0** rows in this set with generated-ID mismatch, missing conversation ID, native session fields, message tool fields, or tool calls.
+- The count split is exact:
+  - **792** rows have `user_id == conversation_id`;
+  - **4,655** rows do not.
+  Historical final-run evidence independently records **792** sessions inserted by the final pass, while **4,654** conversation IDs already existed before that pass and one v1 orphan was repaired afterward. This makes `user_id` behavior a very strong importer-generation discriminator.
+- Legacy `model_config` fields survive widely from pre-final passes: `chatgpt_memory_scope=4254`, `chatgpt_is_study_mode=4254`, `chatgpt_is_do_not_remember=3143`, `chatgpt_voice=17`, `chatgpt_pinned_time=2`. The recovered final importer writes none of these keys.
+- `message_count` drift exists in **1,174** imported sessions. Every drift is positive, and every affected session has `actual_messages / stored_message_count` exactly **3×, 4×, or 5×** (`32`, `618`, `524` sessions respectively). The total excess is **14,367** physical message rows.
+- There are **4,918** repeated non-empty ChatGPT message UUID groups. Across those groups:
+  - extra copies within the same session = `sum(copies - distinct_sessions)` = **14,365**;
+  - cross-session shared copies = `sum(distinct_sessions - 1)` = **1,363**.
+  The **14,365** same-session UUID replay rows plus the orphan's **2** empty-platform-ID rows equal the full **14,367** `message_count` excess exactly. This explains the stored-count drift as repeated message insertion/replay rather than random DB damage.
+- The only non-UUID/empty imported `platform_message_id` rows are message IDs **178232** and **178233**, both in repaired v1 orphan `20231013_125540_0041efa3`, with placeholder timestamps `1.0` and `2.0`.
+
+## STRONG INFERENCE
+
+- The **792** `user_id == conversation_id` rows are the exact final-pass inserts, while the **4,655** mismatches are rows already created by earlier passes (the historical 4,654 existing conversation IDs plus the subsequently repaired orphan). The numerical and field-shape match is exact, but a pre-final DB snapshot / explicit inserted-ID list would be the strongest possible row-by-row proof.
+- No surviving evidence supports the feared final-importer `IntegrityError -> UPDATE source='chatgpt-export'` path having relabelled a normal populated Hermes-native session. The Stage-3 native/tool/platform fingerprint audit was already empty; Stage 4 adds zero generated-ID or native/tool residuals. Treat the collision path as **not observed**, rather than claiming logical impossibility.
+- The final DB's 89,434 imported message rows overstate the original per-session importer counts by 14,367 replay rows. Summed stored `session.message_count` is therefore **75,067** versus 89,434 physical rows.
+
+## OPEN — narrow only
+
+- **953** repeated ChatGPT UUID groups span more than one imported session. These may be legitimate shared/cloned ChatGPT ancestry (for example branched conversations) rather than importer replay. Need compare role/timestamp/content hashes across member sessions before classifying them.
+- Inspect the repaired orphan's 8 physical message rows to determine how the two empty-ID placeholder rows relate to the later UUID-bearing rows.
+- Final source-side loss accounting still requires either the original export or sufficiently strong historical transcript evidence for data that never entered Hermes (non-string parts, content references, attachments/tool structures, alternate branches).
+
+Stage 5 (`extract_issue60_stage5.py`) is intentionally restricted to the first two OPEN DB-only questions and imported message-field presence. It does not restart broad provenance archaeology.

--- a/research/chatgpt-import/issue60/stage5-run.md
+++ b/research/chatgpt-import/issue60/stage5-run.md
@@ -1,0 +1,22 @@
+# Issue #60 — Stage 5 run
+
+Run against the canonical recovered DB from the #60 worktree:
+
+```bash
+cd ~/hermes-benchmark/hermes-issue60
+git fetch origin research/chatgpt-import-provenance-60:refs/remotes/origin/research/chatgpt-import-provenance-60
+git switch --detach refs/remotes/origin/research/chatgpt-import-provenance-60
+git rev-parse --short HEAD
+python3 research/chatgpt-import/extract_issue60_stage5.py
+```
+
+Copy the resulting archive to Windows:
+
+```bash
+mkdir -p /mnt/c/Users/weiti/Downloads/hermes-issue60-stage5
+latest="$(ls -1t issue60-stage5-evidence-*.tar.gz | head -n1)"
+cp -- "$latest" /mnt/c/Users/weiti/Downloads/hermes-issue60-stage5/
+echo "/mnt/c/Users/weiti/Downloads/hermes-issue60-stage5/$(basename "$latest")"
+```
+
+Stage 5 is DB-only and privacy-bounded: it emits hashes/lengths for sampled duplicate/orphan content, not raw private message text.


### PR DESCRIPTION
## Summary

Research-only evidence for #60: reconstruct how the ChatGPT export/history was merged into an **already-existing Hermes `state.db`**, including earlier partial/test import generations, final-pass behavior, message replay side effects, native-row preservation, and final fidelity limits.

**Ground truth:** Hermes runtime began **2026-05-29**; **2026-06-16 is the ChatGPT history import/merge date, not Hermes adoption**.

Refs #60 #58 #54.

## Added

Read-only, fail-closed evidence tools:

- `research/chatgpt-import/extract_issue60_evidence.py`
- `research/chatgpt-import/extract_issue60_stage2.py`
- `research/chatgpt-import/extract_issue60_stage3.py`
- `research/chatgpt-import/extract_issue60_stage4.py`
- `research/chatgpt-import/extract_issue60_stage5.py`

Durable public artifacts include:

- `research/chatgpt-import/issue60/README.md`
- `research/chatgpt-import/issue60/evidence-locators.md`
- `research/chatgpt-import/issue60/evidence-manifest.json`
- `research/chatgpt-import/issue60/recovered-import_final.py`
- `research/chatgpt-import/issue60/import-final-run-output.txt`
- `research/chatgpt-import/issue60/stage4-findings.md`
- `research/chatgpt-import/issue60/stage5-run.md`

Raw historical transcripts/evidence bundles remain private/local because this repo is public; exact locators and SHA identities are retained instead.

## PROVEN so far

### Existing Hermes DB

Historical representative-import evidence records `discord=620 / cron=252 / cli=15 / chatgpt-export=57`, proving the migration was into a populated Hermes DB. Stage 3 independently places the first surviving ChatGPT message at `messages.id=92691`, after messages from 883 distinct native sessions.

### Exact final importer

Historical message `188425` contains the exact `/tmp/chatgpt-export/import_final.py`; `188428` contains its exact final run output.

The final importer linearizes only the active ChatGPT branch:

```text
current_node
→ mapping.parent backward
→ skip null/non-message nodes
→ reverse
→ one Hermes session
```

Final recorded run:

```text
loaded conversations        5447
existing conversation IDs   4654
considered missing           793
new sessions                 792
new messages                3322
final chatgpt-export        5447
final imported messages    89434
duplicate conversation IDs     0
```

The one remaining v1 orphan `20231013_125540_0041efa3` is subsequently repaired from the export.

### Earlier importer generations survive final dedup

Stage 4 proves all 5,447 final imported sessions have a conversation ID and all satisfy `session.id == UTC(started_at) + conversation_id[:8]`.

Surviving field shape splits exactly:

```text
user_id == conversation_id      792
user_id != conversation_id     4655
```

That matches the historical final-pass count of 792 newly inserted sessions versus 4,654 existing conversation IDs + the subsequently repaired orphan. Treat this as strong importer-generation provenance; the final script's field mapping is not the field mapping of every final row.

Legacy pre-final metadata survives widely, including:

```text
chatgpt_memory_scope        4254
chatgpt_is_study_mode       4254
chatgpt_is_do_not_remember  3143
chatgpt_voice                 17
chatgpt_pinned_time             2
```

### Native-row collision/relabel path: not observed

Stage 3 finds zero `chatgpt-export` rows carrying audited native Hermes fingerprints (lineage/end/cwd/routing/tool/Discord-platform shapes). Stage 4's apparent 4,655 residuals are all **only** `user_id_mismatch`; there are zero generated-ID, missing-conversation-ID, native-field, or tool residuals.

There is therefore no surviving evidence that the final importer's `IntegrityError -> UPDATE source='chatgpt-export'` path relabelled a normal populated Hermes-native session. This is strong negative evidence, not a claim of logical impossibility.

### Message replay side effect — PROVEN

1,174 imported sessions have stale stored `message_count`. Every affected session is an exact replay multiple:

```text
3x   32 sessions
4x  618 sessions
5x  524 sessions
```

Physical excess over stored counts = **14,367 message rows**.

Duplicate ChatGPT UUID accounting explains it exactly:

```text
same-session extra UUID copies = 14,365
orphan empty-platform-ID rows  =      2
                                 -------
                                 14,367
```

So the final DB has 89,434 physical imported message rows versus 75,067 summed stored session counts because some import passes replayed entire message sequences.

The only empty/non-UUID imported platform IDs are two rows in the repaired v1 orphan with placeholder timestamps `1.0` and `2.0`.

## Final DB-only closure pass

Stage 5 is intentionally narrow. It only:

1. classifies the 953 duplicate ChatGPT UUID groups that span multiple imported sessions as exact clones vs conflicting data;
2. inspects the repaired orphan using hashes/metadata rather than publishing raw content;
3. records surviving imported message-field presence.

It does **not** restart broad provenance archaeology.

## Remaining source-side fidelity question

The exact importer structurally drops or transforms source data it does not map, including alternate branches, non-string `content.parts`, content references/attachments/tool structures, and null/non-message mapping nodes. Quantifying data that never entered Hermes requires the original ChatGPT export or equally strong historical source evidence.

## Canonical DB safety

```text
/home/skywind/hermes-recovery/runs/20260807-081043/state.recovered.patched.db
SHA-256 23cfa3c8adb94ed403058329ae7e252e1d4c4bc01ead76e22ac7d0ff99948104
```

Expected counts: 7,268 sessions / 231,513 messages / 78 gateway-routing rows.

All extractors use immutable/query-only access and verify source identity/hash before and after.

## Merge status

Still draft until Stage 5 resolves the last DB-only duplicate/orphan questions and #60 records the remaining source-side fidelity limits. No production code is changed.