### PR TITLE
Session metadata FTS: CJK high-water lifecycle (#26)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -190,6 +190,7 @@ infographics/
 infograficos/
 infografico/
 native/fts5_cjk/*.so
+native/fts5_cjk/*.dll
 # Runtime marker written by hermes update when a lazy dependency refresh is
 # interrupted; consumed by launch-time recovery. Never commit it (was tracked
 # by accident via 3a69e34702, removed in the #72002 salvage).

--- a/docs/design/session-metadata-fts.md
+++ b/docs/design/session-metadata-fts.md
@@ -198,16 +198,16 @@ mingw). The CJK tests build it on the fly in CI or honor a prebuilt
   storage-version settlement is #27).
 - `hermes_state_search.py` — shared `_FTS_MESSAGE_SPEC` / `_FTS_SESSION_SPEC` /
   `_FTS_SESSION_CJK_SPEC`, parameterized `fts_rebuild_status/step`,
-  `_fts_rebuild_finish` (honors the spec's operability gate + `finish_hook`),
-  `_seed_fts_rebuild_markers` / `_seed_session_cjk_fts_rebuild_markers`,
-  `_repair_missing_progress` (the shared crash-safe repair),
-  `_repair_optimize_bookkeeping` / `_repair_session_fts_bookkeeping` /
-  `_repair_session_cjk_fts_bookkeeping`, `_fts_cjk_reset_if_stale` /
-  `_fts_session_cjk_reset_if_stale`, `_fts_rebuild_pause`,
-  `fts_optimize_available` / `optimize_fts_storage` session (+ session-CJK)
-  phase.
-- `hermes_cli/session_recovery.py` — session markers treated as generated /
-  pending in offline recovery.
+  `_fts_rebuild_finish` (honors the spec's operability gate + `finish_hook`;
+  the session-CJK hook gates search-serving on "not stale"),
+  `_seed_fts_rebuild_markers` / `_seed_session_spec_rebuild_markers`,
+  `_repair_missing_progress` (the shared crash-safe repair) /
+  `_repair_session_spec_bookkeeping`, `_fts_reset_stale_cjk_surface` /
+  `_fts_cjk_reset_if_stale` / `_fts_session_cjk_reset_if_stale`,
+  `_fts_rebuild_pause`, `fts_optimize_available` / `optimize_fts_storage`
+  session (+ session-CJK) phase.
+- `hermes_cli/session_recovery.py` — session Unicode + CJK markers treated as
+  generated / pending in offline recovery.
 - `tests/test_session_metadata_fts.py` — rowid-hole migration (incl. legacy
   duplicate-title upgrade), raw Unicode external-content, H/P ownership
   regions, crash/restart (incl. the partial-index H-without-P orphan

--- a/docs/design/session-metadata-fts.md
+++ b/docs/design/session-metadata-fts.md
@@ -1,6 +1,7 @@
 # Session metadata FTS (#25) — stable `row_id` + resumable Unicode external-content index
 
-Status: **implemented on `fts/session-row-id-unicode-migration`** (fork #25).
+Status: **implemented** — #25 on `fts/session-row-id-unicode-migration`, its
+optional CJK variant (#26) on `fts/session-cjk-highwater`.
 
 This documents the architecture shipped by #25 and the invariants later tickets
 (#26 CJK, #27 unified lifecycle/storage settlement, #30 normalized trigram) build on.
@@ -131,28 +132,80 @@ helper returns `(fts_ok, candidates)`: when the `sessions_fts` MATCH lane
 itself fails, `fts_ok` is False so title resolution falls back to the LIKE
 lane instead of trusting a partial result.
 
+## CJK variant (issue #26)
+
+`sessions_fts_cjk` is an **optional CJK specialization** of the same
+architecture: the same external-content raw `(title, id, display_name)`
+document keyed by the same named `row_id`, but tokenized with the loadable
+`cjk_unicode61` bigram tokenizer. It does not get a second scheduler — it
+reuses the generic `_FTS_*_SPEC` chunk/finish/repair/pacing engine with its
+own spec.
+
+The one structural difference from Unicode is capability: the tokenizer is an
+optional loadable extension, so **worker operability** (can this process build
+/maintain the index) is a separate in-process fact from **search-serving
+availability** (is the index complete, non-stale, and queryable). A pending
+backfill is a valid `worker-operable = true, search-serving = false` state and
+the worker must still advance there — the donor deadlock that a single
+conflated boolean caused. Durable state is independent:
+`fts_session_cjk_rebuild_high_water` / `_progress` / `fts_session_cjk_stale`
+— never the Unicode-session pair, never the message-CJK pair.
+
+Degradation rules (pinned by tests):
+
+- A tokenizer-less host drops the unsafe CJK triggers only after persisting
+the stale breadcrumb, and **never clears pending H/P** — missing local
+capability is not evidence of completion.
+- A stale index (unknown post-drop gap) is never served and its triggers are
+not blindly reinstalled; a later capable host resets it to a known-empty
+surface and reseeds a fresh CJK H/P from current `MAX(row_id)`.
+- `#77629`: the same operability capability that gates the chunk step gates
+finish; only a successful boundary-sweep finish clears the CJK markers and
+flips search-serving on.
+- Pending/stale/unavailable CJK and lone single-CJK-character queries are
+served by the canonical Unicode/LIKE fallback — never a partial index.
+`_fts_cjk_metadata_candidates` returns `(servable, candidates)` so a valid
+zero-match is distinct from unservable (the seam #14 will route on).
+- All CJK MATCH runs through `_read_ctx()`; the dedicated
+`SessionDB(read_only=True)` attach probes/loads the tokenizer per connection,
+degrading to fallback on failure.
+
+The tokenizer ships as a loadable extension built from
+`native/fts5_cjk/fts5_cjk.c` (`build.sh` on Linux; a Windows `.dll` via
+mingw). The CJK tests build it on the fly in CI or honor a prebuilt
+`HERMES_FTS5_CJK_SO` artifact.
+
 ## Files
 
 - `hermes_state_common.py` — `SESSIONS_FTS_SQL` (external DDL + gated narrow
-  triggers), `SESSION_TABLE_REBUILD_SQL` / `SESSION_INDEX_SQL_STATEMENTS`
-  (the unique title index is deliberately excluded: the existing post-migration
-  duplicate-title repair owns it).
+  triggers), `SESSIONS_FTS_CJK_TABLE_SQL` / `SESSIONS_FTS_CJK_TRIGGER_SQL`
+  (split CJK DDL + gated narrow triggers), `_FTS_SESSION_CJK_TRIGGERS`,
+  `FTS_SESSION_CJK_STALE_KEY`, `SESSION_TABLE_REBUILD_SQL` /
+  `SESSION_INDEX_SQL_STATEMENTS` (the unique title index is deliberately
+  excluded: the existing post-migration duplicate-title repair owns it).
 - `hermes_state.py` — `_migrate_sessions_row_id`, `_ensure_sessions_fts_schema`,
-  `_db_has_internal_content_sessions_fts`, `_backfill_sessions_fts_cjk`,
-  `_session_fts_rebuild_gap`, `_fts_unicode61_fold`, `_fts_query_positive_terms`,
-  `_fts_metadata_candidates` (returns `(fts_ok, candidates)` sorted globally;
-  the gap supplement is a term-superset of the FTS predicate), updated
-  `_fts_numbered_variants`.
+  `_fts_session_schema_transition`, `_db_has_internal_content_sessions_fts`,
+  `_ensure_sessions_fts_cjk_schema`, `_fts_session_cjk_schema_transition`,
+  `_db_has_internal_content_sessions_fts_cjk`, `_session_fts_rebuild_gap`,
+  `_fts_unicode61_fold`, `_fts_query_positive_terms`, `_fts_metadata_candidates`
+  (returns `(fts_ok, candidates)` sorted globally; the gap supplement is a
+  term-superset of the FTS predicate), `_fts_cjk_metadata_candidates` (returns
+  `(servable, candidates)`; unservable on pending/stale/unavailable/lone-char),
+  updated `_fts_numbered_variants`.
 - `hermes_state_schema.py` — `_init_schema` wiring: the sessions-FTS block is
   placed OUTSIDE the message legacy/`else` branch so it runs for every message
   layout (the `fts_storage_version` stamp stays message-scoped; unified
   storage-version settlement is #27).
-- `hermes_state_search.py` — shared `_FTS_MESSAGE_SPEC` / `_FTS_SESSION_SPEC`,
-  parameterized `fts_rebuild_status/step`, `_fts_rebuild_finish`,
-  `_seed_fts_rebuild_markers`, `_repair_missing_progress` (the shared crash-safe
-  repair), `_repair_optimize_bookkeeping` / `_repair_session_fts_bookkeeping`,
-  `_fts_rebuild_pause`, `fts_optimize_available` / `optimize_fts_storage`
-  session phase.
+- `hermes_state_search.py` — shared `_FTS_MESSAGE_SPEC` / `_FTS_SESSION_SPEC` /
+  `_FTS_SESSION_CJK_SPEC`, parameterized `fts_rebuild_status/step`,
+  `_fts_rebuild_finish` (honors the spec's operability gate + `finish_hook`),
+  `_seed_fts_rebuild_markers` / `_seed_session_cjk_fts_rebuild_markers`,
+  `_repair_missing_progress` (the shared crash-safe repair),
+  `_repair_optimize_bookkeeping` / `_repair_session_fts_bookkeeping` /
+  `_repair_session_cjk_fts_bookkeeping`, `_fts_cjk_reset_if_stale` /
+  `_fts_session_cjk_reset_if_stale`, `_fts_rebuild_pause`,
+  `fts_optimize_available` / `optimize_fts_storage` session (+ session-CJK)
+  phase.
 - `hermes_cli/session_recovery.py` — session markers treated as generated /
   pending in offline recovery.
 - `tests/test_session_metadata_fts.py` — rowid-hole migration (incl. legacy

--- a/hermes_cli/session_recovery.py
+++ b/hermes_cli/session_recovery.py
@@ -59,6 +59,12 @@ _GENERATED_META_KEYS = frozenset({
     # the current schema on a fresh destination, never copied.
     "fts_session_rebuild_high_water",
     "fts_session_rebuild_progress",
+    # Session CJK metadata rebuild markers + stale breadcrumb (issue #26) -
+    # optional-CJK derived state, regenerated from the current schema on a
+    # fresh destination, never copied.
+    "fts_session_cjk_rebuild_high_water",
+    "fts_session_cjk_rebuild_progress",
+    "fts_session_cjk_stale",
     "telegram_dm_topic_schema_version",
 })
 
@@ -1110,6 +1116,9 @@ def _verify_recovered_database(
                 "fts_cjk_rebuild_progress",
                 "fts_session_rebuild_high_water",
                 "fts_session_rebuild_progress",
+                "fts_session_cjk_rebuild_high_water",
+                "fts_session_cjk_rebuild_progress",
+                "fts_session_cjk_stale",
             )
             if key in meta
         )

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2479,18 +2479,23 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         return "tool_name" not in sql
 
     @staticmethod
-    def _db_has_internal_content_sessions_fts(cursor: sqlite3.Cursor) -> bool:
-        """True when sessions_fts is the pre-#25 internal-content shape.
+    @staticmethod
+    def _db_has_internal_content_fts(
+        cursor: sqlite3.Cursor, table: str
+    ) -> bool:
+        """True when the given sessions FTS table is an internal-content shape.
 
-        #25's sessions_fts is external-content over raw (title, id,
-        display_name). The pre-#25 shape stores its own copy (title-only).
-        Detected by the absence of ``content=`` in the stored CREATE.
-        Returns False when sessions_fts doesn't exist yet (fresh DB mid-init):
-        the ensure path creates the external shape directly.
+        The #25/#26 external-content shape declares ``content=`` over the
+        canonical ``sessions`` table; any internal-content shape stores its
+        own copy (title-only, pre-#25/#26). Detected by the absence of
+        ``content=`` in the stored CREATE. Returns False when the table
+        doesn't exist yet (fresh DB mid-init): the ensure path creates the
+        external shape directly.
         """
         row = cursor.execute(
             "SELECT sql FROM sqlite_master "
-            "WHERE type = 'table' AND name = 'sessions_fts'"
+            "WHERE type = 'table' AND name = ?",
+            (table,),
         ).fetchone()
         if row is None:
             return False
@@ -2498,25 +2503,16 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         return "content=" not in sql
 
     @staticmethod
+    def _db_has_internal_content_sessions_fts(cursor: sqlite3.Cursor) -> bool:
+        """True when sessions_fts is the pre-#25 internal-content shape."""
+        return SessionDB._db_has_internal_content_fts(cursor, "sessions_fts")
+
+    @staticmethod
     def _db_has_internal_content_sessions_fts_cjk(
         cursor: sqlite3.Cursor,
     ) -> bool:
-        """True when sessions_fts_cjk is the pre-#26 internal title-only shape.
-
-        #26's sessions_fts_cjk is external-content over raw (title, id,
-        display_name). The pre-#26 shape stores its own copy (title-only).
-        Detected by the absence of ``content=`` in the stored CREATE.
-        Returns False when sessions_fts_cjk doesn't exist yet (fresh DB
-        mid-init): the ensure path creates the external shape directly.
-        """
-        row = cursor.execute(
-            "SELECT sql FROM sqlite_master "
-            "WHERE type = 'table' AND name = 'sessions_fts_cjk'"
-        ).fetchone()
-        if row is None:
-            return False
-        sql = (row[0] if not isinstance(row, sqlite3.Row) else row["sql"]) or ""
-        return "content=" not in sql
+        """True when sessions_fts_cjk is the pre-#26 internal title-only shape."""
+        return SessionDB._db_has_internal_content_fts(cursor, "sessions_fts_cjk")
 
     def _warn_trigram_unavailable(self, exc: sqlite3.OperationalError) -> None:
         """Log once that the trigram tokenizer is missing; base FTS5 stays enabled."""

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -6216,6 +6216,61 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             by_row_id.values(), key=lambda c: c["started_at"], reverse=True
         )
 
+    def _fts_cjk_metadata_candidates(
+        self, raw_query: str
+    ) -> Tuple[bool, Optional[List[Dict[str, Any]]]]:
+        """CJK session-metadata candidates over raw (title, id, display_name).
+
+        Optional CJK specialization of ``_fts_metadata_candidates`` (#26) over
+        the external-content ``sessions_fts_cjk``. Executes through
+        ``_read_ctx()`` — never the writer lock (the accepted read-path split).
+        Returns ``(servable, candidates)``:
+
+        - ``(False, None)`` — the CJK lane must NOT serve: the query is a lone
+          single CJK character (the bigram index's useful lower bound is two
+          CJK chars), the query cannot be sanitized, the index is pending or
+          stale, or the tokenizer is unavailable on this connection. Callers
+          route to the canonical Unicode/LIKE lane — a partial CJK index is
+          never served.
+        - ``(True, [])`` — servable, valid zero matches.
+        - ``(True, [...]``) — servable matches (``id`` / ``title`` /
+          ``display_name`` / ``started_at`` / ``row_id``, ``started_at DESC``).
+
+        The servable-vs-zero distinction is what lets #14 route ordinary CJK
+        picker queries without owning lifecycle state.
+        """
+        # A lone single CJK character cannot match inside longer runs in the
+        # bigram index — classify as fallback-only before touching the index.
+        if self._has_lone_cjk_run(raw_query):
+            return False, None
+        sanitized = self._sanitize_fts5_query(raw_query)
+        if not sanitized:
+            return False, None
+        if not getattr(self, "_sessions_cjk_available", False):
+            # Pending / stale / tokenizer-unavailable: not servable.
+            return False, None
+        with self._read_ctx() as conn:
+            try:
+                cursor = conn.execute(
+                    "SELECT s.id AS id, s.title, s.display_name, "
+                    "       s.started_at, s.row_id AS row_id "
+                    "FROM sessions_fts_cjk f "
+                    "JOIN sessions s ON s.row_id = f.rowid "
+                    "WHERE sessions_fts_cjk MATCH ? "
+                    "ORDER BY s.started_at DESC",
+                    (sanitized,),
+                )
+                candidates = [dict(row) for row in cursor]
+            except sqlite3.OperationalError:
+                # CJK lane unavailable/corrupt on this connection: signal
+                # fallback, never trust a partial result.
+                logging.debug(
+                    "sessions_fts_cjk MATCH failed for %r, falling back",
+                    raw_query, exc_info=True,
+                )
+                return False, None
+        return True, candidates
+
     def _fts_numbered_variants(
         self, title: str
     ) -> Optional[List[Dict[str, Any]]]:
@@ -6226,15 +6281,16 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         id / display_name and supplements the bounded ``(P, H]`` rebuild gap —
         title resolution therefore never returns incomplete results
         mid-backfill and the gap logic lives in exactly one place. CJK titles
-        keep their dedicated ``sessions_fts_cjk`` lane + gap supplement (the
-        CJK lifecycle is owned by #26).
+        delegate to the dedicated ``sessions_fts_cjk`` lane
+        (``_fts_cjk_metadata_candidates``), which owns the pending / stale /
+        unavailable / lone-char fallback decision; it never serves a partial
+        CJK index.
 
         Returns None to signal fallback to LIKE (e.g. FTS5 runtime error or
-        the target table unavailable). Returns empty list when no matches.
+        the target table unavailable / pending / stale). Returns empty list
+        when no matches.
         """
         is_cjk = self._contains_cjk(title)
-        if is_cjk and not getattr(self, "_sessions_cjk_available", False):
-            return None
         escaped = title.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
 
         # An unsanitizable query must signal "use the LIKE fallback" (None),
@@ -6243,55 +6299,13 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             return None
 
         if is_cjk:
-            fts_table = "sessions_fts_cjk"
-            sanitized = self._sanitize_fts5_query(title)
-            if not sanitized:
-                return None
-            with self._lock:
-                try:
-                    cursor = self._conn.execute(
-                        f"SELECT s.id AS id, s.title, s.started_at "
-                        f"FROM {fts_table} f "
-                        f"JOIN sessions s ON s.row_id = f.rowid "
-                        f"WHERE {fts_table} MATCH ? "
-                        f"ORDER BY s.started_at DESC",
-                        (sanitized,),
-                    )
-                    candidates = list(cursor)
-                except sqlite3.OperationalError:
-                    logging.debug(
-                        "%s MATCH failed for %r, falling back to LIKE",
-                        fts_table, sanitized, exc_info=True,
-                    )
-                    return None
-            filtered = [
+            servable, candidates = self._fts_cjk_metadata_candidates(title)
+            if not servable:
+                return None  # canonical LIKE fallback
+            return [
                 c for c in candidates
                 if c["title"] and c["title"].startswith(f"{escaped} #")
             ]
-            # Bounded-gap supplement (same rule as the Unicode lane, kept local
-            # for the CJK table which #26 will take over).
-            gap = self._session_fts_rebuild_gap()
-            if gap is not None:
-                progress, high_water = gap
-                with self._read_ctx() as conn:
-                    gap_rows = conn.execute(
-                        "SELECT id, title, started_at FROM sessions "
-                        "WHERE title LIKE ? ESCAPE '\\' "
-                        "AND row_id > ? AND row_id <= ? "
-                        "ORDER BY started_at DESC",
-                        (f"{escaped} #%", progress, high_water),
-                    ).fetchall()
-                gap_filtered = [
-                    c for c in gap_rows
-                    if c["title"] and c["title"].startswith(f"{escaped} #")
-                ]
-                by_id = {c["id"]: c for c in filtered}
-                for c in gap_filtered:
-                    by_id.setdefault(c["id"], c)
-                filtered = sorted(
-                    by_id.values(), key=lambda c: c["started_at"], reverse=True
-                )
-            return filtered
 
         # Non-CJK: the shared raw Unicode lane already merges the FTS
         # candidates with the bounded (P, H] gap, dedupes by row_id, and sorts

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2168,26 +2168,29 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                             )
                             is True
                         )
-                    # Session CJK metadata (issue #26): a read-only consumer
-                    # needs the tokenizer loaded on THIS connection to MATCH —
-                    # a writer-level _fts_cjk_loaded is not proof every read
-                    # connection can. Probe the table, then load best-effort;
-                    # a failed connection-local load degrades to fallback, not
-                    # a crash or a false "CJK available" claim. (The table
-                    # probe is a LIMIT 0 scan and does not tokenize.)
-                    if self._fts_table_probe(cursor, "sessions_fts_cjk") is True:
-                        self._sessions_cjk_worker_operable = (
-                            load_fts5_cjk_extension(self._conn)
-                        )
+                    # Session CJK metadata (issue #26): load the cjk_unicode61
+                    # tokenizer on THIS connection FIRST — custom FTS5
+                    # tokenizers are connection-local, and a vtable using one
+                    # cannot be instantiated before the tokenizer is
+                    # registered on that connection. Then check existence via
+                    # sqlite_master (no vtable instantiation) and the durable
+                    # pending/stale state. A failed connection-local load
+                    # degrades to fallback, never a crash or a false "CJK
+                    # available" claim.
+                    self._sessions_cjk_worker_operable = (
+                        load_fts5_cjk_extension(self._conn)
+                    )
+                    self._sessions_cjk_available = False
+                    if self._sessions_cjk_worker_operable and cursor.execute(
+                        "SELECT 1 FROM sqlite_master "
+                        "WHERE type = 'table' AND name = 'sessions_fts_cjk'"
+                    ).fetchone() is not None:
                         pending = cursor.execute(
                             "SELECT 1 FROM state_meta WHERE key IN "
                             "('fts_session_cjk_rebuild_high_water', "
                             f"'{FTS_SESSION_CJK_STALE_KEY}') LIMIT 1"
                         ).fetchone()
-                        self._sessions_cjk_available = (
-                            self._sessions_cjk_worker_operable
-                            and pending is None
-                        )
+                        self._sessions_cjk_available = pending is None
                 except BaseException:
                     conn, self._conn = self._conn, None
                     try:
@@ -2616,8 +2619,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             self._sessions_cjk_available = False
             return
 
-        # Capable host.
-        self._sessions_cjk_worker_operable = True
+        # Capable host — ``_sessions_cjk_worker_operable`` is derived AFTER the
+        # schema is actually ensured below, so a soft-failed transition never
+        # leaves a worker flag that cannot really operate the target (that
+        # would make ``optimize_fts_storage``'s phase-1d loop retry forever).
 
         # Detect / replace the pre-#26 internal title-only shape on a capable
         # host. Staged in a write transaction: seed the durable CJK-session
@@ -2697,19 +2702,23 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 ok = False
 
         if not ok:
+            self._sessions_cjk_worker_operable = False
             self._sessions_cjk_available = False
             return
 
         # Stale breadcrumb: a tokenizer-less process dropped the triggers at
         # an unknown point — the index has a gap of unknown extent. Do NOT
         # reinstall triggers (an external-content 'delete' for an unindexed
-        # rowid corrupts the index); the next `optimize-storage` run on a
-        # capable host resets and rebuilds from scratch.
+        # rowid corrupts the index), and the plain chunk worker must NOT
+        # operate a stale index either (its gap extends beyond any (P, H]).
+        # The next `optimize-storage` run on a capable host resets and
+        # rebuilds from scratch; the recreate re-derives worker operability.
         stale = cursor.execute(
             "SELECT 1 FROM state_meta WHERE key = ?",
             (FTS_SESSION_CJK_STALE_KEY,),
         ).fetchone()
         if stale:
+            self._sessions_cjk_worker_operable = False
             self._sessions_cjk_available = False
             return
 
@@ -2720,9 +2729,13 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 "sessions_fts_cjk trigger ensure failed; CJK session search "
                 "stays on the Unicode/LIKE lane", exc_info=True,
             )
+            self._sessions_cjk_worker_operable = False
             self._sessions_cjk_available = False
             return
 
+        # Schema + triggers are in place — this worker can genuinely operate
+        # the target now.
+        self._sessions_cjk_worker_operable = True
         backfill_pending = cursor.execute(
             "SELECT 1 FROM state_meta "
             "WHERE key = 'fts_session_cjk_rebuild_high_water' LIMIT 1"
@@ -6242,9 +6255,25 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         if not sanitized:
             return False, None
         if not getattr(self, "_sessions_cjk_available", False):
-            # Pending / stale / tokenizer-unavailable: not servable.
+            # Process-local hint: this process knows the index is not servable.
             return False, None
         with self._read_ctx() as conn:
+            # Durable source of truth, read in the SAME snapshot as the MATCH:
+            # a stale breadcrumb or pending H/P written by ANY process (e.g. a
+            # tokenizer-less sibling sharing this state.db) must make the CJK
+            # lane unservable even when this process's cached
+            # ``_sessions_cjk_available`` is stale. The process-local flag is
+            # only a hint, never the source of truth.
+            if conn.execute(
+                "SELECT 1 FROM state_meta WHERE key = ?",
+                (FTS_SESSION_CJK_STALE_KEY,),
+            ).fetchone() is not None:
+                return False, None
+            if conn.execute(
+                "SELECT 1 FROM state_meta WHERE key = ?",
+                ("fts_session_cjk_rebuild_high_water",),
+            ).fetchone() is not None:
+                return False, None
             try:
                 cursor = conn.execute(
                     "SELECT s.id AS id, s.title, s.display_name, "
@@ -6257,7 +6286,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 )
                 candidates = [dict(row) for row in cursor]
             except sqlite3.OperationalError:
-                # CJK lane unavailable/corrupt on this connection: signal
+                # CJK lane unavailable/corrupt on this connection (e.g. the
+                # tokenizer did not load on this read connection): signal
                 # fallback, never trust a partial result.
                 logging.debug(
                     "sessions_fts_cjk MATCH failed for %r, falling back",

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -50,6 +50,7 @@ from hermes_state_common import (  # noqa: F401  (re-exported for back-compat)
     _BRANCH_CHILD_SQL,
     _COMPRESSION_CHILD_SQL,
     _FTS_CJK_TRIGGERS,
+    _FTS_SESSION_CJK_TRIGGERS,
     _FTS_TRIGGERS,
     _LISTABLE_CHILD_SQL,
     _PREVIEW_RAW_SELECT,
@@ -59,6 +60,7 @@ from hermes_state_common import (  # noqa: F401  (re-exported for back-compat)
     _sql_session_last_active_by_id,
     DEFERRED_INDEX_SQL,
     FTS_CJK_STALE_KEY,
+    FTS_SESSION_CJK_STALE_KEY,
     FTS_SQL,
     FTS_STORAGE_VERSION,
     FTS_TRIGRAM_SQL,
@@ -67,6 +69,8 @@ from hermes_state_common import (  # noqa: F401  (re-exported for back-compat)
     MAX_FTS5_QUERY_CHARS,
     SCHEMA_SQL,
     SCHEMA_VERSION,
+    SESSIONS_FTS_CJK_TABLE_SQL,
+    SESSIONS_FTS_CJK_TRIGGER_SQL,
     SESSIONS_FTS_SQL,
     _PREVIEW_CONTENT_SQL,
     _PREVIEW_HEAD_CHARS,
@@ -249,6 +253,13 @@ def _split_fts_sql_statements(ddl: str) -> List[str]:
 # three gated triggers), executed individually inside the crash-atomic
 # transition's BEGIN IMMEDIATE.
 _SESSIONS_FTS_STATEMENTS = _split_fts_sql_statements(SESSIONS_FTS_SQL)
+
+# The #26 sessions_fts_cjk DDL split into its five statements (external table
+# + three gated triggers, over the same canonical (title, id, display_name)
+# document), executed individually inside the CJK crash-atomic transition.
+_SESSIONS_FTS_CJK_STATEMENTS = _split_fts_sql_statements(
+    SESSIONS_FTS_CJK_TABLE_SQL + SESSIONS_FTS_CJK_TRIGGER_SQL
+)
 
 
 def _scrub_surrogates(value: Any) -> Any:
@@ -2097,6 +2108,14 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         # _init_schema / _probe_fts_cjk.
         self._fts_cjk_loaded = False
         self._fts_cjk_available = False
+        # Session CJK metadata (issue #26): _sessions_cjk_worker_operable is
+        # whether THIS process can build/maintain the sessions_fts_cjk index
+        # (tokenizer loaded on this connection); _sessions_cjk_available is
+        # search-serving availability (index complete, non-stale, queryable).
+        # They are deliberately separate: a pending backfill is W=1/S=0 and
+        # the rebuild worker must still advance there.
+        self._sessions_cjk_worker_operable = False
+        self._sessions_cjk_available = False
         self._fts_unavailable_warned = False
         self._conn = None
         # Async token accounting (see queue_token_counts). The condition
@@ -2148,6 +2167,26 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                                 "messages_fts_trigram",
                             )
                             is True
+                        )
+                    # Session CJK metadata (issue #26): a read-only consumer
+                    # needs the tokenizer loaded on THIS connection to MATCH —
+                    # a writer-level _fts_cjk_loaded is not proof every read
+                    # connection can. Probe the table, then load best-effort;
+                    # a failed connection-local load degrades to fallback, not
+                    # a crash or a false "CJK available" claim. (The table
+                    # probe is a LIMIT 0 scan and does not tokenize.)
+                    if self._fts_table_probe(cursor, "sessions_fts_cjk") is True:
+                        self._sessions_cjk_worker_operable = (
+                            load_fts5_cjk_extension(self._conn)
+                        )
+                        pending = cursor.execute(
+                            "SELECT 1 FROM state_meta WHERE key IN "
+                            "('fts_session_cjk_rebuild_high_water', "
+                            f"'{FTS_SESSION_CJK_STALE_KEY}') LIMIT 1"
+                        ).fetchone()
+                        self._sessions_cjk_available = (
+                            self._sessions_cjk_worker_operable
+                            and pending is None
                         )
                 except BaseException:
                     conn, self._conn = self._conn, None
@@ -2458,6 +2497,27 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         sql = (row[0] if not isinstance(row, sqlite3.Row) else row["sql"]) or ""
         return "content=" not in sql
 
+    @staticmethod
+    def _db_has_internal_content_sessions_fts_cjk(
+        cursor: sqlite3.Cursor,
+    ) -> bool:
+        """True when sessions_fts_cjk is the pre-#26 internal title-only shape.
+
+        #26's sessions_fts_cjk is external-content over raw (title, id,
+        display_name). The pre-#26 shape stores its own copy (title-only).
+        Detected by the absence of ``content=`` in the stored CREATE.
+        Returns False when sessions_fts_cjk doesn't exist yet (fresh DB
+        mid-init): the ensure path creates the external shape directly.
+        """
+        row = cursor.execute(
+            "SELECT sql FROM sqlite_master "
+            "WHERE type = 'table' AND name = 'sessions_fts_cjk'"
+        ).fetchone()
+        if row is None:
+            return False
+        sql = (row[0] if not isinstance(row, sqlite3.Row) else row["sql"]) or ""
+        return "content=" not in sql
+
     def _warn_trigram_unavailable(self, exc: sqlite3.OperationalError) -> None:
         """Log once that the trigram tokenizer is missing; base FTS5 stays enabled."""
         if getattr(self, "_trigram_unavailable_warned", False):
@@ -2486,42 +2546,247 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             exc,
         )
 
-    @staticmethod
-    def _backfill_sessions_fts_cjk(cursor) -> None:
-        """Backfill existing session titles into the legacy CJK table.
+    def _ensure_sessions_fts_cjk_schema(self, cursor) -> None:
+        """Create / repair / self-heal the session CJK metadata index (#26).
 
-        ``cursor`` may be a Cursor or a Connection (both expose ``execute``).
-        The Unicode sessions_fts is no longer backfilled here (issue #25): it
-        is external-content and rebuilt by the resumable H/P chunk engine
-        (``fts_session_rebuild_step``), with search supplementing the bounded
-        gap meanwhile. The cjk table stays internal-content and one-shot
-        backfilled (the CJK lifecycle is owned by #26); it runs in
-        progressive batches with a short breather so the gateway writer is
-        not starved.
+        ``cursor`` may be a Cursor or a Connection (both expose execute /
+        executescript). Called unconditionally from schema init on every
+        writable open — a tokenizer-less host must still be able to degrade
+        the session-CJK surface safely. Sets ``self._sessions_cjk_worker_operable``
+        (can this process build/maintain the CJK index) and
+        ``self._sessions_cjk_available`` (is the completed index search-
+        serving) — two separate facts: a pending backfill is worker-operable
+        while search-unavailable, and the worker must still advance there.
+        Never raises; every failure mode degrades to "no CJK session index"
+        (Unicode session search keeps working).
+
+        Cases:
+          tokenizer NOT loaded, table present with live triggers → drop the
+              session-CJK triggers so canonical session writes don't fail
+              inside them, and persist the durable stale breadcrumb (which
+              the Unicode surface ignores). Pending H/P is NEVER cleared
+              merely because this host cannot operate it.
+          tokenizer loaded, legacy internal table present → replace it with
+              the external shape, seeding CJK-session H/P for populated
+              canonical rows (an empty external index is never served as
+              complete).
+          tokenizer loaded, fresh table → create external table + gated
+              triggers. Empty DB: complete by construction. Populated DB:
+              seed CJK-session H/P so the resumable chunk engine backfills.
+          tokenizer loaded, table present with stale breadcrumb → do NOT
+              reinstall triggers (the post-stale gap is of unknown extent;
+              external-content deletes against never-indexed rowids are
+              unsafe). A later ``optimize-storage`` on a capable host resets
+              and rebuilds from a fresh high-water.
         """
-        conn = getattr(cursor, "connection", cursor)
-        cursor.execute(
-            "SELECT _rowid_ FROM sessions WHERE title IS NOT NULL "
-            "AND _rowid_ NOT IN (SELECT rowid FROM sessions_fts_cjk)"
-        )
-        missing = [row[0] for row in cursor.fetchall()]
-        if missing:
-            batch_sizes = [500, 200, 100, 50]
-            remaining = list(missing)
-            while remaining:
-                bs = batch_sizes.pop(0) if batch_sizes else 50
-                batch = remaining[:bs]
-                remaining = remaining[bs:]
-                placeholders = ",".join("?" for _ in batch)
-                cursor.execute(
-                    f"INSERT OR IGNORE INTO sessions_fts_cjk(rowid, title) "
-                    f"SELECT _rowid_, COALESCE(title, '') FROM sessions "
-                    f"WHERE _rowid_ IN ({placeholders})",
-                    batch,
+        cjk_present = bool(cursor.execute(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' "
+            "AND name = 'sessions_fts_cjk'"
+        ).fetchone())
+
+        if not self._fts_cjk_loaded:
+            self._sessions_cjk_worker_operable = False
+            if cjk_present:
+                live = [
+                    r[0] for r in cursor.execute(
+                        "SELECT name FROM sqlite_master WHERE type = 'trigger' "
+                        f"AND name IN ({','.join('?' for _ in _FTS_SESSION_CJK_TRIGGERS)})",
+                        _FTS_SESSION_CJK_TRIGGERS,
+                    ).fetchall()
+                ]
+                if live:
+                    # Self-heal: this process cannot tokenize, so every
+                    # session write would die inside the session-CJK trigger.
+                    # Breadcrumb FIRST (a crash between the two statements is
+                    # merely conservative), then drop. Missing local capability
+                    # is NEVER evidence that durable CJK work is complete —
+                    # pending H/P is left untouched.
+                    logger.warning(
+                        "sessions_fts_cjk triggers present but the "
+                        "cjk_unicode61 tokenizer is unavailable (%s) — "
+                        "dropping the session-CJK triggers so session writes "
+                        "keep working. CJK session search falls back to the "
+                        "Unicode/LIKE lane; run `hermes sessions "
+                        "optimize-storage` on a host with the extension to "
+                        "rebuild.",
+                        fts5_cjk_so_path(),
+                    )
+                    cursor.execute(
+                        "INSERT INTO state_meta (key, value) VALUES (?, '1') "
+                        "ON CONFLICT(key) DO UPDATE SET value = '1'",
+                        (FTS_SESSION_CJK_STALE_KEY,),
+                    )
+                    for trig in live:
+                        cursor.execute(f"DROP TRIGGER IF EXISTS {trig}")
+            self._sessions_cjk_available = False
+            return
+
+        # Capable host.
+        self._sessions_cjk_worker_operable = True
+
+        # Detect / replace the pre-#26 internal title-only shape on a capable
+        # host. Staged in a write transaction: seed the durable CJK-session
+        # H/P claim (an empty external index is never served as complete),
+        # then tear down the old internal table + its triggers. The external
+        # schema ensure runs after (it uses executescript, which issues an
+        # implicit COMMIT).
+        if self._db_has_internal_content_sessions_fts_cjk(cursor):
+            def _stage(conn):
+                hw = int(conn.execute(
+                    "SELECT COALESCE(MAX(row_id), 0) FROM sessions"
+                ).fetchone()[0])
+                if hw > 0:
+                    for k, v in (
+                        ("fts_session_cjk_rebuild_high_water", str(hw)),
+                        ("fts_session_cjk_rebuild_progress", "0"),
+                    ):
+                        conn.execute(
+                            "INSERT INTO state_meta (key, value) VALUES (?, ?) "
+                            "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                            (k, v),
+                        )
+                else:
+                    # Zero sessions: complete by construction; clear any
+                    # stale markers left by an earlier interrupted open.
+                    conn.execute(
+                        "DELETE FROM state_meta WHERE key IN "
+                        "('fts_session_cjk_rebuild_high_water', "
+                        "'fts_session_cjk_rebuild_progress')"
+                    )
+                for trig in _FTS_SESSION_CJK_TRIGGERS:
+                    conn.execute(f"DROP TRIGGER IF EXISTS {trig}")
+                for tbl in (
+                    "sessions_fts_cjk", "sessions_fts_cjk_data",
+                    "sessions_fts_cjk_idx", "sessions_fts_cjk_content",
+                    "sessions_fts_cjk_docsize", "sessions_fts_cjk_config",
+                ):
+                    conn.execute(f"DROP TABLE IF EXISTS {tbl}")
+            self._execute_write(_stage)
+            logger.warning(
+                "Replacing legacy internal sessions_fts_cjk with the "
+                "external-content CJK metadata index (issue #26); historical "
+                "backfill staged with a durable high-water claim"
+            )
+
+        # Track whether the external table is being created NOW (fresh) vs
+        # already present (reopen). A fresh external table over a populated
+        # DB needs a durable CJK-session H/P claim; an existing table's rows
+        # were either live-indexed by the triggers or are already covered by
+        # durable markers — seeding again would duplicate documents on the
+        # next backfill.
+        existing = bool(cursor.execute(
+            "SELECT 1 FROM sqlite_master "
+            "WHERE type = 'table' AND name = 'sessions_fts_cjk'"
+        ).fetchone())
+
+        # Fresh-create path: stage the durable claim BEFORE the empty external
+        # table can exist (the #76832 invariant analog). A crash between the
+        # claim commit and the schema ensure leaves markers without a table;
+        # reopen re-ensures the schema and finds the claim already durable.
+        if not existing and self.get_meta(
+            "fts_session_cjk_rebuild_high_water"
+        ) is None:
+            self._seed_session_cjk_fts_rebuild_markers(cursor)
+
+        if not existing:
+            ok = self._fts_session_cjk_schema_transition(cursor)
+        else:
+            try:
+                cursor.executescript(SESSIONS_FTS_CJK_TABLE_SQL)
+                ok = True
+            except sqlite3.OperationalError:
+                logger.warning(
+                    "sessions_fts_cjk ensure failed; CJK session search "
+                    "stays on the Unicode/LIKE lane", exc_info=True,
                 )
-                conn.commit()
-                if remaining:
-                    time.sleep(0.05)  # 50ms breather for gateway writer
+                ok = False
+
+        if not ok:
+            self._sessions_cjk_available = False
+            return
+
+        # Stale breadcrumb: a tokenizer-less process dropped the triggers at
+        # an unknown point — the index has a gap of unknown extent. Do NOT
+        # reinstall triggers (an external-content 'delete' for an unindexed
+        # rowid corrupts the index); the next `optimize-storage` run on a
+        # capable host resets and rebuilds from scratch.
+        stale = cursor.execute(
+            "SELECT 1 FROM state_meta WHERE key = ?",
+            (FTS_SESSION_CJK_STALE_KEY,),
+        ).fetchone()
+        if stale:
+            self._sessions_cjk_available = False
+            return
+
+        try:
+            cursor.executescript(SESSIONS_FTS_CJK_TRIGGER_SQL)
+        except sqlite3.OperationalError:
+            logger.warning(
+                "sessions_fts_cjk trigger ensure failed; CJK session search "
+                "stays on the Unicode/LIKE lane", exc_info=True,
+            )
+            self._sessions_cjk_available = False
+            return
+
+        backfill_pending = cursor.execute(
+            "SELECT 1 FROM state_meta "
+            "WHERE key = 'fts_session_cjk_rebuild_high_water' LIMIT 1"
+        ).fetchone()
+        self._sessions_cjk_available = not backfill_pending
+
+    def _fts_session_cjk_schema_transition(self, cursor) -> bool:
+        """Crash-atomic install of the #26 external sessions_fts_cjk schema AND
+        the trigger-owned-region catch-up, in one ``BEGIN IMMEDIATE``.
+
+        Mirrors ``_fts_session_schema_transition`` (#25) for the CJK surface:
+        the DDL (external table + the three CJK-session gated triggers) and
+        the catch-up INSERT land in ONE write transaction. The catch-up
+        indexes any row committed by another connection in the trigger-free
+        window after the H/P claim was staged but before the triggers existed
+        — rows ``> H`` (live-owned) or ``<= P`` (already backfilled) that the
+        index is missing. This is what makes the external-content DELETE
+        trigger safe: a row can never be deleted later for a rowid the index
+        never held. DDL runs via individual ``execute`` (not executescript,
+        whose implicit COMMIT would break the transaction).
+        """
+        def _do(conn):
+            for stmt in _SESSIONS_FTS_CJK_STATEMENTS:
+                conn.execute(stmt)
+            conn.execute(
+                "INSERT INTO sessions_fts_cjk(rowid, title, id, display_name) "
+                "SELECT s.row_id, s.title, s.id, s.display_name "
+                "FROM sessions s "
+                "WHERE (s.row_id > COALESCE("
+                "    (SELECT CAST(value AS INTEGER) FROM state_meta "
+                "     WHERE key = 'fts_session_cjk_rebuild_high_water'), -1)"
+                "   OR s.row_id <= COALESCE("
+                "    (SELECT CAST(value AS INTEGER) FROM state_meta "
+                "     WHERE key = 'fts_session_cjk_rebuild_progress'), -1))"
+                "  AND NOT EXISTS ("
+                "    SELECT 1 FROM sessions_fts_cjk_docsize d WHERE d.id = s.row_id"
+                "  )"
+            )
+        # Schema-init bookkeeping must not advance the routine-write merge
+        # cadence (the write-path cadence test asserts exact boundaries).
+        before = self._write_count
+        try:
+            self._execute_write(_do)
+        except sqlite3.OperationalError as exc:
+            if "no such module" in str(exc).lower() and "fts5" in str(exc).lower():
+                self._warn_fts5_unavailable(exc)
+                return False
+            # Any other failure (most commonly "no such tokenizer:
+            # cjk_unicode61" when the extension loaded but registration
+            # failed) degrades ONLY the optional CJK surface — never disable
+            # the whole FTS path for an optional tokenizer.
+            logger.warning(
+                "sessions_fts_cjk transition failed; CJK session search stays "
+                "on the Unicode/LIKE lane", exc_info=True,
+            )
+            return False
+        finally:
+            self._write_count = before
+        return True
 
     def _ensure_sessions_fts_schema(self, cursor: sqlite3.Cursor) -> bool:
         """Migrate / self-heal the session Unicode metadata FTS surface (#25).

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2479,7 +2479,6 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         return "tool_name" not in sql
 
     @staticmethod
-    @staticmethod
     def _db_has_internal_content_fts(
         cursor: sqlite3.Cursor, table: str
     ) -> bool:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -6246,6 +6246,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
         The servable-vs-zero distinction is what lets #14 route ordinary CJK
         picker queries without owning lifecycle state.
+
+        The durable guard checks and the MATCH run inside ONE explicit read
+        transaction, so ``(servable=True, ...)`` always reflects a single
+        consistent SQLite snapshot — never a torn read of a partially-mutated
+        index that a concurrent writer landed between a standalone guard
+        statement and the MATCH.
         """
         # A lone single CJK character cannot match inside longer runs in the
         # bigram index — classify as fallback-only before touching the index.
@@ -6258,43 +6264,70 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             # Process-local hint: this process knows the index is not servable.
             return False, None
         with self._read_ctx() as conn:
-            # Durable source of truth, read in the SAME snapshot as the MATCH:
-            # a stale breadcrumb or pending H/P written by ANY process (e.g. a
-            # tokenizer-less sibling sharing this state.db) must make the CJK
-            # lane unservable even when this process's cached
-            # ``_sessions_cjk_available`` is stale. The process-local flag is
-            # only a hint, never the source of truth.
-            if conn.execute(
+            # ONE SQLite snapshot for the durable guard reads AND the MATCH.
+            # ``_read_ctx()`` connections are autocommit (isolation_level
+            # = None), so each SELECT would otherwise open a FRESH read
+            # transaction — a concurrent writer could land stale/drop/mutate
+            # between the guard and the MATCH, and the lane would serve a
+            # partial index. An explicit deferred read transaction fixes the
+            # guard+MATCH to a single snapshot: under WAL it is snapshot-only
+            # (never blocks the writer) and costs nothing on the hot path.
+            began = False
+            if not conn.in_transaction:
+                try:
+                    conn.execute("BEGIN")
+                    began = True
+                except sqlite3.OperationalError:
+                    # Already inside a transaction (or cannot begin here):
+                    # the reads still share whatever snapshot already exists.
+                    began = False
+            try:
+                if self._cjk_lane_durable_guarded(conn):
+                    return False, None
+                try:
+                    cursor = conn.execute(
+                        "SELECT s.id AS id, s.title, s.display_name, "
+                        "       s.started_at, s.row_id AS row_id "
+                        "FROM sessions_fts_cjk f "
+                        "JOIN sessions s ON s.row_id = f.rowid "
+                        "WHERE sessions_fts_cjk MATCH ? "
+                        "ORDER BY s.started_at DESC",
+                        (sanitized,),
+                    )
+                    candidates = [dict(row) for row in cursor]
+                except sqlite3.OperationalError:
+                    # CJK lane unavailable/corrupt on this connection (e.g.
+                    # the tokenizer did not load on this read connection):
+                    # signal fallback, never trust a partial result.
+                    logging.debug(
+                        "sessions_fts_cjk MATCH failed for %r, falling back",
+                        raw_query, exc_info=True,
+                    )
+                    return False, None
+            finally:
+                if began:
+                    conn.execute("COMMIT")
+        return True, candidates
+
+    def _cjk_lane_durable_guarded(self, conn) -> bool:
+        """True when a durable CJK guard is present on ``conn``'s snapshot.
+
+        Either the stale breadcrumb (a tokenizer-less sibling dropped the CJK
+        triggers over an index gap of unknown extent) or a pending high-water
+        claim (a rebuild in flight) makes the CJK lane unservable — a partial
+        index is never served. Must be evaluated on the SAME connection /
+        snapshot that runs the MATCH (see ``_fts_cjk_metadata_candidates``).
+        """
+        return (
+            conn.execute(
                 "SELECT 1 FROM state_meta WHERE key = ?",
                 (FTS_SESSION_CJK_STALE_KEY,),
-            ).fetchone() is not None:
-                return False, None
-            if conn.execute(
+            ).fetchone() is not None
+            or conn.execute(
                 "SELECT 1 FROM state_meta WHERE key = ?",
                 ("fts_session_cjk_rebuild_high_water",),
-            ).fetchone() is not None:
-                return False, None
-            try:
-                cursor = conn.execute(
-                    "SELECT s.id AS id, s.title, s.display_name, "
-                    "       s.started_at, s.row_id AS row_id "
-                    "FROM sessions_fts_cjk f "
-                    "JOIN sessions s ON s.row_id = f.rowid "
-                    "WHERE sessions_fts_cjk MATCH ? "
-                    "ORDER BY s.started_at DESC",
-                    (sanitized,),
-                )
-                candidates = [dict(row) for row in cursor]
-            except sqlite3.OperationalError:
-                # CJK lane unavailable/corrupt on this connection (e.g. the
-                # tokenizer did not load on this read connection): signal
-                # fallback, never trust a partial result.
-                logging.debug(
-                    "sessions_fts_cjk MATCH failed for %r, falling back",
-                    raw_query, exc_info=True,
-                )
-                return False, None
-        return True, candidates
+            ).fetchone() is not None
+        )
 
     def _fts_numbered_variants(
         self, title: str

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -710,29 +710,81 @@ BEGIN
 END;
 """
 
-# CJK title search — cjk_unicode61 loadable tokenizer, mirroring
-# messages_fts_cjk. Requires libfts5_cjk.so (native/fts5_cjk/build.sh);
-# callers gate table creation on the extension being loaded and fall back
-# to LIKE when it is absent.
-SESSIONS_FTS_CJK_SQL = """
+# ── Sessions CJK metadata FTS (issue #26) ──────────────────────────────
+# Optional CJK specialization of the #25 Unicode session architecture: the
+# SAME external-content raw ``(title, id, display_name)`` document keyed by
+# the SAME named ``sessions.row_id``, but tokenized with the loadable
+# cjk_unicode61 bigram tokenizer. It has its own durable H/P marker pair
+# (``fts_session_cjk_rebuild_high_water`` / ``fts_session_cjk_rebuild_progress``)
+# and its own stale key (``fts_session_cjk_stale``) so optional tokenizer
+# availability can never gate or corrupt the complete Unicode index. Split
+# table/trigger DDL so a stale optional index can exist while unsafe triggers
+# remain absent. The trigger predicates mirror #25 with the CJK-session
+# marker names, and the UPDATE trigger fires only on title/id/display_name
+# changes (AFTER UPDATE OF plus a value-change guard).
+SESSIONS_FTS_CJK_TABLE_SQL = """
 CREATE VIRTUAL TABLE IF NOT EXISTS sessions_fts_cjk USING fts5(
     title,
+    id,
+    display_name,
+    content='sessions',
+    content_rowid='row_id',
     tokenize='cjk_unicode61'
 );
+"""
 
-CREATE TRIGGER IF NOT EXISTS sessions_fts_cjk_insert AFTER INSERT ON sessions BEGIN
-    INSERT INTO sessions_fts_cjk(rowid, title) VALUES (new.rowid, new.title);
+SESSIONS_FTS_CJK_TRIGGER_SQL = """
+CREATE TRIGGER IF NOT EXISTS sessions_fts_cjk_insert AFTER INSERT ON sessions
+WHEN (new.row_id > COALESCE((SELECT CAST(value AS INTEGER) FROM state_meta
+                             WHERE key = 'fts_session_cjk_rebuild_high_water'), -1)
+   OR new.row_id <= COALESCE((SELECT CAST(value AS INTEGER) FROM state_meta
+                              WHERE key = 'fts_session_cjk_rebuild_progress'), -1))
+BEGIN
+    INSERT INTO sessions_fts_cjk(rowid, title, id, display_name)
+    VALUES (new.row_id, new.title, new.id, new.display_name);
 END;
 
-CREATE TRIGGER IF NOT EXISTS sessions_fts_cjk_delete AFTER DELETE ON sessions BEGIN
-    DELETE FROM sessions_fts_cjk WHERE rowid = old.rowid;
+CREATE TRIGGER IF NOT EXISTS sessions_fts_cjk_delete AFTER DELETE ON sessions
+WHEN (old.row_id > COALESCE((SELECT CAST(value AS INTEGER) FROM state_meta
+                             WHERE key = 'fts_session_cjk_rebuild_high_water'), -1)
+   OR old.row_id <= COALESCE((SELECT CAST(value AS INTEGER) FROM state_meta
+                              WHERE key = 'fts_session_cjk_rebuild_progress'), -1))
+BEGIN
+    INSERT INTO sessions_fts_cjk(sessions_fts_cjk, rowid, title, id, display_name)
+    VALUES ('delete', old.row_id, old.title, old.id, old.display_name);
 END;
 
-CREATE TRIGGER IF NOT EXISTS sessions_fts_cjk_update AFTER UPDATE ON sessions BEGIN
-    DELETE FROM sessions_fts_cjk WHERE rowid = old.rowid;
-    INSERT INTO sessions_fts_cjk(rowid, title) VALUES (new.rowid, new.title);
+CREATE TRIGGER IF NOT EXISTS sessions_fts_cjk_update
+AFTER UPDATE OF title, id, display_name ON sessions
+WHEN (old.title IS NOT new.title
+   OR old.id IS NOT new.id
+   OR old.display_name IS NOT new.display_name)
+   AND (old.row_id > COALESCE((SELECT CAST(value AS INTEGER) FROM state_meta
+                               WHERE key = 'fts_session_cjk_rebuild_high_water'), -1)
+     OR old.row_id <= COALESCE((SELECT CAST(value AS INTEGER) FROM state_meta
+                                WHERE key = 'fts_session_cjk_rebuild_progress'), -1))
+BEGIN
+    INSERT INTO sessions_fts_cjk(sessions_fts_cjk, rowid, title, id, display_name)
+    VALUES ('delete', old.row_id, old.title, old.id, old.display_name);
+    INSERT INTO sessions_fts_cjk(rowid, title, id, display_name)
+    VALUES (new.row_id, new.title, new.id, new.display_name);
 END;
 """
+
+
+_FTS_SESSION_CJK_TRIGGERS = (
+    "sessions_fts_cjk_insert",
+    "sessions_fts_cjk_delete",
+    "sessions_fts_cjk_update",
+)
+
+
+# state_meta breadcrumb set when a tokenizer-less process had to drop the
+# session-CJK triggers to keep canonical session writes alive: rows written
+# from that moment on are missing from the CJK index, so it must not serve
+# reads until a capable host resets and rebuilds. Distinct from the message
+# ``FTS_CJK_STALE_KEY`` and from the Unicode-session markers.
+FTS_SESSION_CJK_STALE_KEY = "fts_session_cjk_stale"
 
 LEGACY_FTS_SQL = """
 CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -24,7 +24,6 @@ from hermes_state_common import (
     LEGACY_FTS_TRIGRAM_SQL,
     SCHEMA_SQL,
     SCHEMA_VERSION,
-    SESSIONS_FTS_CJK_SQL,
     SESSIONS_FTS_SQL,
     SESSION_INDEX_SQL_STATEMENTS,
     SESSION_TABLE_REBUILD_SQL,
@@ -1189,16 +1188,15 @@ class SessionSchemaMixin:
             # sessions_fts with no triggers and no H/P claim.
             sessions_fts_ok = self._ensure_sessions_fts_schema(cursor)
             self._sessions_fts_available = sessions_fts_ok
-            # CJK title table stays internal-content and one-shot
-            # backfilled (the CJK lifecycle is owned by #26).
-            sessions_cjk_ok = False
-            if sessions_fts_ok and self._fts_cjk_loaded:
-                sessions_cjk_ok = self._ensure_fts_schema(
-                    cursor, "sessions_fts_cjk", SESSIONS_FTS_CJK_SQL,
-                )
-            self._sessions_cjk_available = sessions_cjk_ok
-            if sessions_cjk_ok:
-                self._backfill_sessions_fts_cjk(cursor)
+            # CJK session metadata (issue #26): an optional specialization of
+            # the Unicode session lifecycle over the same raw (title, id,
+            # display_name) document. Runs unconditionally (even when the
+            # tokenizer is unavailable) so a tokenizer-less host can degrade
+            # the session-CJK surface safely. Sets
+            # ``_sessions_cjk_worker_operable`` (can this process build/
+            # maintain the CJK index) and ``_sessions_cjk_available`` (is the
+            # completed index search-serving) as separate facts.
+            self._ensure_sessions_fts_cjk_schema(cursor)
 
             # Replace any pre-existing broad AFTER UPDATE triggers with
             # AFTER UPDATE OF variants. IF NOT EXISTS cannot rewrite them.

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -19,12 +19,14 @@ from typing import Any, Callable, Collection, Dict, List, Optional, Tuple
 from agent.skill_commands import describe_skill_invocation
 from hermes_state_common import (
     FTS_CJK_STALE_KEY,
+    FTS_SESSION_CJK_STALE_KEY,
     FTS_SQL,
     FTS_STORAGE_VERSION,
     FTS_TRIGRAM_SQL,
     MAX_FTS5_QUERY_CHARS,
     SCHEMA_VERSION,
     _FTS_CJK_TRIGGERS,
+    _FTS_SESSION_CJK_TRIGGERS,
 )
 
 # Moved methods logged under the "hermes_state" logger before the split;
@@ -74,6 +76,38 @@ _FTS_SESSION_SPEC = {
     "reset_tables": ("sessions_fts",),
     "available": lambda self: getattr(self, "_sessions_fts_available", False),
     "trigram_available": lambda self: False,
+}
+
+# Optional CJK session-metadata specialization (issue #26) of the SAME
+# generic rebuild engine: identical external-content raw (title, id,
+# display_name) document keyed by named row_id, its OWN H/P marker pair and
+# stale key (never the Unicode-session pair, never the message-CJK pair).
+#
+# The worker gate is ``_sessions_cjk_worker_operable`` (can this process
+# build/maintain the CJK index) — NOT ``_sessions_cjk_available`` (search
+# serving). The donor deadlock was one boolean doing both jobs: pending made
+# serving false, the same false blocked the worker, finish never ran, search
+# never became available. The #77629 invariant (optional capability gates
+# finish exactly as it gates step) is honored by routing both through this
+# same callback and by the availability gate in ``_fts_rebuild_finish``.
+# ``finish_hook`` flips search-serving on only after the boundary sweep
+# clears the CJK markers.
+_FTS_SESSION_CJK_SPEC = {
+    "name": "sessions_cjk",
+    "high_water_key": "fts_session_cjk_rebuild_high_water",
+    "progress_key": "fts_session_cjk_rebuild_progress",
+    "fts_table": "sessions_fts_cjk",
+    "fts_columns": ("title", "id", "display_name"),
+    "source_table": "sessions",
+    "source_columns": ("title", "id", "display_name"),
+    "row_key": "row_id",
+    "trigram_fts": None,
+    "trigram_columns": (),
+    "trigram_where": None,
+    "reset_tables": ("sessions_fts_cjk",),
+    "available": lambda self: getattr(self, "_sessions_cjk_worker_operable", False),
+    "trigram_available": lambda self: False,
+    "finish_hook": lambda self: setattr(self, "_sessions_cjk_available", True),
 }
 
 
@@ -652,6 +686,24 @@ class SessionSearchMixin:
             return 0
         return self._seed_fts_rebuild_markers(
             conn, _FTS_SESSION_SPEC, force=force
+        )
+
+    def _seed_session_cjk_fts_rebuild_markers(
+        self, conn, *, force: bool = False
+    ) -> int:
+        """Session CJK metadata variant of ``_seed_fts_rebuild_markers``
+        (issue #26).
+
+        An empty DB is complete by construction (the triggers cover every
+        future row) and must not carry a spurious claim that would make
+        ``fts_optimize_available`` advertise pending work forever. Gated on
+        tokenizer capability by the caller.
+        """
+        n = conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0]
+        if n == 0 and not force:
+            return 0
+        return self._seed_fts_rebuild_markers(
+            conn, _FTS_SESSION_CJK_SPEC, force=force
         )
 
     def _repair_missing_progress(self, conn, spec: Dict[str, Any]) -> None:

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -107,7 +107,7 @@ _FTS_SESSION_CJK_SPEC = {
     "reset_tables": ("sessions_fts_cjk",),
     "available": lambda self: getattr(self, "_sessions_cjk_worker_operable", False),
     "trigram_available": lambda self: False,
-    "finish_hook": lambda self: setattr(self, "_sessions_cjk_available", True),
+    "finish_hook": lambda self: self._fts_session_cjk_finish_set_serving(),
 }
 
 
@@ -442,6 +442,24 @@ class SessionSearchMixin:
         """
         return self.fts_rebuild_step(spec=_FTS_SESSION_CJK_SPEC)
 
+    def _fts_session_cjk_finish_set_serving(self) -> None:
+        """Flip session-CJK search-serving on after finish, unless the index
+        is stale (issue #26).
+
+        #77629/#26 invariant: only a successful boundary-sweep finish that
+        also finds no stale breadcrumb makes the index search-serving. An
+        incapable host may have persisted ``fts_session_cjk_stale`` and
+        dropped the CJK triggers mid-rebuild, leaving a gap of unknown
+        extent — that index is never served until a capable host resets and
+        rebuilds.
+        """
+        with self._read_ctx() as conn:
+            stale = conn.execute(
+                "SELECT 1 FROM state_meta WHERE key = ?",
+                (FTS_SESSION_CJK_STALE_KEY,),
+            ).fetchone()
+        self._sessions_cjk_available = stale is None
+
     def fts_cjk_rebuild_status(self) -> Optional[Dict[str, Any]]:
         """CJK-index backfill progress, or None when none is pending."""
         with self._read_ctx() as conn:
@@ -532,37 +550,56 @@ class SessionSearchMixin:
         self._fts_cjk_available = True
         logger.info("CJK FTS index backfill complete — serving CJK search.")
 
-    def _fts_cjk_reset_if_stale(self) -> None:
-        """Rebuild path for a stale cjk index (triggers were dropped).
+    def _fts_reset_stale_cjk_surface(
+        self,
+        *,
+        stale_key: str,
+        trigger_tuple: Collection[str],
+        drop_tables: Collection[str],
+        drop_views: Collection[str] = (),
+        meta_keys: Collection[str],
+        recreate: Callable[[], None],
+    ) -> None:
+        """Drop-and-recreate a stale optional CJK index from scratch, shared
+        by the message (``_fts_cjk_reset_if_stale``) and session
+        (``_fts_session_cjk_reset_if_stale``) CJK surfaces.
 
-        The gap's extent is unknown, so the only safe recovery is a from-
-        scratch rebuild: drop the table + triggers, clear the breadcrumb,
-        recreate via ``_ensure_fts_cjk_schema`` (which sets fresh backfill
-        markers on a populated DB). Called from ``optimize_fts_storage`` on
-        a tokenizer-capable host; no-op when not stale.
+        A stale index (its triggers were dropped by a tokenizer-less host) has
+        a gap of unknown extent, so the only safe recovery is a from-scratch
+        rebuild: drop the table + triggers, clear the stale breadcrumb and any
+        H/P, then let ``recreate`` re-ensure the surface (which sets fresh
+        backfill markers on a populated DB). No-op when not stale or not
+        tokenizer-capable.
         """
         if not self._fts_cjk_loaded:
             return
 
         def _do(conn):
             stale = conn.execute(
-                "SELECT 1 FROM state_meta WHERE key = ?",
-                (FTS_CJK_STALE_KEY,),
+                "SELECT 1 FROM state_meta WHERE key = ?", (stale_key,),
             ).fetchone()
             if not stale:
                 return False
-            for trig in _FTS_CJK_TRIGGERS:
+            for trig in trigger_tuple:
                 conn.execute(f"DROP TRIGGER IF EXISTS {trig}")
-            conn.execute("DROP TABLE IF EXISTS messages_fts_cjk")
-            conn.execute("DROP VIEW IF EXISTS messages_fts_cjk_src")
+            for tbl in drop_tables:
+                conn.execute(f"DROP TABLE IF EXISTS {tbl}")
+            for view in drop_views:
+                conn.execute(f"DROP VIEW IF EXISTS {view}")
+            ph = ", ".join("?" for _ in meta_keys)
             conn.execute(
-                "DELETE FROM state_meta WHERE key IN "
-                f"('{FTS_CJK_STALE_KEY}', 'fts_cjk_rebuild_high_water', "
-                "'fts_cjk_rebuild_progress')"
+                f"DELETE FROM state_meta WHERE key IN ({ph})", tuple(meta_keys),
             )
             return True
+
         was_stale = self._execute_write(_do)
         if was_stale:
+            recreate()
+
+    def _fts_cjk_reset_if_stale(self) -> None:
+        """Rebuild path for a stale message CJK index (triggers were dropped).
+        See ``_fts_reset_stale_cjk_surface``."""
+        def _recreate():
             # Recreate outside the write transaction — _ensure_fts_cjk_schema
             # uses executescript(), which implicitly commits any pending
             # transaction and must not run inside _execute_write's BEGIN
@@ -571,52 +608,47 @@ class SessionSearchMixin:
                 self._ensure_fts_cjk_schema(self._conn)
                 self._conn.commit()
 
+        self._fts_reset_stale_cjk_surface(
+            stale_key=FTS_CJK_STALE_KEY,
+            trigger_tuple=_FTS_CJK_TRIGGERS,
+            drop_tables=("messages_fts_cjk",),
+            drop_views=("messages_fts_cjk_src",),
+            meta_keys=(
+                FTS_CJK_STALE_KEY,
+                "fts_cjk_rebuild_high_water",
+                "fts_cjk_rebuild_progress",
+            ),
+            recreate=_recreate,
+        )
+
     def _fts_session_cjk_reset_if_stale(self) -> None:
         """Rebuild path for a stale session-CJK index (triggers were dropped
-        by a tokenizer-less host, issue #26).
-
-        The gap's extent is unknown, so the only safe recovery is a from-
-        scratch rebuild: drop the table + triggers, clear the breadcrumb and
-        any CJK H/P, then recreate via ``_ensure_sessions_fts_cjk_schema``
-        (which sets fresh CJK-session markers on a populated DB). Called from
-        ``optimize_fts_storage`` on a tokenizer-capable host; no-op when not
-        stale.
-        """
-        if not self._fts_cjk_loaded:
-            return
-
-        def _do(conn):
-            stale = conn.execute(
-                "SELECT 1 FROM state_meta WHERE key = ?",
-                (FTS_SESSION_CJK_STALE_KEY,),
-            ).fetchone()
-            if not stale:
-                return False
-            for trig in _FTS_SESSION_CJK_TRIGGERS:
-                conn.execute(f"DROP TRIGGER IF EXISTS {trig}")
-            conn.execute("DROP TABLE IF EXISTS sessions_fts_cjk")
-            for tbl in (
-                "sessions_fts_cjk_data", "sessions_fts_cjk_idx",
-                "sessions_fts_cjk_content", "sessions_fts_cjk_docsize",
-                "sessions_fts_cjk_config",
-            ):
-                conn.execute(f"DROP TABLE IF EXISTS {tbl}")
-            conn.execute(
-                "DELETE FROM state_meta WHERE key IN "
-                f"('{FTS_SESSION_CJK_STALE_KEY}', "
-                "'fts_session_cjk_rebuild_high_water', "
-                "'fts_session_cjk_rebuild_progress')"
-            )
-            return True
-        was_stale = self._execute_write(_do)
-        if was_stale:
+        by a tokenizer-less host, issue #26). See
+        ``_fts_reset_stale_cjk_surface``."""
+        def _recreate():
             # Recreate OUTSIDE the write transaction and OUTSIDE self._lock:
             # _ensure_sessions_fts_cjk_schema manages its own locking (its
-            # crash-atomic transition uses _execute_write, and self._lock is
-            # a plain non-reentrant Lock). Sets fresh CJK-session markers on
-            # a populated DB.
+            # crash-atomic transition uses _execute_write, and self._lock is a
+            # plain non-reentrant Lock). Sets fresh CJK-session markers on a
+            # populated DB.
             self._ensure_sessions_fts_cjk_schema(self._conn)
             self._conn.commit()
+
+        self._fts_reset_stale_cjk_surface(
+            stale_key=FTS_SESSION_CJK_STALE_KEY,
+            trigger_tuple=_FTS_SESSION_CJK_TRIGGERS,
+            drop_tables=(
+                "sessions_fts_cjk", "sessions_fts_cjk_data",
+                "sessions_fts_cjk_idx", "sessions_fts_cjk_content",
+                "sessions_fts_cjk_docsize", "sessions_fts_cjk_config",
+            ),
+            meta_keys=(
+                FTS_SESSION_CJK_STALE_KEY,
+                "fts_session_cjk_rebuild_high_water",
+                "fts_session_cjk_rebuild_progress",
+            ),
+            recreate=_recreate,
+        )
 
     def _fts_external_index_empty_with_source(
         self, conn, source_table: str, fts_table: str
@@ -746,19 +778,26 @@ class SessionSearchMixin:
             )
         return int(hw)
 
-    def _seed_session_fts_rebuild_markers(
-        self, conn, *, force: bool = False
+    def _seed_session_spec_rebuild_markers(
+        self, conn, spec: Dict[str, Any], *, force: bool = False
     ) -> int:
-        """Session Unicode metadata variant of ``_seed_fts_rebuild_markers``.
+        """Shared session-metadata variant of ``_seed_fts_rebuild_markers``.
 
         An empty DB is complete by construction (the triggers cover every
         future row) and must not carry a spurious claim that would make
-        ``fts_optimize_available`` advertise pending work forever.
+        ``fts_optimize_available`` advertise pending work forever. Shared by
+        the Unicode (issue #25) and CJK (issue #26) session specs.
         """
         n = conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0]
         if n == 0 and not force:
             return 0
-        return self._seed_fts_rebuild_markers(
+        return self._seed_fts_rebuild_markers(conn, spec, force=force)
+
+    def _seed_session_fts_rebuild_markers(
+        self, conn, *, force: bool = False
+    ) -> int:
+        """Session Unicode metadata variant of ``_seed_fts_rebuild_markers``."""
+        return self._seed_session_spec_rebuild_markers(
             conn, _FTS_SESSION_SPEC, force=force
         )
 
@@ -766,17 +805,8 @@ class SessionSearchMixin:
         self, conn, *, force: bool = False
     ) -> int:
         """Session CJK metadata variant of ``_seed_fts_rebuild_markers``
-        (issue #26).
-
-        An empty DB is complete by construction (the triggers cover every
-        future row) and must not carry a spurious claim that would make
-        ``fts_optimize_available`` advertise pending work forever. Gated on
-        tokenizer capability by the caller.
-        """
-        n = conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0]
-        if n == 0 and not force:
-            return 0
-        return self._seed_fts_rebuild_markers(
+        (issue #26). Gated on tokenizer capability by the caller."""
+        return self._seed_session_spec_rebuild_markers(
             conn, _FTS_SESSION_CJK_SPEC, force=force
         )
 
@@ -849,67 +879,50 @@ class SessionSearchMixin:
                 self._seed_fts_rebuild_markers(conn, force=True)
         self._execute_write(_do)
 
-    def _repair_session_fts_bookkeeping(self) -> None:
-        """Heal interrupted session Unicode metadata backfill bookkeeping
-        (#25). Reuses ``_repair_missing_progress`` (the shared crash-safe
-        rule) for the orphan high_water-without-progress case, and its own
-        orphan claim-seeding for a fresh external index over a populated DB
-        that lost its markers. Never re-implements the reset-before-replay
-        rule.
+    def _repair_session_spec_bookkeeping(self, spec: Dict[str, Any]) -> None:
+        """Shared session-metadata repair for interrupted backfill bookkeeping
+        (#25 Unicode / #26 CJK). Reuses ``_repair_missing_progress`` (the
+        shared crash-safe rule) for the orphan high_water-without-progress
+        case, and seeds a fresh claim for a fresh external index over a
+        populated DB that lost its markers. Never re-implements the
+        reset-before-replay rule.
         """
         def _do(conn):
             existing_hw = conn.execute(
-                "SELECT value FROM state_meta "
-                "WHERE key = 'fts_session_rebuild_high_water'"
+                "SELECT value FROM state_meta WHERE key = ?",
+                (spec["high_water_key"],),
             ).fetchone()
             if existing_hw is not None:
                 progress = conn.execute(
-                    "SELECT 1 FROM state_meta "
-                    "WHERE key = 'fts_session_rebuild_progress'"
+                    "SELECT 1 FROM state_meta WHERE key = ?",
+                    (spec["progress_key"],),
                 ).fetchone()
                 if progress is None:
-                    self._repair_missing_progress(conn, _FTS_SESSION_SPEC)
+                    self._repair_missing_progress(conn, spec)
                 return
             # No claim: a freshly-created external index over a populated DB
             # that lost its markers, or a crash window after schema ensure
             # without a claim. Seed a full backfill (orphan recovery).
             if self._fts_external_index_empty_with_source(
-                conn, "sessions", "sessions_fts"
+                conn, spec["source_table"], spec["fts_table"]
             ):
-                self._seed_session_fts_rebuild_markers(conn, force=True)
+                self._seed_session_spec_rebuild_markers(conn, spec, force=True)
         self._execute_write(_do)
 
-    def _repair_session_cjk_fts_bookkeeping(self) -> None:
-        """Heal interrupted session-CJK backfill bookkeeping (issue #26).
+    def _repair_session_fts_bookkeeping(self) -> None:
+        """Heal interrupted session Unicode metadata backfill bookkeeping
+        (#25). See ``_repair_session_spec_bookkeeping``."""
+        self._repair_session_spec_bookkeeping(_FTS_SESSION_SPEC)
 
-        Reuses ``_repair_missing_progress`` (the shared crash-safe rule) for
-        the orphan high_water-without-progress case, and seeds a fresh CJK
-        claim for a fresh external index over a populated DB that lost its
-        markers. Never re-implements the reset-before-replay rule. Only
-        meaningful on a tokenizer-capable host: an incapable host cannot have
-        created the CJK surface, and must never fabricate durable CJK claims.
+    def _repair_session_cjk_fts_bookkeeping(self) -> None:
+        """Heal interrupted session-CJK backfill bookkeeping (issue #26). See
+        ``_repair_session_spec_bookkeeping``. Only meaningful on a
+        tokenizer-capable host: an incapable host cannot have created the CJK
+        surface, and must never fabricate durable CJK claims.
         """
         if not self._fts_cjk_loaded:
             return
-
-        def _do(conn):
-            existing_hw = conn.execute(
-                "SELECT value FROM state_meta "
-                "WHERE key = 'fts_session_cjk_rebuild_high_water'"
-            ).fetchone()
-            if existing_hw is not None:
-                progress = conn.execute(
-                    "SELECT 1 FROM state_meta "
-                    "WHERE key = 'fts_session_cjk_rebuild_progress'"
-                ).fetchone()
-                if progress is None:
-                    self._repair_missing_progress(conn, _FTS_SESSION_CJK_SPEC)
-                return
-            if self._fts_external_index_empty_with_source(
-                conn, "sessions", "sessions_fts_cjk"
-            ):
-                self._seed_session_cjk_fts_rebuild_markers(conn, force=True)
-        self._execute_write(_do)
+        self._repair_session_spec_bookkeeping(_FTS_SESSION_CJK_SPEC)
 
     def fts_optimize_available(self) -> bool:
         """True when `optimize_fts_storage()` has work to do: either this DB

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -225,6 +225,12 @@ class SessionSearchMixin:
         down with it.
         """
         spec = spec or _FTS_MESSAGE_SPEC
+        # #77629 invariant: the SAME optional operability capability that
+        # gates the chunked step must gate finish. A host that lost the
+        # capability (e.g. a CJK tokenizer it could load at open) must not
+        # enter a finish path that falsely settles durable work.
+        if not spec["available"](self):
+            return
         include_trigram = bool(
             spec.get("trigram_fts") and spec["trigram_available"](self)
         )
@@ -272,6 +278,11 @@ class SessionSearchMixin:
                 (spec["high_water_key"], spec["progress_key"]),
             )
         self._execute_write(_do)
+        # Optional per-spec post-finish transition (e.g. flip session-CJK
+        # search-serving availability once the boundary sweep has settled).
+        hook = spec.get("finish_hook")
+        if hook is not None:
+            hook(self)
         logger.info(
             "Deferred %s FTS rebuild complete — all rows indexed.", spec["name"]
         )
@@ -415,6 +426,22 @@ class SessionSearchMixin:
         """
         return self.fts_rebuild_step(spec=_FTS_SESSION_SPEC)
 
+    def fts_session_cjk_rebuild_status(self) -> Optional[Dict[str, Any]]:
+        """Session CJK metadata index backfill progress, or None when none is
+        pending (issue #26)."""
+        return self.fts_rebuild_status(spec=_FTS_SESSION_CJK_SPEC)
+
+    def fts_session_cjk_rebuild_step(self) -> bool:
+        """Backfill one chunk of the session CJK metadata index (issue #26).
+
+        True while work remains. Shares the generic chunk / finish / crash
+        rules with the Unicode session and message rebuilds. The worker gate
+        is **worker operability** (``_sessions_cjk_worker_operable``), never
+        search-serving availability — a pending CJK backfill (W=1, S=0) must
+        still advance, run finish, and only then flip to serving.
+        """
+        return self.fts_rebuild_step(spec=_FTS_SESSION_CJK_SPEC)
+
     def fts_cjk_rebuild_status(self) -> Optional[Dict[str, Any]]:
         """CJK-index backfill progress, or None when none is pending."""
         with self._read_ctx() as conn:
@@ -543,6 +570,53 @@ class SessionSearchMixin:
             with self._lock:
                 self._ensure_fts_cjk_schema(self._conn)
                 self._conn.commit()
+
+    def _fts_session_cjk_reset_if_stale(self) -> None:
+        """Rebuild path for a stale session-CJK index (triggers were dropped
+        by a tokenizer-less host, issue #26).
+
+        The gap's extent is unknown, so the only safe recovery is a from-
+        scratch rebuild: drop the table + triggers, clear the breadcrumb and
+        any CJK H/P, then recreate via ``_ensure_sessions_fts_cjk_schema``
+        (which sets fresh CJK-session markers on a populated DB). Called from
+        ``optimize_fts_storage`` on a tokenizer-capable host; no-op when not
+        stale.
+        """
+        if not self._fts_cjk_loaded:
+            return
+
+        def _do(conn):
+            stale = conn.execute(
+                "SELECT 1 FROM state_meta WHERE key = ?",
+                (FTS_SESSION_CJK_STALE_KEY,),
+            ).fetchone()
+            if not stale:
+                return False
+            for trig in _FTS_SESSION_CJK_TRIGGERS:
+                conn.execute(f"DROP TRIGGER IF EXISTS {trig}")
+            conn.execute("DROP TABLE IF EXISTS sessions_fts_cjk")
+            for tbl in (
+                "sessions_fts_cjk_data", "sessions_fts_cjk_idx",
+                "sessions_fts_cjk_content", "sessions_fts_cjk_docsize",
+                "sessions_fts_cjk_config",
+            ):
+                conn.execute(f"DROP TABLE IF EXISTS {tbl}")
+            conn.execute(
+                "DELETE FROM state_meta WHERE key IN "
+                f"('{FTS_SESSION_CJK_STALE_KEY}', "
+                "'fts_session_cjk_rebuild_high_water', "
+                "'fts_session_cjk_rebuild_progress')"
+            )
+            return True
+        was_stale = self._execute_write(_do)
+        if was_stale:
+            # Recreate OUTSIDE the write transaction and OUTSIDE self._lock:
+            # _ensure_sessions_fts_cjk_schema manages its own locking (its
+            # crash-atomic transition uses _execute_write, and self._lock is
+            # a plain non-reentrant Lock). Sets fresh CJK-session markers on
+            # a populated DB.
+            self._ensure_sessions_fts_cjk_schema(self._conn)
+            self._conn.commit()
 
     def _fts_external_index_empty_with_source(
         self, conn, source_table: str, fts_table: str
@@ -805,6 +879,38 @@ class SessionSearchMixin:
                 self._seed_session_fts_rebuild_markers(conn, force=True)
         self._execute_write(_do)
 
+    def _repair_session_cjk_fts_bookkeeping(self) -> None:
+        """Heal interrupted session-CJK backfill bookkeeping (issue #26).
+
+        Reuses ``_repair_missing_progress`` (the shared crash-safe rule) for
+        the orphan high_water-without-progress case, and seeds a fresh CJK
+        claim for a fresh external index over a populated DB that lost its
+        markers. Never re-implements the reset-before-replay rule. Only
+        meaningful on a tokenizer-capable host: an incapable host cannot have
+        created the CJK surface, and must never fabricate durable CJK claims.
+        """
+        if not self._fts_cjk_loaded:
+            return
+
+        def _do(conn):
+            existing_hw = conn.execute(
+                "SELECT value FROM state_meta "
+                "WHERE key = 'fts_session_cjk_rebuild_high_water'"
+            ).fetchone()
+            if existing_hw is not None:
+                progress = conn.execute(
+                    "SELECT 1 FROM state_meta "
+                    "WHERE key = 'fts_session_cjk_rebuild_progress'"
+                ).fetchone()
+                if progress is None:
+                    self._repair_missing_progress(conn, _FTS_SESSION_CJK_SPEC)
+                return
+            if self._fts_external_index_empty_with_source(
+                conn, "sessions", "sessions_fts_cjk"
+            ):
+                self._seed_session_cjk_fts_rebuild_markers(conn, force=True)
+        self._execute_write(_do)
+
     def fts_optimize_available(self) -> bool:
         """True when `optimize_fts_storage()` has work to do: either this DB
         is a legacy inline-FTS install that can be optimized to the v23
@@ -845,6 +951,14 @@ class SessionSearchMixin:
             if self._fts_cjk_loaded and self._conn.execute(
                 "SELECT 1 FROM state_meta WHERE key IN "
                 f"('fts_cjk_rebuild_high_water', '{FTS_CJK_STALE_KEY}') LIMIT 1"
+            ).fetchone():
+                return True
+            # Session CJK metadata rebuild pending or stale (issue #26) —
+            # same tokenizer-capability gate as the message CJK index.
+            if self._fts_cjk_loaded and self._conn.execute(
+                "SELECT 1 FROM state_meta WHERE key IN "
+                "('fts_session_cjk_rebuild_high_water', "
+                f"'{FTS_SESSION_CJK_STALE_KEY}') LIMIT 1"
             ).fetchone():
                 return True
             if self._has_fts_trash(self._conn):
@@ -956,6 +1070,9 @@ class SessionSearchMixin:
         self._repair_optimize_bookkeeping()
         # Same healing for the session Unicode metadata rebuild (issue #25).
         self._repair_session_fts_bookkeeping()
+        # Same healing for the session CJK metadata rebuild (issue #26);
+        # no-op on a host that cannot tokenize.
+        self._repair_session_cjk_fts_bookkeeping()
 
         # Only demote if we're actually still on the legacy shape. If a prior
         # run already demoted (markers/trash present), skip straight to
@@ -991,6 +1108,9 @@ class SessionSearchMixin:
         # can only be recovered from scratch — reset it now so the cjk
         # backfill phase below rebuilds it. No-op without the tokenizer.
         self._fts_cjk_reset_if_stale()
+        # Same from-scratch recovery for a stale session-CJK index (issue
+        # #26); no-op without the tokenizer.
+        self._fts_session_cjk_reset_if_stale()
         # An optimized v23 DB gaining the cjk index for the first time (no
         # legacy work left, tokenizer newly installed): ensure the table +
         # markers exist so the backfill phase has work to claim.
@@ -1007,6 +1127,8 @@ class SessionSearchMixin:
                 st = self.fts_cjk_rebuild_status()
             if st is None:
                 st = self.fts_session_rebuild_status()
+            if st is None:
+                st = self.fts_session_cjk_rebuild_status()
             progress_cb({
                 "phase": phase,
                 "percent": st["percent"] if st else 100,
@@ -1042,6 +1164,17 @@ class SessionSearchMixin:
             while True:
                 _t0 = time.monotonic()
                 if not self.fts_session_rebuild_step():
+                    break
+                _emit("backfill")
+                self._fts_rebuild_pause(time.monotonic() - _t0)
+
+        # Phase 1d: backfill the session CJK metadata index (issue #26) — the
+        # same shared chunk engine and pacing, gated on the independent
+        # CJK-session markers (worker operability, never search availability).
+        if self.fts_session_cjk_rebuild_status() is not None:
+            while True:
+                _t0 = time.monotonic()
+                if not self.fts_session_cjk_rebuild_step():
                     break
                 _emit("backfill")
                 self._fts_rebuild_pause(time.monotonic() - _t0)

--- a/tests/hermes_cli/test_session_recovery.py
+++ b/tests/hermes_cli/test_session_recovery.py
@@ -594,6 +594,18 @@ def test_cli_allow_partial_salvages_rows_across_a_corrupt_leaf(
     }
 
 
+def test_session_cjk_derived_keys_are_generated_meta():
+    """#26: the session-CJK derived markers (H/P/stale) are regenerated from
+    the fresh destination's own schema on recovery — never copied from the
+    source — mirroring the #25 session Unicode pair."""
+    for key in (
+        "fts_session_cjk_rebuild_high_water",
+        "fts_session_cjk_rebuild_progress",
+        "fts_session_cjk_stale",
+    ):
+        assert key in session_recovery._GENERATED_META_KEYS, key
+
+
 def test_partial_recovery_clears_only_unreadable_system_prompt_refs(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_session_metadata_cjk_fts.py
+++ b/tests/test_session_metadata_cjk_fts.py
@@ -14,6 +14,7 @@ is present. The degraded/unavailable-host tests that need no tokenizer always
 run.
 """
 
+import os
 import sqlite3
 import shutil
 import subprocess
@@ -27,6 +28,19 @@ from hermes_state import SCHEMA_SQL, SessionDB
 REPO = Path(__file__).resolve().parent.parent
 SRC = REPO / "native" / "fts5_cjk" / "fts5_cjk.c"
 VENDOR = REPO / "native" / "fts5_cjk" / "vendor"
+
+
+def _loadable_extension(path: Path) -> bool:
+    """True when ``path`` is a real loadable FTS5 extension on this build."""
+    probe = sqlite3.connect(":memory:")
+    try:
+        probe.enable_load_extension(True)
+        probe.load_extension(str(path))
+        return True
+    except Exception:
+        return False
+    finally:
+        probe.close()
 
 
 def _build_populated_sessions_db(db_path, n=1200):
@@ -73,11 +87,24 @@ def db(tmp_path):
 
 @pytest.fixture(scope="session")
 def cjk_so(tmp_path_factory):
-    """Build the cjk_unicode61 loadable tokenizer from source; skip when no C
-    toolchain / extension loading is available (mirrors test_fts_cjk_bigram)."""
+    """Provide a loadable cjk_unicode61 tokenizer extension.
+
+    Honors a prebuilt artifact supplied via ``HERMES_FTS5_CJK_SO`` (e.g. a
+    Windows ``.dll`` cross-compiled from ``native/fts5_cjk/fts5_cjk.c`` with
+    mingw) so capable-host tests run without a local C toolchain — the same
+    env override production's ``fts5_cjk_so_path()`` honors. Otherwise builds
+    from source (CI/Linux images ship gcc). Skips when neither is available.
+    """
+    prebuilt = os.environ.get("HERMES_FTS5_CJK_SO")
+    if prebuilt:
+        p = Path(prebuilt)
+        if p.is_file() and _loadable_extension(p):
+            return p
+        pytest.skip(f"HERMES_FTS5_CJK_SO set but not loadable: {p}")
     if shutil.which("gcc") is None or not SRC.exists():
         pytest.skip("no C toolchain / tokenizer source")
-    out = tmp_path_factory.mktemp("fts5cjk") / "libfts5_cjk.so"
+    ext = "dll" if os.name == "nt" else "so"
+    out = tmp_path_factory.mktemp("fts5cjk") / f"libfts5_cjk.{ext}"
     try:
         subprocess.run(
             ["gcc", "-shared", "-fPIC", "-O2", f"-I{VENDOR}", str(SRC),
@@ -86,14 +113,8 @@ def cjk_so(tmp_path_factory):
         )
     except subprocess.CalledProcessError as e:
         pytest.skip(f"tokenizer build failed: {e.stderr[:200]}")
-    probe = sqlite3.connect(":memory:")
-    try:
-        probe.enable_load_extension(True)
-        probe.load_extension(str(out))
-    except Exception as e:
-        pytest.skip(f"extension loading unavailable: {e}")
-    finally:
-        probe.close()
+    if not _loadable_extension(out):
+        pytest.skip("built tokenizer not loadable in this build")
     return out
 
 
@@ -407,10 +428,14 @@ class TestCjkDegradation:
         db_path = tmp_path / "s.db"
         _build_populated_sessions_db(db_path, n=20)
         w = _open_capable(db_path, cjk_so, monkeypatch)
-        w.fts_session_cjk_rebuild_step()  # partial progress
+        # Opening a populated DB stages CJK H=20, P=0. Force a partial
+        # in-flight progress so the degradation path is exercised
+        # deterministically (a single step could otherwise complete the small
+        # index in one chunk and clear the markers).
+        w.set_meta(CJK_PROG, "5")
         hw = w.get_meta(CJK_HW)
         prog = w.get_meta(CJK_PROG)
-        assert hw is not None
+        assert hw == "20" and prog == "5"
         w.close()
 
         r = _open_incapable(db_path, tmp_path, monkeypatch)
@@ -470,12 +495,16 @@ class TestCjkSearchSeam:
         d = _open_capable(db_path, cjk_so, monkeypatch)
         try:
             assert d._sessions_cjk_available is False
+            # A pending CJK backfill must not serve the CJK lane.
             servable, candidates = d._fts_cjk_metadata_candidates("標題")
             assert servable is False
             assert candidates is None
-            # But canonical fallback still finds the row.
-            _, uni = d._fts_metadata_candidates("標題")
-            assert any(c["id"] == "s1" for c in uni)
+            # But canonical fallback (the Unicode lane) still finds the same
+            # session through its ASCII token while CJK is pending.
+            d.create_session("s51", source="cli")
+            d.set_session_title("s51", "CJK 標題 Plan")
+            _, uni = d._fts_metadata_candidates("plan")
+            assert any(c["id"] == "s51" for c in uni)
         finally:
             d.close()
 

--- a/tests/test_session_metadata_cjk_fts.py
+++ b/tests/test_session_metadata_cjk_fts.py
@@ -210,9 +210,214 @@ def _assert_sessions_fts_cjk_integrity(db):
     )
 
 
+def _assert_sessions_fts_cjk_internal_integrity(db):
+    """Ordinary FTS5 internal integrity-check (shadow-table structure only).
+    Unlike the rank=1 form, safe mid-migration when the (P, H] gap rows are
+    legitimately unindexed."""
+    db._conn.execute(
+        "INSERT INTO sessions_fts_cjk(sessions_fts_cjk) "
+        "VALUES('integrity-check')"
+    )
+
+
+def _cjk_three_region_db(cjk_so, tmp_path, monkeypatch):
+    """SessionDB with a CJK rebuild staged so all three ownership regions are
+    represented: rows <= P are backfilled into the CJK index, rows (P,H] are
+    the unindexed worker-owned gap, and newly created sessions are > H
+    (live-indexed by the triggers)."""
+    db_path = tmp_path / "s.db"
+    _build_populated_sessions_db(db_path, n=8)  # row 1..8
+    d = _open_capable(db_path, cjk_so, monkeypatch)  # CJK H=8, P=0
+    d._conn.execute(
+        "INSERT INTO sessions_fts_cjk(rowid, title, id, display_name) "
+        "SELECT row_id, title, id, display_name FROM sessions "
+        "WHERE row_id <= 3"
+    )
+    d.set_meta(CJK_PROG, "3")
+    return d
+
+
 # =========================================================================
 # Group A — external-content raw shape (replaces legacy title-only)
 # =========================================================================
+
+
+# =========================================================================
+# Group B2 — trigger ownership regions behavioral matrix (<=P, (P,H], >H)
+# =========================================================================
+
+
+class TestCjkTriggerOwnershipRegions:
+    """Behavioral matrix for the CJK trigger ownership regions during a
+    pending backfill — acceptance criterion: trigger behavior follows the
+    same indexed-region invariant as Unicode (row <= P or > H live; (P,H]
+    worker-owned and left alone)."""
+
+    def test_insert_above_high_water_is_live_indexed(
+        self, cjk_so, tmp_path, monkeypatch
+    ):
+        """A session created above the captured H is indexed immediately by
+        the insert trigger."""
+        d = _cjk_three_region_db(cjk_so, tmp_path, monkeypatch)
+        try:
+            d.create_session("s9", source="cli")   # row 9 > H
+            d.set_session_title("s9", "Live Insert")
+            assert _cjk_fts_rowids(d, "live") == [9]
+        finally:
+            d.close()
+
+    def test_delete_indexed_prefix_row_removes_doc(
+        self, cjk_so, tmp_path, monkeypatch
+    ):
+        """Deleting a <=P row (already indexed) removes its CJK document."""
+        d = _cjk_three_region_db(cjk_so, tmp_path, monkeypatch)
+        try:
+            d.set_session_title("s1", "Alpha One")   # row 1 <= P
+            assert _cjk_fts_rowids(d, "alpha") == [1]
+            d.delete_session("s1")
+            assert _cjk_fts_rowids(d, "alpha") == []
+            _assert_sessions_fts_cjk_internal_integrity(d)
+        finally:
+            d.close()
+
+    def test_delete_gap_row_issues_no_fts_delete(
+        self, cjk_so, tmp_path, monkeypatch
+    ):
+        """Deleting a (P,H] row (never indexed) issues no external-content
+        delete; the index stays free of stale postings."""
+        d = _cjk_three_region_db(cjk_so, tmp_path, monkeypatch)
+        try:
+            d.set_session_title("s7", "Gamma Gap")   # row 7 in (P,H]
+            assert _cjk_fts_rowids(d, "gamma") == []
+            d.delete_session("s7")
+            assert _cjk_fts_rowids(d, "gamma") == []
+            assert d.get_session("s7") is None
+            _assert_sessions_fts_cjk_internal_integrity(d)
+        finally:
+            d.close()
+
+    def test_delete_live_row_removes_doc(self, cjk_so, tmp_path, monkeypatch):
+        """Deleting a >H live row removes its live-indexed document."""
+        d = _cjk_three_region_db(cjk_so, tmp_path, monkeypatch)
+        try:
+            d.create_session("s9", source="cli")
+            d.set_session_title("s9", "Live Echo")
+            assert _cjk_fts_rowids(d, "echo") == [9]
+            d.delete_session("s9")
+            assert _cjk_fts_rowids(d, "echo") == []
+            _assert_sessions_fts_cjk_internal_integrity(d)
+        finally:
+            d.close()
+
+    def test_update_indexed_prefix_row_rewrites_doc(
+        self, cjk_so, tmp_path, monkeypatch
+    ):
+        """Updating a <=P row rewrites its already-indexed CJK document."""
+        d = _cjk_three_region_db(cjk_so, tmp_path, monkeypatch)
+        try:
+            d.set_session_title("s1", "Alpha One")
+            assert _cjk_fts_rowids(d, "alpha") == [1]
+            d.set_session_title("s1", "Alpha Updated")
+            assert _cjk_fts_rowids(d, "alpha") == [1]
+            assert _cjk_fts_rowids(d, "updated") == [1]
+        finally:
+            d.close()
+
+    def test_update_gap_row_does_not_rewrite_index(
+        self, cjk_so, tmp_path, monkeypatch
+    ):
+        """Updating a (P,H] row must not rewrite a document that was never
+        indexed; the index stays healthy."""
+        d = _cjk_three_region_db(cjk_so, tmp_path, monkeypatch)
+        try:
+            d.set_session_title("s7", "Gamma Gap")
+            d.set_session_title("s7", "Gamma Changed")
+            assert _cjk_fts_rowids(d, "gamma") == []
+            assert _cjk_fts_rowids(d, "changed") == []
+            _assert_sessions_fts_cjk_internal_integrity(d)
+        finally:
+            d.close()
+
+    def test_update_live_row_rewrites_doc(self, cjk_so, tmp_path, monkeypatch):
+        """Updating a >H live row rewrites its live-indexed document."""
+        d = _cjk_three_region_db(cjk_so, tmp_path, monkeypatch)
+        try:
+            d.create_session("s9", source="cli")
+            d.set_session_title("s9", "Live Delta")
+            assert _cjk_fts_rowids(d, "delta") == [9]
+            d.set_session_title("s9", "Live Changed")
+            assert _cjk_fts_rowids(d, "delta") == []
+            assert _cjk_fts_rowids(d, "changed") == [9]
+        finally:
+            d.close()
+
+    def test_unrelated_column_update_does_not_rewrite_index(
+        self, cjk_so, tmp_path, monkeypatch
+    ):
+        """A narrow UPDATE OF title,id,display_name trigger: an unrelated
+        metadata column write must not rewrite the CJK index."""
+        d = _cjk_three_region_db(cjk_so, tmp_path, monkeypatch)
+        try:
+            d.set_session_title("s1", "Alpha One")
+            assert _cjk_fts_rowids(d, "alpha") == [1]
+            d._conn.execute(
+                "UPDATE sessions SET message_count = 5 WHERE row_id = 1"
+            )
+            d._conn.commit()
+            assert _cjk_fts_rowids(d, "alpha") == [1]
+        finally:
+            d.close()
+
+
+# =========================================================================
+# Group C2 — read-only connection capability seam
+# =========================================================================
+
+
+class TestCjkReadOnly:
+    def test_read_only_completed_cjk_index_matches(
+        self, cjk_so, tmp_path, monkeypatch
+    ):
+        """A dedicated SessionDB(read_only=True) with the tokenizer loaded on
+        its connection must MATCH the completed CJK index — tokenizer
+        capability is connection-local, and the read seam derives serving
+        from the durable state in the same snapshot."""
+        db_path = tmp_path / "s.db"
+        _build_populated_sessions_db(db_path, n=20)
+        w = _open_capable(db_path, cjk_so, monkeypatch)
+        while w.fts_session_cjk_rebuild_step():
+            pass
+        w.create_session("日本語ID", source="cli")
+        w.set_session_title("日本語ID", "東京タワー計画")
+        w.close()
+        monkeypatch.setenv("HERMES_FTS5_CJK_SO", str(cjk_so))
+        ro = SessionDB(db_path=db_path, read_only=True)
+        try:
+            servable, candidates = ro._fts_cjk_metadata_candidates("東京")
+            assert servable is True
+            assert any(c["id"] == "日本語ID" for c in candidates)
+        finally:
+            ro.close()
+
+    def test_read_only_without_tokenizer_falls_back(
+        self, cjk_so, tmp_path, monkeypatch
+    ):
+        """A tokenizer-less read-only consumer cannot MATCH the CJK index: it
+        reports unservable (canonical fallback), never a partial result."""
+        db_path = tmp_path / "s.db"
+        _build_populated_sessions_db(db_path, n=20)
+        w = _open_capable(db_path, cjk_so, monkeypatch)
+        while w.fts_session_cjk_rebuild_step():
+            pass
+        w.close()
+        monkeypatch.setenv("HERMES_FTS5_CJK_SO", str(tmp_path / "absent.so"))
+        ro = SessionDB(db_path=db_path, read_only=True)
+        try:
+            servable, candidates = ro._fts_cjk_metadata_candidates("東京")
+            assert servable is False
+            assert candidates is None
+        finally:
+            ro.close()
 
 
 class TestCjkExternalContentShape:
@@ -339,6 +544,30 @@ class TestCjkRebuildMarkers:
             assert d.get_meta(CJK_PROG) is None
             assert d.get_meta(CJK_STALE) == "1"
             assert d._sessions_cjk_available is False
+        finally:
+            d.close()
+
+    def test_schema_soft_fail_keeps_worker_operable_false(
+        self, cjk_so, tmp_path, monkeypatch
+    ):
+        """A soft-failed CJK schema transition must not leave worker-operable
+        True — otherwise optimize's phase 1d would retry the missing/unusable
+        table forever (fts_rebuild_step treats OperationalError as transient).
+        worker-operable means 'can operate the target NOW', not just '.so
+        loaded once'."""
+        db_path = tmp_path / "s.db"
+        _build_populated_sessions_db(db_path, n=20)
+        monkeypatch.setattr(
+            SessionDB,
+            "_fts_session_cjk_schema_transition",
+            lambda self, cursor: False,
+        )
+        d = _open_capable(db_path, cjk_so, monkeypatch)
+        try:
+            assert d._sessions_cjk_worker_operable is False
+            assert d._sessions_cjk_available is False
+            # The worker refuses to advance (no infinite retry loop).
+            assert d.fts_session_cjk_rebuild_step() is False
         finally:
             d.close()
 
@@ -567,6 +796,34 @@ class TestCjkSearchSeam:
             assert _cjk_match_ids(d, "東京") == ["日本語ID"]      # title
             assert _cjk_match_ids(d, "日本語") == ["日本語ID"]    # logical id
             assert _cjk_match_ids(d, "カタカナ") == ["日本語ID"]  # display_name
+        finally:
+            d.close()
+
+    def test_cross_process_stale_keeps_serving_off(
+        self, cjk_so, tmp_path, monkeypatch
+    ):
+        """A long-lived capable process whose cache says the CJK index is
+        servable must still stop serving when a tokenizer-less sibling
+        persists the durable stale breadcrumb. The durable state — read in
+        the same snapshot as the MATCH — is the source of truth, never the
+        process-local flag."""
+        db_path = tmp_path / "s.db"
+        _build_populated_sessions_db(db_path, n=20)
+        d = _open_capable(db_path, cjk_so, monkeypatch)
+        try:
+            while d.fts_session_cjk_rebuild_step():
+                pass
+            d.create_session("日本語ID", source="cli")
+            d.set_session_title("日本語ID", "東京タワー計画")
+            # In-memory cache says serving...
+            assert d._sessions_cjk_available is True
+            servable, candidates = d._fts_cjk_metadata_candidates("東京")
+            assert servable is True
+            # ...but a sibling process persisted the durable stale breadcrumb.
+            d.set_meta(CJK_STALE, "1")
+            servable, candidates = d._fts_cjk_metadata_candidates("東京")
+            assert servable is False
+            assert candidates is None
         finally:
             d.close()
 

--- a/tests/test_session_metadata_cjk_fts.py
+++ b/tests/test_session_metadata_cjk_fts.py
@@ -14,6 +14,7 @@ is present. The degraded/unavailable-host tests that need no tokenizer always
 run.
 """
 
+import contextlib
 import os
 import sqlite3
 import shutil
@@ -181,6 +182,20 @@ def _open_incapable(db_path, tmp_path, monkeypatch):
     """Open SessionDB with the tokenizer unavailable (absent .so)."""
     monkeypatch.setenv("HERMES_FTS5_CJK_SO", str(tmp_path / "absent.so"))
     return SessionDB(db_path=db_path)
+
+
+def _pre_enable_wal(db_path):
+    """Pre-set journal_mode=WAL on disk so SessionDB's vulnerable-runtime
+    fallback leaves it in WAL (``_apply_delete_for_wal_reset_bug`` only
+    downgrades DBs that are not already WAL). The P1 interleaving test needs
+    WAL: a concurrent committed writer must be able to land between a reader's
+    guard and MATCH (snapshot isolation), which DELETE-mode locking forbids.
+    Harmless for a throwaway temp DB."""
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute("PRAGMA journal_mode=WAL")
+    finally:
+        conn.close()
 
 
 def _cjk_fts_rowids(db, query):
@@ -824,6 +839,119 @@ class TestCjkSearchSeam:
             servable, candidates = d._fts_cjk_metadata_candidates("東京")
             assert servable is False
             assert candidates is None
+        finally:
+            d.close()
+
+    def test_stale_write_between_guard_and_match_stays_consistent(
+        self, cjk_so, tmp_path, monkeypatch
+    ):
+        """P1 (PR #65): the durable guard and the MATCH must share ONE SQLite
+        snapshot. This manufactures the exact interleaving the above test
+        cannot: it wraps the connection ``_read_ctx`` yields in a proxy that
+        commits a concurrent sibling's write (mark stale + drop the CJK
+        triggers + add AND directly index a new canonical session) on a
+        SEPARATE connection right AFTER the guard's first read completes but
+        BEFORE the MATCH runs.
+
+        Pre-fix (autocommit: a fresh snapshot per SELECT) the MATCH opens a
+        new snapshot that already contains the sibling's new index row → the
+        lane reports ``(servable=True, ...)`` over a stale-guarded, partially
+        rebuilt index. Post-fix the MATCH stays on the guard's snapshot → it
+        returns the consistent pre-write rows and never serves a row that
+        belongs to a later, stale-guarded snapshot.
+        """
+        db_path = tmp_path / "s.db"
+        _build_populated_sessions_db(db_path, n=20)
+        _pre_enable_wal(db_path)  # WAL: concurrent committed writer required
+        d = _open_capable(db_path, cjk_so, monkeypatch)
+        try:
+            while d.fts_session_cjk_rebuild_step():
+                pass
+            d.create_session("日本語ID", source="cli")
+            d.set_session_title("日本語ID", "東京タワー計画")
+            assert d._sessions_cjk_available is True
+
+            def commit_sibling():
+                # The sibling's mid-flight write, committed on a SEPARATE
+                # connection while our read transaction stays open: mark
+                # stale, drop the CJK triggers, add a new canonical session
+                # AND index it directly — so the CJK index now differs from
+                # the guard's snapshot.
+                b = sqlite3.connect(str(db_path), isolation_level=None)
+                b.enable_load_extension(True)
+                b.load_extension(str(cjk_so))
+                try:
+                    b.execute("BEGIN IMMEDIATE")
+                    b.execute(
+                        "INSERT INTO state_meta (key, value) VALUES (?, ?) "
+                        "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                        (CJK_STALE, "1"),
+                    )
+                    b.execute("DROP TRIGGER IF EXISTS sessions_fts_cjk_insert")
+                    b.execute("DROP TRIGGER IF EXISTS sessions_fts_cjk_delete")
+                    b.execute("DROP TRIGGER IF EXISTS sessions_fts_cjk_update")
+                    b.execute(
+                        "INSERT INTO sessions (row_id, id, source, "
+                        "started_at, title) VALUES (?, ?, 'cli', ?, ?)",
+                        (1000, "sibling_new", 1.0, "東京ライバル"),
+                    )
+                    b.execute(
+                        "INSERT INTO sessions_fts_cjk "
+                        "(rowid, title, id, display_name) "
+                        "VALUES (?, ?, ?, NULL)",
+                        (1000, "東京ライバル", "sibling_new"),
+                    )
+                    b.execute("COMMIT")
+                finally:
+                    b.close()
+
+            real_read_ctx = SessionDB._read_ctx
+
+            class _RacyReadConn:
+                """Delegates to the real read connection, but after the FIRST
+                durable guard SELECT completes it commits the sibling's
+                concurrent write — manufacturing the P1 interleaving between
+                the guard and the MATCH that a plain sequential test cannot.
+                (``sqlite3.Connection.execute`` is a C-level slot and cannot
+                be monkeypatched directly.)"""
+
+                def __init__(self, conn, on_guard_read):
+                    self._conn = conn
+                    self._on_guard_read = on_guard_read
+                    self._fired = False
+
+                @property
+                def in_transaction(self):
+                    return self._conn.in_transaction
+
+                def execute(self, sql, *args, **kwargs):
+                    cur = self._conn.execute(sql, *args, **kwargs)
+                    if (
+                        not self._fired
+                        and isinstance(sql, str)
+                        and "state_meta" in sql
+                        and sql.lstrip().upper().startswith("SELECT")
+                    ):
+                        # First guard read done — its snapshot (no stale) is
+                        # established. Now let the sibling's write land.
+                        self._fired = True
+                        self._on_guard_read()
+                    return cur
+
+            @contextlib.contextmanager
+            def racy_read_ctx(self):
+                with real_read_ctx(self) as conn:
+                    yield _RacyReadConn(conn, commit_sibling)
+
+            monkeypatch.setattr(SessionDB, "_read_ctx", racy_read_ctx)
+            servable, candidates = d._fts_cjk_metadata_candidates("東京")
+            # Post-fix: consistent pre-write snapshot — the pre-existing row
+            # is found and the sibling's post-snapshot row is NOT served as
+            # if current (it lives on a later, stale-guarded snapshot the
+            # guard never saw).
+            assert servable is True
+            assert any(c["id"] == "日本語ID" for c in candidates)
+            assert all(c["id"] != "sibling_new" for c in candidates)
         finally:
             d.close()
 

--- a/tests/test_session_metadata_cjk_fts.py
+++ b/tests/test_session_metadata_cjk_fts.py
@@ -1,0 +1,553 @@
+"""Tests for the #26 session-metadata CJK FTS lifecycle.
+
+CJK session metadata is an OPTIONAL specialization of #25's Unicode
+external-content architecture: the same stable ``sessions.row_id`` identity,
+the same external-content/resumable H/P rebuild model, and the same generic
+chunk/finish engine — while keeping tokenizer capability (worker-operable)
+separate from search-serving availability, using independent CJK-session
+durable markers, and degrading safely when the ``cjk_unicode61`` tokenizer is
+unavailable.
+
+Builds the loadable tokenizer from ``native/fts5_cjk/fts5_cjk.c`` on the fly
+(CI/Linux images ship gcc); the capable-host tests skip when no C toolchain
+is present. The degraded/unavailable-host tests that need no tokenizer always
+run.
+"""
+
+import sqlite3
+import shutil
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+from hermes_state import SCHEMA_SQL, SessionDB
+
+REPO = Path(__file__).resolve().parent.parent
+SRC = REPO / "native" / "fts5_cjk" / "fts5_cjk.c"
+VENDOR = REPO / "native" / "fts5_cjk" / "vendor"
+
+
+def _build_populated_sessions_db(db_path, n=1200):
+    """Build a DB with ``n`` sessions (explicit row_ids 1..n) and no FTS
+    surfaces, so the open stages a full H/P claim over an empty index (the
+    real #25/#26 migration shape). Mirrors the #25 module helper."""
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA foreign_keys=OFF")
+    conn.executescript(SCHEMA_SQL)
+    t0 = time.time()
+    conn.executemany(
+        "INSERT INTO sessions (row_id, id, source, started_at, title) "
+        "VALUES (?, ?, 'cli', ?, ?)",
+        [(i, f"s{i}", t0 + i, f"Title {i}") for i in range(1, n + 1)],
+    )
+    conn.commit()
+    conn.close()
+
+
+def _fts_sql(conn, table):
+    """The stored CREATE statement for ``table`` from sqlite_master."""
+    row = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?",
+        (table,),
+    ).fetchone()
+    return (row[0] if isinstance(row, sqlite3.Row) else row[0]) if row else ""
+
+# Durable CJK-session marker keys (independent from both the Unicode-session
+# pair and the message-CJK pair).
+CJK_HW = "fts_session_cjk_rebuild_high_water"
+CJK_PROG = "fts_session_cjk_rebuild_progress"
+CJK_STALE = "fts_session_cjk_stale"
+UNI_HW = "fts_session_rebuild_high_water"
+
+
+@pytest.fixture()
+def db(tmp_path):
+    """Fresh SessionDB with no CJK tokenizer (plain FTS5) — used by the
+    tokenizer-independent fallback tests."""
+    d = SessionDB(db_path=tmp_path / "state.db")
+    yield d
+    d.close()
+
+
+@pytest.fixture(scope="session")
+def cjk_so(tmp_path_factory):
+    """Build the cjk_unicode61 loadable tokenizer from source; skip when no C
+    toolchain / extension loading is available (mirrors test_fts_cjk_bigram)."""
+    if shutil.which("gcc") is None or not SRC.exists():
+        pytest.skip("no C toolchain / tokenizer source")
+    out = tmp_path_factory.mktemp("fts5cjk") / "libfts5_cjk.so"
+    try:
+        subprocess.run(
+            ["gcc", "-shared", "-fPIC", "-O2", f"-I{VENDOR}", str(SRC),
+             "-o", str(out)],
+            check=True, capture_output=True, text=True,
+        )
+    except subprocess.CalledProcessError as e:
+        pytest.skip(f"tokenizer build failed: {e.stderr[:200]}")
+    probe = sqlite3.connect(":memory:")
+    try:
+        probe.enable_load_extension(True)
+        probe.load_extension(str(out))
+    except Exception as e:
+        pytest.skip(f"extension loading unavailable: {e}")
+    finally:
+        probe.close()
+    return out
+
+
+@pytest.fixture()
+def cjk_db(cjk_so, tmp_path, monkeypatch):
+    """Fresh SessionDB on a tokenizer-capable host (empty DB)."""
+    monkeypatch.setenv("HERMES_FTS5_CJK_SO", str(cjk_so))
+    d = SessionDB(db_path=tmp_path / "state.db")
+    yield d
+    d.close()
+
+
+# The pre-#26 sessions_fts_cjk shape: internal-content, title-only, one-shot,
+# three broad triggers (mirrors the pinned SESSIONS_FTS_CJK_SQL).
+_LEGACY_SESSIONS_FTS_CJK_DDL = """
+CREATE VIRTUAL TABLE sessions_fts_cjk USING fts5(
+    title,
+    tokenize='cjk_unicode61'
+);
+
+CREATE TRIGGER sessions_fts_cjk_insert AFTER INSERT ON sessions BEGIN
+    INSERT INTO sessions_fts_cjk(rowid, title) VALUES (new.rowid, new.title);
+END;
+
+CREATE TRIGGER sessions_fts_cjk_delete AFTER DELETE ON sessions BEGIN
+    DELETE FROM sessions_fts_cjk WHERE rowid = old.rowid;
+END;
+
+CREATE TRIGGER sessions_fts_cjk_update AFTER UPDATE ON sessions BEGIN
+    DELETE FROM sessions_fts_cjk WHERE rowid = old.rowid;
+    INSERT INTO sessions_fts_cjk(rowid, title) VALUES (new.rowid, new.title);
+END;
+"""
+
+
+def _build_legacy_cjk_db(db_path, cjk_so, n=10):
+    """Build a pre-#26 DB: modern sessions (named row_id) with a legacy
+    internal-content title-only ``sessions_fts_cjk`` + broad triggers. The
+    tokenizer must be loaded on the build connection to create the legacy
+    table (tokenize='cjk_unicode61')."""
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA foreign_keys=OFF")
+    conn.executescript(SCHEMA_SQL)
+    conn.enable_load_extension(True)
+    conn.load_extension(str(cjk_so))
+    t0 = time.time()
+    conn.executemany(
+        "INSERT INTO sessions (row_id, id, source, started_at, title) "
+        "VALUES (?, ?, 'cli', ?, ?)",
+        [(i, f"s{i}", t0 + i, f"標題 {i}") for i in range(1, n + 1)],
+    )
+    conn.executescript(_LEGACY_SESSIONS_FTS_CJK_DDL)
+    conn.commit()
+    conn.close()
+
+
+def _open_capable(db_path, cjk_so, monkeypatch):
+    """Open SessionDB with the tokenizer available."""
+    monkeypatch.setenv("HERMES_FTS5_CJK_SO", str(cjk_so))
+    return SessionDB(db_path=db_path)
+
+
+def _open_incapable(db_path, tmp_path, monkeypatch):
+    """Open SessionDB with the tokenizer unavailable (absent .so)."""
+    monkeypatch.setenv("HERMES_FTS5_CJK_SO", str(tmp_path / "absent.so"))
+    return SessionDB(db_path=db_path)
+
+
+def _cjk_fts_rowids(db, query):
+    """CJK-session FTS rowids (sessions.row_id) that MATCH, read DIRECTLY
+    from the index — no canonical-sessions JOIN (delete-test probe)."""
+    with db._read_ctx() as conn:
+        rows = conn.execute(
+            "SELECT rowid FROM sessions_fts_cjk WHERE sessions_fts_cjk MATCH ?",
+            (query,),
+        ).fetchall()
+    return [r["rowid"] for r in rows]
+
+
+def _cjk_match_ids(db, query):
+    """Session ids matched through the completed CJK metadata lane."""
+    servable, candidates = db._fts_cjk_metadata_candidates(query)
+    assert servable is True, "CJK lane should be servable here"
+    return [c["id"] for c in candidates]
+
+
+def _assert_sessions_fts_cjk_integrity(db):
+    """rank=1 integrity check: cross-checks the CJK external index against
+    the canonical sessions content table (catches orphan/stale postings)."""
+    db._conn.execute(
+        "INSERT INTO sessions_fts_cjk(sessions_fts_cjk, rank) "
+        "VALUES('integrity-check', 1)"
+    )
+
+
+# =========================================================================
+# Group A — external-content raw shape (replaces legacy title-only)
+# =========================================================================
+
+
+class TestCjkExternalContentShape:
+    def test_sessions_fts_cjk_ddl_is_external_content_raw_metadata(self, cjk_db):
+        """sessions_fts_cjk is external-content over raw (title, id,
+        display_name) keyed by named ``row_id`` — NOT the legacy title-only
+        internal shape."""
+        sql = _fts_sql(cjk_db._conn, "sessions_fts_cjk")
+        assert "content='sessions'" in sql
+        assert "content_rowid='row_id'" in sql
+        assert "tokenize='cjk_unicode61'" in sql
+        for col in ("title", "id", "display_name"):
+            assert col in sql
+
+    def test_update_trigger_is_narrow(self, cjk_db):
+        """The CJK update trigger is AFTER UPDATE OF title,id,display_name
+        with a value-change guard — unrelated metadata writes do not rewrite
+        the CJK index."""
+        trig = cjk_db._conn.execute(
+            "SELECT sql FROM sqlite_master "
+            "WHERE type = 'trigger' AND name = 'sessions_fts_cjk_update'"
+        ).fetchone()
+        sql = trig[0] if not isinstance(trig, sqlite3.Row) else trig["sql"]
+        compact = " ".join(sql.split())
+        assert "AFTER UPDATE OF title, id, display_name" in compact
+
+    def test_legacy_internal_cjk_table_replaced_on_capable_open(
+        self, cjk_so, tmp_path, monkeypatch
+    ):
+        """A pre-#26 internal title-only sessions_fts_cjk is replaced by the
+        external-content shape on a tokenizer-capable open; the legacy shadow
+        tables are gone."""
+        db_path = tmp_path / "legacy.db"
+        _build_legacy_cjk_db(db_path, cjk_so, n=10)
+        d = _open_capable(db_path, cjk_so, monkeypatch)
+        try:
+            sql = _fts_sql(d._conn, "sessions_fts_cjk")
+            assert "content='sessions'" in sql
+            assert "content_rowid='row_id'" in sql
+            # Legacy broad triggers are gone; gated external triggers exist.
+            live = {
+                r[0] for r in d._conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type = 'trigger' "
+                    "AND name LIKE 'sessions_fts_cjk_%'"
+                ).fetchall()
+            }
+            assert {"sessions_fts_cjk_insert", "sessions_fts_cjk_delete",
+                    "sessions_fts_cjk_update"} <= live
+        finally:
+            d.close()
+
+
+# =========================================================================
+# Group B — independent CJK-session H/P + worker-progress deadlock pin
+# =========================================================================
+
+
+class TestCjkRebuildMarkers:
+    def test_populated_db_stages_cjk_session_markers(self, cjk_so, tmp_path, monkeypatch):
+        """A populated DB opened on a capable host stages CJK-session-owned
+        H/P markers — independent of the Unicode session pair (the two indexes
+        may sit at different completion points)."""
+        db_path = tmp_path / "s.db"
+        _build_populated_sessions_db(db_path, n=50)
+        d = _open_capable(db_path, cjk_so, monkeypatch)
+        try:
+            assert d.get_meta(CJK_HW) is not None
+            assert d.get_meta(CJK_PROG) == "0"
+            # Independent markers: seeding CJK must never borrow the Unicode
+            # claim (and vice versa).
+            assert d.get_meta(UNI_HW) is not None  # Unicode also staged
+            # The CJK and Unicode claims are separate keys.
+            assert CJK_HW != UNI_HW
+        finally:
+            d.close()
+
+    def test_empty_db_cjk_complete_no_markers(self, cjk_db):
+        """An empty DB's CJK index is complete by construction — no claim, and
+        search-serving is available immediately."""
+        assert cjk_db.get_meta(CJK_HW) is None
+        assert cjk_db._sessions_cjk_available is True
+
+    def test_cjk_pending_worker_progresses_while_search_unavailable(
+        self, cjk_so, tmp_path, monkeypatch
+    ):
+        """THE deadlock regression: a pending CJK backfill has worker-operable
+        = true and search-serving = false; the worker must still advance, run
+        finish, clear the markers, and only then become search-serving."""
+        db_path = tmp_path / "s.db"
+        _build_populated_sessions_db(db_path, n=50)
+        d = _open_capable(db_path, cjk_so, monkeypatch)
+        try:
+            assert d._sessions_cjk_worker_operable is True
+            assert d._sessions_cjk_available is False
+            assert d.fts_session_cjk_rebuild_status() is not None
+
+            steps = 0
+            while d.fts_session_cjk_rebuild_step() and steps < 200:
+                steps += 1
+            assert d.get_meta(CJK_HW) is None
+            assert d.get_meta(CJK_PROG) is None
+            assert d._sessions_cjk_available is True
+        finally:
+            d.close()
+
+    def test_cjk_markers_survive_reopen_no_reseed(self, cjk_so, tmp_path, monkeypatch):
+        """A partial CJK rebuild is not reseeded to zero on reopen — the same
+        H/P resume as the Unicode lifecycle."""
+        db_path = tmp_path / "s.db"
+        _build_populated_sessions_db(db_path, n=50)
+        w = _open_capable(db_path, cjk_so, monkeypatch)
+        w.fts_session_cjk_rebuild_step()  # advance a bit
+        hw = w.get_meta(CJK_HW)
+        prog = w.get_meta(CJK_PROG)
+        w.close()
+
+        r = _open_capable(db_path, cjk_so, monkeypatch)
+        try:
+            assert r.get_meta(CJK_HW) == hw
+            assert r.get_meta(CJK_PROG) == prog
+        finally:
+            r.close()
+
+    def test_cjk_finish_sets_search_serving_after_boundary_sweep(
+        self, cjk_so, tmp_path, monkeypatch
+    ):
+        """Finish runs the boundary sweep under the SAME operability gate as
+        step, then clears CJK H/P and flips search-serving on."""
+        db_path = tmp_path / "s.db"
+        _build_populated_sessions_db(db_path, n=50)
+        d = _open_capable(db_path, cjk_so, monkeypatch)
+        try:
+            # Backfill everything by hand, then delete one doc to simulate a
+            # write that slipped at the boundary; a single step (P >= H) must
+            # run the finish sweep and restore the missing doc.
+            d._conn.execute(
+                "INSERT INTO sessions_fts_cjk(rowid, title, id, display_name) "
+                "SELECT row_id, title, id, display_name FROM sessions "
+                "WHERE row_id <= 50"
+            )
+            d._conn.execute(
+                "UPDATE state_meta SET value = '50' WHERE key = ?", (CJK_PROG,)
+            )
+            d._conn.execute(
+                "INSERT INTO sessions_fts_cjk(sessions_fts_cjk, rowid, title, id, display_name) "
+                "SELECT 'delete', s.row_id, s.title, s.id, s.display_name "
+                "FROM sessions s WHERE s.id = 's25'"
+            )
+            d._conn.commit()
+            assert 25 not in _cjk_fts_rowids(d, "標題")
+            assert d.fts_session_cjk_rebuild_step() is False
+            assert d.get_meta(CJK_HW) is None
+            assert d._sessions_cjk_available is True
+        finally:
+            d.close()
+
+    def test_stale_capable_restart_resets_and_rebuilds_from_fresh_highwater(
+        self, cjk_so, tmp_path, monkeypatch
+    ):
+        """A tokenizer-less host dropping the CJK triggers marks the index
+        stale. A later capable host must reset to a known-empty surface and
+        reseed a fresh CJK H/P from the CURRENT MAX(row_id), then rebuild —
+        never reuse the old partial claim."""
+        db_path = tmp_path / "s.db"
+        _build_populated_sessions_db(db_path, n=20)
+        w = _open_capable(db_path, cjk_so, monkeypatch)
+        # Stage a partial CJK claim.
+        w.set_meta(CJK_HW, "20")
+        w.set_meta(CJK_PROG, "5")
+        w.close()
+
+        # Incapable open: drops triggers, leaves durable state, marks stale.
+        r = _open_incapable(db_path, tmp_path, monkeypatch)
+        assert r.get_meta(CJK_HW) == "20"
+        assert r.get_meta(CJK_STALE) == "1"
+        r.close()
+
+        # New sessions are added while the index is unusable.
+        with sqlite3.connect(str(db_path)) as conn:
+            conn.execute(
+                "INSERT INTO sessions (id, source, started_at) "
+                "VALUES ('s21', 'cli', ?)", (time.time(),)
+            )
+            conn.commit()
+
+        # Capable reopen + optimize: reset + reseed from MAX(row_id)=21 and
+        # rebuild to completion -> search-serving.
+        d = _open_capable(db_path, cjk_so, monkeypatch)
+        try:
+            assert d.get_meta(CJK_STALE) is not None
+            result = d.optimize_fts_storage(vacuum=False)
+            assert result["ok"] is True, result
+            assert d.get_meta(CJK_HW) is None
+            assert d.get_meta(CJK_STALE) is None
+            assert d._sessions_cjk_available is True
+        finally:
+            d.close()
+
+
+# =========================================================================
+# Group C — tokenizer-unavailable degradation
+# =========================================================================
+
+
+class TestCjkDegradation:
+    def test_incapable_host_preserves_pending_and_keeps_unicode_healthy(
+        self, cjk_so, tmp_path, monkeypatch
+    ):
+        """Reopening a DB with pending CJK work on a tokenizer-less host keeps
+        the durable pending state (missing capability is never evidence of
+        completion), leaves Unicode/session writes and search healthy, and
+        marks the index stale for a later capable rebuild."""
+        db_path = tmp_path / "s.db"
+        _build_populated_sessions_db(db_path, n=20)
+        w = _open_capable(db_path, cjk_so, monkeypatch)
+        w.fts_session_cjk_rebuild_step()  # partial progress
+        hw = w.get_meta(CJK_HW)
+        prog = w.get_meta(CJK_PROG)
+        assert hw is not None
+        w.close()
+
+        r = _open_incapable(db_path, tmp_path, monkeypatch)
+        try:
+            assert r._sessions_cjk_worker_operable is False
+            assert r._sessions_cjk_available is False
+            # Pending durable state untouched — no false completion.
+            assert r.get_meta(CJK_HW) == hw
+            assert r.get_meta(CJK_PROG) == prog
+            # Canonical session writes still work.
+            r.create_session("S", source="cli")
+            r.set_session_title("S", "Unicode Session New")
+            # Unicode metadata search still works.
+            _, cands = r._fts_metadata_candidates("unicode")
+            assert any(c["id"] == "S" for c in cands)
+            # The index is marked stale so a capable host resets/rebuilds.
+            assert r.get_meta(CJK_STALE) == "1"
+        finally:
+            r.close()
+
+    def test_incapable_host_fresh_empty_db_is_healthy(self, tmp_path, monkeypatch):
+        """A tokenizer-less host on a fresh DB: no CJK table created, Unicode
+        sessions work normally, no stale breadcrumb fabricated."""
+        monkeypatch.setenv("HERMES_FTS5_CJK_SO", str(tmp_path / "absent.so"))
+        d = SessionDB(db_path=tmp_path / "fresh.db")
+        try:
+            assert d._sessions_cjk_worker_operable is False
+            assert d._sessions_cjk_available is False
+            assert d.get_meta(CJK_STALE) is None
+            d.create_session("s1", source="cli")
+            d.set_session_title("s1", "Hello")
+            assert d.get_session_by_title("Hello")["id"] == "s1"
+        finally:
+            d.close()
+
+
+# =========================================================================
+# Group D — search seam: pending/unavailable/1-char fallback vs zero matches
+# =========================================================================
+
+
+class TestCjkSearchSeam:
+    def test_lone_cjk_char_is_fallback_only(self, db):
+        """A one-character CJK query is classified as fallback-only — the
+        bigram index's useful lower bound is two CJK characters. Does not
+        require the tokenizer: the fallback decision is made before touching
+        the index."""
+        servable, candidates = db._fts_cjk_metadata_candidates("中")
+        assert servable is False
+        assert candidates is None
+
+    def test_pending_cjk_not_served(self, cjk_so, tmp_path, monkeypatch):
+        """A pending CJK backfill must not serve search: the seam reports
+        unservable (canonical fallback), never a partial index."""
+        db_path = tmp_path / "s.db"
+        _build_populated_sessions_db(db_path, n=50)
+        d = _open_capable(db_path, cjk_so, monkeypatch)
+        try:
+            assert d._sessions_cjk_available is False
+            servable, candidates = d._fts_cjk_metadata_candidates("標題")
+            assert servable is False
+            assert candidates is None
+            # But canonical fallback still finds the row.
+            _, uni = d._fts_metadata_candidates("標題")
+            assert any(c["id"] == "s1" for c in uni)
+        finally:
+            d.close()
+
+    def test_unavailable_tokenizer_not_served(self, tmp_path, monkeypatch):
+        """No tokenizer: the seam reports unservable and routing falls back."""
+        monkeypatch.setenv("HERMES_FTS5_CJK_SO", str(tmp_path / "absent.so"))
+        d = SessionDB(db_path=tmp_path / "s.db")
+        try:
+            d.create_session("s1", source="cli")
+            d.set_session_title("s1", "日本語セッション")
+            servable, candidates = d._fts_cjk_metadata_candidates("日本語")
+            assert servable is False
+            assert candidates is None
+        finally:
+            d.close()
+
+    def test_completed_cjk_index_finds_title_id_display_name(
+        self, cjk_so, tmp_path, monkeypatch
+    ):
+        """A completed CJK index finds representative 2+ char CJK in title,
+        logical session id, AND display_name."""
+        db_path = tmp_path / "s.db"
+        _build_populated_sessions_db(db_path, n=20)
+        d = _open_capable(db_path, cjk_so, monkeypatch)
+        try:
+            while d.fts_session_cjk_rebuild_step():
+                pass
+            assert d._sessions_cjk_available is True
+            d.create_session("日本語ID", source="cli")
+            d.set_session_title("日本語ID", "東京タワー計画")
+            d._conn.execute(
+                "UPDATE sessions SET display_name = 'カタカナ表示' "
+                "WHERE id = '日本語ID'"
+            )
+            d._conn.commit()
+            assert _cjk_match_ids(d, "東京") == ["日本語ID"]      # title
+            assert _cjk_match_ids(d, "日本語") == ["日本語ID"]    # logical id
+            assert _cjk_match_ids(d, "カタカナ") == ["日本語ID"]  # display_name
+        finally:
+            d.close()
+
+    def test_cjk_valid_zero_match_distinct_from_capability_failure(
+        self, cjk_so, tmp_path, monkeypatch
+    ):
+        """A servable CJK query with no matches returns (True, []) — distinct
+        from (False, None) capability/pending failure so #14 can route."""
+        db_path = tmp_path / "s.db"
+        _build_populated_sessions_db(db_path, n=20)
+        d = _open_capable(db_path, cjk_so, monkeypatch)
+        try:
+            while d.fts_session_cjk_rebuild_step():
+                pass
+            servable, candidates = d._fts_cjk_metadata_candidates("不存在詞彙")
+            assert servable is True
+            assert candidates == []
+        finally:
+            d.close()
+
+    def test_completed_cjk_index_integrity_after_deletes(
+        self, cjk_so, tmp_path, monkeypatch
+    ):
+        """After a completed CJK backfill, deleting a live row leaves no
+        orphan posting (rank=1 external-content consistency)."""
+        db_path = tmp_path / "s.db"
+        _build_populated_sessions_db(db_path, n=20)
+        d = _open_capable(db_path, cjk_so, monkeypatch)
+        try:
+            while d.fts_session_cjk_rebuild_step():
+                pass
+            d.set_session_title("s1", "東京タワー")
+            d.delete_session("s1")
+            assert 1 not in _cjk_fts_rowids(d, "東京")
+            _assert_sessions_fts_cjk_integrity(d)
+        finally:
+            d.close()

--- a/tests/test_session_metadata_cjk_fts.py
+++ b/tests/test_session_metadata_cjk_fts.py
@@ -318,6 +318,30 @@ class TestCjkRebuildMarkers:
         finally:
             d.close()
 
+    def test_finish_hook_keeps_search_unavailable_when_stale(
+        self, cjk_so, tmp_path, monkeypatch
+    ):
+        """A stale breadcrumb persisted by an incapable host mid-rebuild (it
+        dropped the CJK triggers, leaving a gap of unknown extent) must keep
+        search-serving OFF even after finish clears the H/P markers — an index
+        with an unknown gap is never served in-process (#77629/#26)."""
+        db_path = tmp_path / "s.db"
+        _build_populated_sessions_db(db_path, n=50)
+        d = _open_capable(db_path, cjk_so, monkeypatch)
+        try:
+            # Simulate an incapable host persisting the stale breadcrumb
+            # while the rebuild is in flight.
+            d.set_meta(CJK_STALE, "1")
+            while d.fts_session_cjk_rebuild_step():
+                pass
+            # Finish ran (markers cleared) but search must stay unavailable.
+            assert d.get_meta(CJK_HW) is None
+            assert d.get_meta(CJK_PROG) is None
+            assert d.get_meta(CJK_STALE) == "1"
+            assert d._sessions_cjk_available is False
+        finally:
+            d.close()
+
     def test_cjk_markers_survive_reopen_no_reseed(self, cjk_so, tmp_path, monkeypatch):
         """A partial CJK rebuild is not reseeded to zero on reopen — the same
         H/P resume as the Unicode lifecycle."""


### PR DESCRIPTION
Draft PR opened for code review of the existing `fts/session-cjk-highwater` implementation branch.

Refs #26.

Review target: #26 acceptance criteria and the completed #33 research handoff, especially worker-operability vs search-serving separation, independent CJK H/P state, stale/tokenizer-unavailable degradation, shared rebuild lifecycle, live-write trigger regions, and all-three-field candidate/search behavior.