### PR TITLE
feat(search): production compression-lineage resolver (#68)

### DIFF
--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -2008,7 +2008,6 @@ class SessionSearchMixin:
         lineage_depth_cap: int = 64,
         request_id: str = None,
         current_session_id: Optional[str] = None,
-        title_session_id: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Select discovery winners in SQLite without candidate hydration.
 
@@ -2022,10 +2021,12 @@ class SessionSearchMixin:
         contain no full message content and no candidate context; FTS
         snippets are computed only for the final winners.
 
-        ``current_session_id`` / ``title_session_id`` are raw session ids
-        re-resolved inside this snapshot with the SAME memo/state used for
-        candidate roots, so current-session / exact-title exclusion and
-        winner dedupe share one root meaning and one work budget.
+        ``current_session_id`` is a raw session id re-resolved inside this
+        snapshot with the SAME memo/state used for candidate roots, so
+        current-session exclusion and winner dedupe share one root meaning and
+        one work budget.  Exact-title exclusion arrives via
+        ``excluded_lineage_roots`` (resolved by the caller with the same
+        compression-lineage implementation).
 
         ``lineage_depth_cap`` is retained only for caller compatibility; #68
         replaced depth as an identity/safety boundary with a traversal-local
@@ -2042,9 +2043,6 @@ class SessionSearchMixin:
             "lineage_memo_entries": 0,
             "lineage_candidates_inspected": 0,
             "lineage_bound_hit": False,
-            "lineage_snapshot_ran": False,
-            "lineage_title_root": None,
-            "lineage_current_root": None,
             "route": "none",
         }}
         if not self._fts_enabled or not query or not query.strip():
@@ -2282,11 +2280,6 @@ class SessionSearchMixin:
         state = _LineageResolutionState(_LINEAGE_WORK_BUDGET)
         winners: List[Dict[str, Any]] = []
         seen_roots: set[str] = set()
-        # True once the winner phase actually executes the in-snapshot
-        # current/title resolution; stays False for early returns (FTS
-        # unavailable / empty query / MATCH error) so the tool can tell
-        # "snapshot could not prove lineage" from "snapshot never ran".
-        lineage_snapshot_ran = False
 
         with self._read_ctx() as conn:
             started_tx = not conn.in_transaction
@@ -2324,9 +2317,6 @@ class SessionSearchMixin:
                             "lineage_memo_entries": 0,
                             "lineage_candidates_inspected": 0,
                             "lineage_bound_hit": False,
-                            "lineage_snapshot_ran": False,
-                            "lineage_title_root": None,
-                            "lineage_current_root": None,
                             "route": route,
                         },
                     }
@@ -2341,31 +2331,14 @@ class SessionSearchMixin:
                         candidates[0].pop("candidate_unique_sessions", 0)
                     )
 
-                # Exact-title exclusion re-resolves the raw title session id
-                # in-snapshot with the SAME memo/state/budget as candidates, so
-                # the title slot and the content lane share one root meaning
-                # (#68 review finding 1).  Full exclusion: the title already
-                # occupies its slot, its lineage members must not duplicate it.
-                # resolved_title_root is reported so the tool can decide whether
-                # the title result itself is a PROVEN safe winner (distinct
-                # from the current lineage) or must be dropped on B exhaustion.
-                lineage_snapshot_ran = True
+                # Exact-title exclusion arrives as pre-resolved roots in
+                # ``excluded_lineage_roots`` (the caller resolves them with the
+                # same compression-lineage implementation).  Full exclusion:
+                # the title already occupies its slot, so its lineage members
+                # must not duplicate it as content winners.
                 excluded_roots = {str(root) for root in excluded_lineage_roots}
-                resolved_title_root: Optional[str] = None
-                if title_session_id:
-                    outcome = self._resolve_compression_lineage_on_conn(
-                        conn, str(title_session_id), state
-                    )
-                    if outcome is _BUDGET_EXHAUSTED:
-                        state.bound_hit = True
-                    elif outcome is _UNRESOLVED:
-                        excluded_roots.add(str(title_session_id))
-                    else:
-                        resolved_title_root = outcome
-                        excluded_roots.add(outcome)
 
                 current_root: Optional[str] = None
-                resolved_current_root: Optional[str] = None
                 current_ancestors: set = set()
                 if current_session_id:
                     # Re-resolve the raw current identity inside this winner
@@ -2379,11 +2352,9 @@ class SessionSearchMixin:
                     elif outcome is _UNRESOLVED:
                         # Conservative: an unresolved current session excludes
                         # only its own id rather than broadening exclusion to
-                        # an unproven ancestor.  resolved_current_root stays
-                        # None — the snapshot cannot prove lineage distinctness.
+                        # an unproven ancestor.
                         current_root = str(current_session_id)
                     else:
-                        resolved_current_root = outcome
                         current_root = outcome
                         current_ancestors = (
                             self._current_lineage_ancestors_on_conn(
@@ -2392,7 +2363,6 @@ class SessionSearchMixin:
                         )
                 elif current_lineage_root:
                     current_root = str(current_lineage_root)
-                    resolved_current_root = current_root
 
                 def _is_archived(candidate: Dict[str, Any]) -> bool:
                     """True when a hit's content left the live context."""
@@ -2492,9 +2462,6 @@ class SessionSearchMixin:
                     "lineage_memo_entries": len(state.memo),
                     "lineage_candidates_inspected": state.candidates_inspected,
                     "lineage_bound_hit": state.bound_hit,
-                    "lineage_snapshot_ran": lineage_snapshot_ran,
-                    "lineage_title_root": resolved_title_root,
-                    "lineage_current_root": resolved_current_root,
                     "route": route,
                 }
             finally:

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -2042,6 +2042,8 @@ class SessionSearchMixin:
             "lineage_memo_entries": 0,
             "lineage_candidates_inspected": 0,
             "lineage_bound_hit": False,
+            "lineage_title_root": None,
+            "lineage_current_root": None,
             "route": "none",
         }}
         if not self._fts_enabled or not query or not query.strip():
@@ -2316,6 +2318,8 @@ class SessionSearchMixin:
                             "lineage_memo_entries": 0,
                             "lineage_candidates_inspected": 0,
                             "lineage_bound_hit": False,
+                            "lineage_title_root": None,
+                            "lineage_current_root": None,
                             "route": route,
                         },
                     }
@@ -2335,7 +2339,11 @@ class SessionSearchMixin:
                 # the title slot and the content lane share one root meaning
                 # (#68 review finding 1).  Full exclusion: the title already
                 # occupies its slot, its lineage members must not duplicate it.
+                # resolved_title_root is reported so the tool can decide whether
+                # the title result itself is a PROVEN safe winner (distinct
+                # from the current lineage) or must be dropped on B exhaustion.
                 excluded_roots = {str(root) for root in excluded_lineage_roots}
+                resolved_title_root: Optional[str] = None
                 if title_session_id:
                     outcome = self._resolve_compression_lineage_on_conn(
                         conn, str(title_session_id), state
@@ -2345,9 +2353,11 @@ class SessionSearchMixin:
                     elif outcome is _UNRESOLVED:
                         excluded_roots.add(str(title_session_id))
                     else:
+                        resolved_title_root = outcome
                         excluded_roots.add(outcome)
 
                 current_root: Optional[str] = None
+                resolved_current_root: Optional[str] = None
                 current_ancestors: set = set()
                 if current_session_id:
                     # Re-resolve the raw current identity inside this winner
@@ -2361,17 +2371,20 @@ class SessionSearchMixin:
                     elif outcome is _UNRESOLVED:
                         # Conservative: an unresolved current session excludes
                         # only its own id rather than broadening exclusion to
-                        # an unproven ancestor.
+                        # an unproven ancestor.  resolved_current_root stays
+                        # None — the snapshot cannot prove lineage distinctness.
                         current_root = str(current_session_id)
                     else:
+                        resolved_current_root = outcome
                         current_root = outcome
-                    current_ancestors = (
-                        self._current_lineage_ancestors_on_conn(
-                            conn, str(current_session_id), state
+                        current_ancestors = (
+                            self._current_lineage_ancestors_on_conn(
+                                conn, str(current_session_id), state
+                            )
                         )
-                    )
                 elif current_lineage_root:
                     current_root = str(current_lineage_root)
+                    resolved_current_root = current_root
 
                 def _is_archived(candidate: Dict[str, Any]) -> bool:
                     """True when a hit's content left the live context."""
@@ -2380,71 +2393,65 @@ class SessionSearchMixin:
                         or int(candidate["message_compacted"] or 0) == 1
                     )
 
-                # Ranked DISTINCT owner candidates (frozen #68 pipeline): group
-                # the bounded raw hits by owning session with each owner's hits
-                # in rank order, then resolve each owner exactly ONCE.  From the
-                # owner's ranked hits pick the first displayable anchor — under
-                # current exclusion a live hit is skipped so the next
-                # compacted-history hit of the same owner still surfaces
-                # (compacted history is never erased by owner dedupe).
-                owner_hits: Dict[str, List[Dict[str, Any]]] = {}
-                owner_order: List[str] = []
+                # Resolve each owner exactly ONCE (lazily, on first encounter)
+                # while iterating the bounded raw hits in rank order.  Winner
+                # ordering therefore follows the rank of each owner's FIRST
+                # DISPLAYABLE anchor — a live current-lineage hit is skipped so
+                # a later compacted-history hit of the same owner can still
+                # surface, but it must not let that owner jump ahead of a
+                # higher-ranked displayable winner from another session (#68
+                # review round-3: ranking/winner ordering unchanged).
+                owner_resolved: set = set()
+                owner_root: Dict[str, Optional[str]] = {}
                 for candidate in candidates:
-                    owner = str(candidate["owning_session_id"])
-                    if owner not in owner_hits:
-                        owner_hits[owner] = []
-                        owner_order.append(owner)
-                    owner_hits[owner].append(candidate)
-
-                for owner in owner_order:
                     if len(winners) >= result_limit:
                         break
-                    state.candidates_inspected += 1
-                    outcome = self._resolve_compression_lineage_on_conn(
-                        conn, owner, state
-                    )
-                    if outcome is _BUDGET_EXHAUSTED:
-                        state.bound_hit = True
-                        # Stop the entire ranked scan: the bound candidate may
-                        # have produced a higher-ranked new root than every
-                        # later candidate, so skipping it would violate ranking.
-                        break
-                    if outcome is _UNRESOLVED:
+                    owner = str(candidate["owning_session_id"])
+                    if owner not in owner_resolved:
+                        owner_resolved.add(owner)
+                        state.candidates_inspected += 1
+                        outcome = self._resolve_compression_lineage_on_conn(
+                            conn, owner, state
+                        )
+                        if outcome is _BUDGET_EXHAUSTED:
+                            state.bound_hit = True
+                            # Stop the entire ranked scan: the bound candidate
+                            # may have produced a higher-ranked new root than
+                            # every later candidate, so skipping it would
+                            # violate ranking.
+                            break
+                        owner_root[owner] = (
+                            outcome if outcome is not _UNRESOLVED else None
+                        )
+                    root = owner_root[owner]
+                    if root is None:
                         continue
-                    root = outcome
-                    if root in excluded_roots:
-                        continue
-                    if root in seen_roots:
+                    if root in excluded_roots or root in seen_roots:
                         continue
                     in_current_context = (
                         (current_root is not None and root == current_root)
                         or owner in current_ancestors
                     )
-                    anchor: Optional[Dict[str, Any]] = None
-                    for hit in owner_hits[owner]:
-                        if in_current_context and not _is_archived(hit):
-                            # live content of the current lineage stays hidden;
-                            # a later compacted-history hit of this owner is
-                            # still tried as the anchor.
-                            continue
-                        anchor = hit
-                        break
-                    if anchor is None:
+                    if in_current_context and not _is_archived(candidate):
+                        # live content of the current lineage stays hidden; the
+                        # owner's displayable anchor is a later compacted hit,
+                        # so this hit does not (yet) produce a winner.
                         continue
+                    # First displayable hit of this owner in rank order.
                     seen_roots.add(root)
                     state.accepted_roots = len(seen_roots)
                     winners.append({
-                        "id": anchor["message_id"],
+                        "id": candidate["message_id"],
                         "session_id": owner,
-                        "role": anchor["role"],
-                        "snippet": anchor["snippet"],
-                        "timestamp": anchor["timestamp"],
-                        "source": anchor["source"],
-                        "model": anchor["model"],
-                        "session_started": anchor["session_started"],
+                        "role": candidate["role"],
+                        "snippet": candidate["snippet"],
+                        "timestamp": candidate["timestamp"],
+                        "source": candidate["source"],
+                        "model": candidate["model"],
+                        "session_started": candidate["session_started"],
                         "lineage_root_id": root,
-                        "candidate_order": anchor["candidate_order"],
-                        "source_priority": anchor["source_priority"],
+                        "candidate_order": candidate["candidate_order"],
+                        "source_priority": candidate["source_priority"],
                     })
 
                 if route != "like" and winners:
@@ -2477,6 +2484,8 @@ class SessionSearchMixin:
                     "lineage_memo_entries": len(state.memo),
                     "lineage_candidates_inspected": state.candidates_inspected,
                     "lineage_bound_hit": state.bound_hit,
+                    "lineage_title_root": resolved_title_root,
+                    "lineage_current_root": resolved_current_root,
                     "route": route,
                 }
             finally:

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -2042,6 +2042,7 @@ class SessionSearchMixin:
             "lineage_memo_entries": 0,
             "lineage_candidates_inspected": 0,
             "lineage_bound_hit": False,
+            "lineage_snapshot_ran": False,
             "lineage_title_root": None,
             "lineage_current_root": None,
             "route": "none",
@@ -2281,6 +2282,11 @@ class SessionSearchMixin:
         state = _LineageResolutionState(_LINEAGE_WORK_BUDGET)
         winners: List[Dict[str, Any]] = []
         seen_roots: set[str] = set()
+        # True once the winner phase actually executes the in-snapshot
+        # current/title resolution; stays False for early returns (FTS
+        # unavailable / empty query / MATCH error) so the tool can tell
+        # "snapshot could not prove lineage" from "snapshot never ran".
+        lineage_snapshot_ran = False
 
         with self._read_ctx() as conn:
             started_tx = not conn.in_transaction
@@ -2318,6 +2324,7 @@ class SessionSearchMixin:
                             "lineage_memo_entries": 0,
                             "lineage_candidates_inspected": 0,
                             "lineage_bound_hit": False,
+                            "lineage_snapshot_ran": False,
                             "lineage_title_root": None,
                             "lineage_current_root": None,
                             "route": route,
@@ -2342,6 +2349,7 @@ class SessionSearchMixin:
                 # resolved_title_root is reported so the tool can decide whether
                 # the title result itself is a PROVEN safe winner (distinct
                 # from the current lineage) or must be dropped on B exhaustion.
+                lineage_snapshot_ran = True
                 excluded_roots = {str(root) for root in excluded_lineage_roots}
                 resolved_title_root: Optional[str] = None
                 if title_session_id:
@@ -2484,6 +2492,7 @@ class SessionSearchMixin:
                     "lineage_memo_entries": len(state.memo),
                     "lineage_candidates_inspected": state.candidates_inspected,
                     "lineage_bound_hit": state.bound_hit,
+                    "lineage_snapshot_ran": lineage_snapshot_ran,
                     "lineage_title_root": resolved_title_root,
                     "lineage_current_root": resolved_current_root,
                     "route": route,

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -34,6 +34,104 @@ from hermes_state_common import (
 logger = logging.getLogger("hermes_state")
 
 
+# ── Compression-lineage resolver (#68) ────────────────────────────────────
+#
+# One logical session-search query resolves each ranked owner candidate to
+# its positive compression-continuation root with a query-local
+# memo/path-compression pass.  Generic parentage is NOT lineage: only a
+# child whose parent exists, whose parent ended by ``'compression'``, that is
+# not a ``tool`` session, and whose branch/delegate markers do not explicitly
+# point at that parent forms a compression edge.  Foreign markers pointing
+# elsewhere do not disqualify the edge.
+#
+# Safety is orthogonal to lineage identity: a traversal-local seen-set proves
+# cycles, and a global per-query work budget bounds indexed row fetches.  A
+# budget-exhausted partial path is operational uncertainty, never semantic
+# evidence, so it is not memoized as unresolved.
+_LINEAGE_WORK_BUDGET = 2000
+_UNRESOLVED = object()
+_BUDGET_EXHAUSTED = object()
+
+_LINEAGE_NODE_SQL = """
+SELECT
+    child.id,
+    child.parent_session_id,
+    child.source,
+    child.model_config,
+    parent.id AS parent_exists,
+    parent.end_reason AS parent_end_reason
+FROM sessions child
+LEFT JOIN sessions parent ON parent.id = child.parent_session_id
+WHERE child.id = ?
+"""
+
+
+def _lineage_markers(
+    model_config: Any,
+) -> Tuple[bool, Optional[str], Optional[str]]:
+    """Return ``(config_valid, branched_from, delegate_from)`` for a session.
+
+    Malformed / non-object ``model_config`` is treated as "no proven positive
+    edge" (the conservative direction): the current node becomes its own root
+    rather than traversing an unproven parent.
+    """
+    if model_config in (None, ""):
+        return True, None, None
+    value = model_config
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except (TypeError, ValueError):
+            return False, None, None
+    if not isinstance(value, dict):
+        return False, None, None
+    markers: List[Optional[str]] = []
+    for key in ("_branched_from", "_delegate_from"):
+        marker = value.get(key)
+        if marker is None:
+            markers.append(None)
+        elif isinstance(marker, str) and marker:
+            markers.append(marker)
+        else:
+            return False, None, None
+    return True, markers[0], markers[1]
+
+
+class _LineageResolutionState:
+    """Per-logical-query resolver state for one winner search.
+
+    ``work`` counts exactly one successful uncached lineage-node row fetch;
+    memo hits, absent-row fetches, and local cycle checks consume nothing.
+    ``memo`` maps a lineage node to a resolved root string or ``_UNRESOLVED``.
+    A budget-exhausted partial path is never written to the memo.
+    """
+
+    __slots__ = (
+        "budget",
+        "work",
+        "memo",
+        "memo_hits",
+        "bound_hit",
+        "candidates_inspected",
+        "accepted_roots",
+    )
+
+    def __init__(self, budget: int = _LINEAGE_WORK_BUDGET) -> None:
+        self.budget = max(1, int(budget))
+        self.work = 0
+        self.memo: Dict[str, Any] = {}
+        self.memo_hits = 0
+        self.bound_hit = False
+        self.candidates_inspected = 0
+        self.accepted_roots = 0
+
+    def _memoize_unresolved(self, path: List[str], node: str) -> None:
+        """Mark *path* plus *node* as proven unresolved (zero later lookups)."""
+        for visited in path:
+            self.memo.setdefault(visited, _UNRESOLVED)
+        self.memo.setdefault(node, _UNRESOLVED)
+
+
 # Deferred-rebuild specs shared by the message and session metadata FTS
 # engines. Each spec describes one external-content index family so the
 # crash-safe claim / chunk / finish rules (accepted through #76832 for
@@ -1718,6 +1816,148 @@ class SessionSearchMixin:
                 return None
             return [dict(row) for row in tri_cursor.fetchall()]
 
+    def _resolve_compression_lineage_on_conn(
+        self,
+        conn: sqlite3.Connection,
+        session_id: str,
+        state: _LineageResolutionState,
+    ) -> Any:
+        """Resolve *session_id* to its compression root on *conn*.
+
+        Returns the resolved root string, ``_UNRESOLVED`` for a proven
+        semantic unresolved outcome (missing row / dangling parent / positive
+        cycle), or ``_BUDGET_EXHAUSTED`` when the global work budget would be
+        exceeded by the next uncached lookup.
+
+        The loop ordering is correctness-significant at the B boundary:
+        memo lookup first, then traversal-local cycle proof, then the budget
+        check (only because another uncached lookup is now required), then the
+        one-node point lookup.
+        """
+        if not session_id:
+            return _UNRESOLVED
+        node = str(session_id)
+        path: List[str] = []
+        seen: set[str] = set()
+
+        while True:
+            cached = state.memo.get(node)
+            if cached is _UNRESOLVED:
+                state.memo_hits += 1
+                for visited in path:
+                    state.memo.setdefault(visited, _UNRESOLVED)
+                return _UNRESOLVED
+            if cached is not None:
+                # Memo hit: path-compress the visited prefix to the known root.
+                state.memo_hits += 1
+                for visited in path:
+                    state.memo.setdefault(visited, cached)
+                return cached
+
+            if node in seen:
+                # Positive cycle proven from the traversal-local seen-set
+                # with no further DB lookup (valid even at work == B).
+                state._memoize_unresolved(path, node)
+                return _UNRESOLVED
+            seen.add(node)
+
+            if state.work >= state.budget:
+                # Another uncached lookup is required and the budget is gone.
+                # This is operational uncertainty, NOT semantic unresolved, so
+                # the partial path is left out of the memo.
+                state.bound_hit = True
+                return _BUDGET_EXHAUSTED
+
+            row = conn.execute(_LINEAGE_NODE_SQL, (node,)).fetchone()
+            if row is None:
+                # The node row itself is missing: zero successful-fetch work
+                # for that absent row; the traversed path is semantically
+                # unresolved.
+                state._memoize_unresolved(path, node)
+                return _UNRESOLVED
+            state.work += 1
+
+            current = str(row["id"])
+            path.append(current)
+            parent_id = row["parent_session_id"]
+            if parent_id is None:
+                root = current
+                break
+            parent_id = str(parent_id)
+
+            if row["parent_exists"] is None:
+                # Dangling parent: malformed lineage, fail closed.
+                state._memoize_unresolved(path, node)
+                return _UNRESOLVED
+
+            config_valid, branched_from, delegate_from = _lineage_markers(
+                row["model_config"]
+            )
+            positive_edge = (
+                config_valid
+                and row["parent_end_reason"] == "compression"
+                and row["source"] != "tool"
+                and branched_from != parent_id
+                and delegate_from != parent_id
+            )
+            if not positive_edge:
+                root = current
+                break
+
+            node = parent_id
+
+        for visited in path:
+            state.memo.setdefault(visited, root)
+        return root
+
+    def resolve_compression_lineage(
+        self,
+        session_id: str,
+        *,
+        work_budget: int = _LINEAGE_WORK_BUDGET,
+    ) -> Optional[str]:
+        """Resolve *session_id* to its positive compression-continuation root.
+
+        Returns the root id, or ``None`` when the outcome is a proven semantic
+        unresolved (missing row / dangling parent / positive cycle) or the work
+        budget is exhausted.  Never falls back to generic parent ancestry; an
+        unresolved session is kept separate instead of broadening exclusion to
+        an unproven ancestor.
+        """
+        if not session_id:
+            return None
+        with self._read_ctx() as conn:
+            started_tx = not conn.in_transaction
+            if started_tx:
+                conn.execute("BEGIN")
+            try:
+                state = _LineageResolutionState(work_budget)
+                outcome = self._resolve_compression_lineage_on_conn(
+                    conn, str(session_id), state
+                )
+            finally:
+                if started_tx and conn.in_transaction:
+                    conn.rollback()
+        if outcome is _UNRESOLVED or outcome is _BUDGET_EXHAUSTED:
+            return None
+        return outcome
+
+    def get_first_message_id(self, session_id: str) -> Optional[int]:
+        """Return the first active message id for *session_id*, or None.
+
+        Lightweight bounded anchor lookup used by session-search title
+        discovery; avoids loading the whole transcript just to find one id.
+        """
+        if not session_id:
+            return None
+        with self._read_ctx() as conn:
+            row = conn.execute(
+                "SELECT id FROM messages WHERE session_id = ? AND active = 1 "
+                "ORDER BY id LIMIT 1",
+                (str(session_id),),
+            ).fetchone()
+        return row["id"] if row is not None else None
+
     def search_session_winners(
         self,
         query: str,
@@ -1732,20 +1972,36 @@ class SessionSearchMixin:
         current_lineage_root: Optional[str] = None,
         lineage_depth_cap: int = 64,
         request_id: str = None,
+        current_session_id: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Select discovery winners in SQLite without candidate hydration.
 
-        The candidate scan deliberately remains wider than the requested result
-        limit. SQLite first ranks up to ``candidate_limit`` lightweight FTS/LIKE
-        rows, resolves their parent chains with a recursive CTE, keeps one hit
-        per lineage, and only then applies ``result_limit``. The returned rows
-        contain no full message content and no candidate context.
+        The candidate scan deliberately remains wider than the requested
+        result limit.  SQLite first ranks up to ``candidate_limit``
+        lightweight FTS/LIKE rows and projects one ranked owner candidate per
+        distinct owning session (preserving the best-ranked message anchor).
+        A query-local Python resolver then walks each owner to its positive
+        compression-continuation root under one coherent logical read
+        snapshot, dedupes by root, and stops as soon as ``result_limit``
+        distinct roots survive (early-K).  The returned rows contain no full
+        message content and no candidate context; FTS snippets are computed
+        only for the final winners.
+
+        ``lineage_depth_cap`` is retained only for caller compatibility; #68
+        replaced depth as an identity/safety boundary with a traversal-local
+        cycle seen-set plus a global successful-row work budget.
         """
+        del lineage_depth_cap
         empty = {"winners": [], "stats": {
             "candidate_count": 0,
             "candidate_unique_sessions": 0,
             "lineage_count": 0,
             "winner_count": 0,
+            "lineage_work": 0,
+            "lineage_memo_hits": 0,
+            "lineage_memo_entries": 0,
+            "lineage_candidates_inspected": 0,
+            "lineage_bound_hit": False,
             "route": "none",
         }}
         if not self._fts_enabled or not query or not query.strip():
@@ -1756,7 +2012,6 @@ class SessionSearchMixin:
             return empty
         candidate_limit = max(1, min(int(candidate_limit), 1000))
         result_limit = max(0, min(int(result_limit), 100))
-        lineage_depth_cap = max(1, min(int(lineage_depth_cap), 256))
         role_filter = list(role_filter or ("user", "assistant"))
         exclude_sources = list(exclude_sources or ())
         source_filter = list(source_filter or ())
@@ -1891,7 +2146,9 @@ class SessionSearchMixin:
                     s.model,
                     s.started_at AS session_started,
                     0.0 AS fts_rank,
-                    {source_priority} AS source_priority
+                    {source_priority} AS source_priority,
+                    s.end_reason AS session_end_reason,
+                    m.compacted AS message_compacted
                 FROM messages m
                 JOIN sessions s ON s.id = m.session_id
                 WHERE {candidate_where}
@@ -1908,7 +2165,9 @@ class SessionSearchMixin:
                     s.model,
                     s.started_at AS session_started,
                     rank AS fts_rank,
-                    {source_priority} AS source_priority
+                    {source_priority} AS source_priority,
+                    s.end_reason AS session_end_reason,
+                    m.compacted AS message_compacted
                 FROM {candidate_from}
                 JOIN messages m ON m.id = {candidate_from}.rowid
                 JOIN sessions s ON s.id = m.session_id
@@ -1939,34 +2198,10 @@ class SessionSearchMixin:
                 ranked_candidates = ""
                 candidate_base = fts_candidate
 
-        exclusion_parts = []
-        exclusion_params: list = []
-        if excluded_lineage_roots:
-            exclusion_parts.append(
-                "lineage_root_id NOT IN "
-                f"({','.join('?' for _ in excluded_lineage_roots)})"
-            )
-            exclusion_params.extend(excluded_lineage_roots)
-        if current_lineage_root:
-            exclusion_parts.append("lineage_root_id != ?")
-            exclusion_params.append(current_lineage_root)
-        exclusion_sql = " AND ".join(exclusion_parts) or "1 = 1"
-
-        if route == "like":
-            final_snippet_expr = "ranked.snippet"
-            final_snippet_join = ""
-        else:
-            # FTS5's snippet() needs the MATCH expression on the same table
-            # cursor.  Keep the exact tokenized query used for candidate
-            # selection and apply it only after lineage winners are selected.
-            final_snippet_expr = (
-                f"snippet({candidate_from}, 0, '>>>', '<<<', '...', 40)"
-            )
-            final_snippet_join = (
-                f"JOIN {candidate_from} ON {candidate_from}.rowid = ranked.message_id "
-                f"AND {candidate_from} MATCH ?"
-            )
-
+        # Ranked distinct owner candidates: keep each owner's best-ranked raw
+        # hit (first by candidate_order) as its anchor.  Lineage resolution
+        # supplies only a dedupe/exclusion key and must never rewrite the
+        # match anchor to the root session.
         sql = f"""
             WITH
             {ranked_candidates}
@@ -1987,158 +2222,210 @@ class SessionSearchMixin:
                     COUNT(DISTINCT owning_session_id) AS candidate_unique_sessions
                 FROM candidate_hits
             ),
-            lineage_seeds AS (
-                SELECT DISTINCT owning_session_id AS seed_session_id
-                FROM candidate_hits
-            ),
-            lineage_walk(seed_session_id, session_id, parent_session_id, depth, path) AS (
-                SELECT
-                    seeds.seed_session_id,
-                    s.id,
-                    s.parent_session_id,
-                    0,
-                    printf('|%s|', s.id)
-                FROM lineage_seeds seeds
-                JOIN sessions s ON s.id = seeds.seed_session_id
-                UNION ALL
-                SELECT
-                    walk.seed_session_id,
-                    parent.id,
-                    parent.parent_session_id,
-                    walk.depth + 1,
-                    walk.path || parent.id || '|'
-                FROM lineage_walk walk
-                JOIN sessions parent ON parent.id = walk.parent_session_id
-                WHERE walk.depth < {lineage_depth_cap}
-                  AND instr(walk.path, printf('|%s|', parent.id)) = 0
-            ),
-            lineage_resolution AS (
-                SELECT
-                    seeds.seed_session_id,
-                    COALESCE(
-                        (
-                            SELECT walk.parent_session_id
-                            FROM lineage_walk walk
-                            WHERE walk.seed_session_id = seeds.seed_session_id
-                              AND walk.parent_session_id IS NOT NULL
-                              AND instr(
-                                  walk.path,
-                                  printf('|%s|', walk.parent_session_id)
-                              ) > 0
-                            ORDER BY walk.depth DESC
-                            LIMIT 1
-                        ),
-                        (
-                            SELECT walk.session_id
-                            FROM lineage_walk walk
-                            WHERE walk.seed_session_id = seeds.seed_session_id
-                            ORDER BY walk.depth DESC
-                            LIMIT 1
-                        ),
-                        seeds.seed_session_id
-                    ) AS lineage_root_id
-                FROM lineage_seeds seeds
-            ),
-            lineage_ranked AS (
-                SELECT
-                    hits.*,
-                    resolution.lineage_root_id,
-                    ROW_NUMBER() OVER (
-                        PARTITION BY resolution.lineage_root_id
-                        ORDER BY hits.source_priority, hits.candidate_order
-                    ) AS lineage_rank
-                FROM candidate_hits hits
-                JOIN lineage_resolution resolution
-                  ON resolution.seed_session_id = hits.owning_session_id
+            owner_candidates AS (
+                SELECT *
+                FROM (
+                    SELECT
+                        candidate_hits.*,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY owning_session_id
+                            ORDER BY candidate_order
+                        ) AS owner_rank
+                    FROM candidate_hits
+                )
+                WHERE owner_rank = 1
             )
             SELECT
-                ranked.message_id AS id,
-                ranked.owning_session_id AS session_id,
-                ranked.role,
-                {final_snippet_expr} AS snippet,
-                ranked.timestamp,
-                ranked.source,
-                ranked.model,
-                ranked.session_started,
-                ranked.lineage_root_id,
-                ranked.candidate_order,
-                ranked.source_priority,
+                owner_candidates.*,
                 stats.candidate_count,
                 stats.candidate_unique_sessions
-            FROM lineage_ranked ranked
-            {final_snippet_join}
+            FROM owner_candidates
             CROSS JOIN candidate_stats stats
-            WHERE ranked.lineage_rank = 1
-              AND {exclusion_sql}
-            ORDER BY ranked.source_priority, ranked.candidate_order
-            LIMIT ?
+            ORDER BY owner_candidates.source_priority, owner_candidates.candidate_order
         """
-        # The LIKE candidate SELECT has an extra snippet parameter before the
-        # WHERE values; candidate_limit/offset were already appended above for
-        # that route and must not be duplicated.
-        if route == "like":
-            sql_params = params + exclusion_params + [result_limit]
-        else:
-            # params[0] is the tokenized FTS query; candidate_limit/offset are
-            # already at the tail of params.  The final MATCH cursor needs the
-            # same query before the result LIMIT parameter.
-            sql_params = params + [params[0]] + exclusion_params + [result_limit]
 
         request_value = request_id or "-"
         started = time.perf_counter()
-        try:
-            with self._lock:
-                execute_started = time.perf_counter()
-                cursor = self._conn.execute(sql, sql_params)
-                rows = [dict(row) for row in cursor.fetchall()]
-                execute_ms = int((time.perf_counter() - execute_started) * 1000)
-        except sqlite3.OperationalError as exc:
-            # Match search_messages() behavior: malformed FTS input is a
-            # no-result search, not a tool-level failure. This also preserves
-            # title-only discovery when the title contains FTS punctuation.
-            logger.warning(
-                "SESSION_WINNERS query failed request_id=%s route=%s error=%s",
-                request_value,
-                route,
-                type(exc).__name__,
-            )
-            return {
-                "winners": [],
-                "stats": {
-                    "candidate_count": 0,
-                    "candidate_unique_sessions": 0,
-                    "lineage_count": 0,
-                    "winner_count": 0,
-                    "route": route,
-                },
-            }
+        state = _LineageResolutionState(_LINEAGE_WORK_BUDGET)
+        winners: List[Dict[str, Any]] = []
+        seen_roots: set[str] = set()
 
-        if rows:
-            stats = {
-                "candidate_count": int(rows[0].pop("candidate_count", 0)),
-                "candidate_unique_sessions": int(
-                    rows[0].pop("candidate_unique_sessions", 0)
-                ),
-            }
-        else:
-            stats = {"candidate_count": 0, "candidate_unique_sessions": 0}
-        winners = rows
-        stats.update({
-            "lineage_count": len({row["lineage_root_id"] for row in winners}),
-            "winner_count": len(winners),
-            "route": route,
-        })
+        with self._read_ctx() as conn:
+            started_tx = not conn.in_transaction
+            if started_tx:
+                conn.execute("BEGIN")
+            try:
+                try:
+                    execute_started = time.perf_counter()
+                    candidates = [
+                        dict(row) for row in conn.execute(sql, params).fetchall()
+                    ]
+                    execute_ms = int(
+                        (time.perf_counter() - execute_started) * 1000
+                    )
+                except sqlite3.OperationalError as exc:
+                    # Match search_messages() behavior: malformed FTS input is
+                    # a no-result search, not a tool-level failure.  This also
+                    # preserves title-only discovery when the title contains
+                    # FTS punctuation.
+                    logger.warning(
+                        "SESSION_WINNERS query failed request_id=%s route=%s error=%s",
+                        request_value,
+                        route,
+                        type(exc).__name__,
+                    )
+                    return {
+                        "winners": [],
+                        "stats": {
+                            "candidate_count": 0,
+                            "candidate_unique_sessions": 0,
+                            "lineage_count": 0,
+                            "winner_count": 0,
+                            "lineage_work": 0,
+                            "lineage_memo_hits": 0,
+                            "lineage_memo_entries": 0,
+                            "lineage_candidates_inspected": 0,
+                            "lineage_bound_hit": False,
+                            "route": route,
+                        },
+                    }
+
+                candidate_count = 0
+                candidate_unique_sessions = 0
+                for candidate in candidates:
+                    candidate.pop("owner_rank", None)
+                if candidates:
+                    candidate_count = int(
+                        candidates[0].pop("candidate_count", 0)
+                    )
+                    candidate_unique_sessions = int(
+                        candidates[0].pop("candidate_unique_sessions", 0)
+                    )
+
+                excluded_roots = {str(root) for root in excluded_lineage_roots}
+                current_root: Optional[str] = None
+                if current_session_id:
+                    # Re-resolve the raw current identity inside this winner
+                    # snapshot with the SAME memo/state so current-session
+                    # exclusion and candidate dedupe share one root meaning.
+                    outcome = self._resolve_compression_lineage_on_conn(
+                        conn, str(current_session_id), state
+                    )
+                    if outcome is _BUDGET_EXHAUSTED:
+                        state.bound_hit = True
+                    elif outcome is _UNRESOLVED:
+                        # Conservative: an unresolved current session excludes
+                        # only its own id rather than broadening exclusion to
+                        # an unproven ancestor.
+                        current_root = str(current_session_id)
+                    else:
+                        current_root = outcome
+                elif current_lineage_root:
+                    current_root = str(current_lineage_root)
+
+                for candidate in candidates:
+                    if len(winners) >= result_limit:
+                        break
+                    state.candidates_inspected += 1
+                    outcome = self._resolve_compression_lineage_on_conn(
+                        conn, str(candidate["owning_session_id"]), state
+                    )
+                    if outcome is _BUDGET_EXHAUSTED:
+                        state.bound_hit = True
+                        # Stop the entire ranked scan: the bound candidate may
+                        # have produced a higher-ranked new root than every
+                        # later candidate, so skipping it would violate ranking.
+                        break
+                    if outcome is _UNRESOLVED:
+                        continue
+                    root = outcome
+                    if root in excluded_roots:
+                        continue
+                    if current_root is not None and root == current_root:
+                        # Current-lineage exclusion: live content is already in
+                        # context, but compression-archived history (an owner
+                        # that itself ended by compression, or a compacted
+                        # matched row) is no longer in live context and stays
+                        # discoverable.
+                        is_ended_session = (
+                            candidate["session_end_reason"] == "compression"
+                        )
+                        is_compacted_hit = (
+                            int(candidate["message_compacted"] or 0) == 1
+                        )
+                        if not (is_ended_session or is_compacted_hit):
+                            continue
+                    if root in seen_roots:
+                        continue
+                    seen_roots.add(root)
+                    state.accepted_roots = len(seen_roots)
+                    winners.append({
+                        "id": candidate["message_id"],
+                        "session_id": candidate["owning_session_id"],
+                        "role": candidate["role"],
+                        "snippet": candidate["snippet"],
+                        "timestamp": candidate["timestamp"],
+                        "source": candidate["source"],
+                        "model": candidate["model"],
+                        "session_started": candidate["session_started"],
+                        "lineage_root_id": root,
+                        "candidate_order": candidate["candidate_order"],
+                        "source_priority": candidate["source_priority"],
+                    })
+
+                if route != "like" and winners:
+                    # FTS5 snippet() needs the MATCH expression on the same
+                    # table cursor.  Keep the exact tokenized query used for
+                    # candidate selection and apply it only after winners are
+                    # known so the candidate scan stays narrow.
+                    match_query = params[0]
+                    snippet_sql = (
+                        f"SELECT snippet({candidate_from}, 0, '>>>', '<<<', "
+                        f"'...', 40) AS snippet FROM {candidate_from} "
+                        f"WHERE rowid = ? AND {candidate_from} MATCH ?"
+                    )
+                    for winner in winners:
+                        snippet_row = conn.execute(
+                            snippet_sql, (winner["id"], match_query)
+                        ).fetchone()
+                        winner["snippet"] = (
+                            snippet_row["snippet"]
+                            if snippet_row is not None else None
+                        )
+
+                stats = {
+                    "candidate_count": candidate_count,
+                    "candidate_unique_sessions": candidate_unique_sessions,
+                    "lineage_count": len(seen_roots),
+                    "winner_count": len(winners),
+                    "lineage_work": state.work,
+                    "lineage_memo_hits": state.memo_hits,
+                    "lineage_memo_entries": len(state.memo),
+                    "lineage_candidates_inspected": state.candidates_inspected,
+                    "lineage_bound_hit": state.bound_hit,
+                    "route": route,
+                }
+            finally:
+                if started_tx and conn.in_transaction:
+                    conn.rollback()
+
         logger.info(
             "SESSION_WINNERS request_id=%s route=%s candidate_count=%d "
             "candidate_unique_sessions=%d lineage_count=%d winner_count=%d "
-            "query_ms=%d",
+            "lineage_work=%d lineage_memo_hits=%d lineage_candidates_inspected=%d "
+            "lineage_bound_hit=%s query_ms=%d execute_ms=%d",
             request_value,
             route,
             stats["candidate_count"],
             stats["candidate_unique_sessions"],
             stats["lineage_count"],
             stats["winner_count"],
+            stats["lineage_work"],
+            stats["lineage_memo_hits"],
+            stats["lineage_candidates_inspected"],
+            stats["lineage_bound_hit"],
             int((time.perf_counter() - started) * 1000),
+            execute_ms,
         )
         return {"winners": winners, "stats": stats}
 

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -2380,11 +2380,26 @@ class SessionSearchMixin:
                         or int(candidate["message_compacted"] or 0) == 1
                     )
 
+                # Ranked DISTINCT owner candidates (frozen #68 pipeline): group
+                # the bounded raw hits by owning session with each owner's hits
+                # in rank order, then resolve each owner exactly ONCE.  From the
+                # owner's ranked hits pick the first displayable anchor — under
+                # current exclusion a live hit is skipped so the next
+                # compacted-history hit of the same owner still surfaces
+                # (compacted history is never erased by owner dedupe).
+                owner_hits: Dict[str, List[Dict[str, Any]]] = {}
+                owner_order: List[str] = []
                 for candidate in candidates:
+                    owner = str(candidate["owning_session_id"])
+                    if owner not in owner_hits:
+                        owner_hits[owner] = []
+                        owner_order.append(owner)
+                    owner_hits[owner].append(candidate)
+
+                for owner in owner_order:
                     if len(winners) >= result_limit:
                         break
                     state.candidates_inspected += 1
-                    owner = str(candidate["owning_session_id"])
                     outcome = self._resolve_compression_lineage_on_conn(
                         conn, owner, state
                     )
@@ -2399,38 +2414,37 @@ class SessionSearchMixin:
                     root = outcome
                     if root in excluded_roots:
                         continue
-                    if current_root is not None and root == current_root:
-                        # Current compression-lineage exclusion: live content
-                        # is already in context, but compression-archived
-                        # history (a compression-ended owner or a compacted
-                        # matched row) is not in live context and stays
-                        # discoverable.  Per-hit: if THIS hit is rejected, a
-                        # later compacted hit of the same owner is still tried,
-                        # so compacted history is never erased by owner dedupe.
-                        if not _is_archived(candidate):
-                            continue
-                    if owner in current_ancestors:
-                        # A live-context generic ancestor of the current
-                        # session (delegation/branch parent) is still visible
-                        # to the agent; the same compression carve-out applies.
-                        if not _is_archived(candidate):
-                            continue
                     if root in seen_roots:
+                        continue
+                    in_current_context = (
+                        (current_root is not None and root == current_root)
+                        or owner in current_ancestors
+                    )
+                    anchor: Optional[Dict[str, Any]] = None
+                    for hit in owner_hits[owner]:
+                        if in_current_context and not _is_archived(hit):
+                            # live content of the current lineage stays hidden;
+                            # a later compacted-history hit of this owner is
+                            # still tried as the anchor.
+                            continue
+                        anchor = hit
+                        break
+                    if anchor is None:
                         continue
                     seen_roots.add(root)
                     state.accepted_roots = len(seen_roots)
                     winners.append({
-                        "id": candidate["message_id"],
+                        "id": anchor["message_id"],
                         "session_id": owner,
-                        "role": candidate["role"],
-                        "snippet": candidate["snippet"],
-                        "timestamp": candidate["timestamp"],
-                        "source": candidate["source"],
-                        "model": candidate["model"],
-                        "session_started": candidate["session_started"],
+                        "role": anchor["role"],
+                        "snippet": anchor["snippet"],
+                        "timestamp": anchor["timestamp"],
+                        "source": anchor["source"],
+                        "model": anchor["model"],
+                        "session_started": anchor["session_started"],
                         "lineage_root_id": root,
-                        "candidate_order": candidate["candidate_order"],
-                        "source_priority": candidate["source_priority"],
+                        "candidate_order": anchor["candidate_order"],
+                        "source_priority": anchor["source_priority"],
                     })
 
                 if route != "like" and winners:

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -1958,6 +1958,41 @@ class SessionSearchMixin:
             ).fetchone()
         return row["id"] if row is not None else None
 
+    def _current_lineage_ancestors_on_conn(
+        self,
+        conn: sqlite3.Connection,
+        session_id: str,
+        state: _LineageResolutionState,
+    ) -> set:
+        """Collect the current session's generic parent chain ids.
+
+        Current-session exclusion must also hide live-context ancestors that
+        are NOT compression lineage: a delegation/branch child is still
+        visible to its parent agent, so the parent's content stays excluded
+        even though the child is a distinct compression root (#68).  Walks
+        ``parent_session_id`` links on the same connection, counts successful
+        row fetches toward the work budget, and stops on a missing row, a
+        cycle, or budget exhaustion.
+        """
+        ancestors: set = set()
+        seen: set = set()
+        node = str(session_id) if session_id else None
+        while node and node not in seen:
+            seen.add(node)
+            if state.work >= state.budget:
+                state.bound_hit = True
+                break
+            row = conn.execute(_LINEAGE_NODE_SQL, (node,)).fetchone()
+            if row is None:
+                break
+            state.work += 1
+            parent = row["parent_session_id"]
+            if parent is None:
+                break
+            node = str(parent)
+            ancestors.add(node)
+        return ancestors
+
     def search_session_winners(
         self,
         query: str,
@@ -1973,19 +2008,24 @@ class SessionSearchMixin:
         lineage_depth_cap: int = 64,
         request_id: str = None,
         current_session_id: Optional[str] = None,
+        title_session_id: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Select discovery winners in SQLite without candidate hydration.
 
         The candidate scan deliberately remains wider than the requested
-        result limit.  SQLite first ranks up to ``candidate_limit``
-        lightweight FTS/LIKE rows and projects one ranked owner candidate per
-        distinct owning session (preserving the best-ranked message anchor).
-        A query-local Python resolver then walks each owner to its positive
-        compression-continuation root under one coherent logical read
-        snapshot, dedupes by root, and stops as soon as ``result_limit``
-        distinct roots survive (early-K).  The returned rows contain no full
-        message content and no candidate context; FTS snippets are computed
-        only for the final winners.
+        result limit.  SQLite ranks up to ``candidate_limit`` lightweight
+        FTS/LIKE rows; a query-local Python resolver then walks each hit's
+        owning session to its positive compression-continuation root under
+        one coherent logical read snapshot, keeps the first eligible hit per
+        owner as its anchor, dedupes by root, and stops as soon as
+        ``result_limit`` distinct roots survive (early-K).  The returned rows
+        contain no full message content and no candidate context; FTS
+        snippets are computed only for the final winners.
+
+        ``current_session_id`` / ``title_session_id`` are raw session ids
+        re-resolved inside this snapshot with the SAME memo/state used for
+        candidate roots, so current-session / exact-title exclusion and
+        winner dedupe share one root meaning and one work budget.
 
         ``lineage_depth_cap`` is retained only for caller compatibility; #68
         replaced depth as an identity/safety boundary with a traversal-local
@@ -2198,10 +2238,13 @@ class SessionSearchMixin:
                 ranked_candidates = ""
                 candidate_base = fts_candidate
 
-        # Ranked distinct owner candidates: keep each owner's best-ranked raw
-        # hit (first by candidate_order) as its anchor.  Lineage resolution
-        # supplies only a dedupe/exclusion key and must never rewrite the
-        # match anchor to the root session.
+        # The bounded ranked raw-hit set stays the upstream source.  Owner
+        # dedupe happens in Python AFTER per-hit current-visibility: the first
+        # eligible hit of an owner becomes its anchor, so a compacted-history
+        # hit is never erased by an earlier live hit that current-session
+        # exclusion rejects (#68 review finding).  Lineage resolution supplies
+        # only a dedupe/exclusion key and must never rewrite the match anchor
+        # to the root session.
         sql = f"""
             WITH
             {ranked_candidates}
@@ -2221,27 +2264,14 @@ class SessionSearchMixin:
                     COUNT(*) AS candidate_count,
                     COUNT(DISTINCT owning_session_id) AS candidate_unique_sessions
                 FROM candidate_hits
-            ),
-            owner_candidates AS (
-                SELECT *
-                FROM (
-                    SELECT
-                        candidate_hits.*,
-                        ROW_NUMBER() OVER (
-                            PARTITION BY owning_session_id
-                            ORDER BY candidate_order
-                        ) AS owner_rank
-                    FROM candidate_hits
-                )
-                WHERE owner_rank = 1
             )
             SELECT
-                owner_candidates.*,
+                candidate_hits.*,
                 stats.candidate_count,
                 stats.candidate_unique_sessions
-            FROM owner_candidates
+            FROM candidate_hits
             CROSS JOIN candidate_stats stats
-            ORDER BY owner_candidates.source_priority, owner_candidates.candidate_order
+            ORDER BY candidate_hits.source_priority, candidate_hits.candidate_order
         """
 
         request_value = request_id or "-"
@@ -2292,8 +2322,6 @@ class SessionSearchMixin:
 
                 candidate_count = 0
                 candidate_unique_sessions = 0
-                for candidate in candidates:
-                    candidate.pop("owner_rank", None)
                 if candidates:
                     candidate_count = int(
                         candidates[0].pop("candidate_count", 0)
@@ -2302,8 +2330,25 @@ class SessionSearchMixin:
                         candidates[0].pop("candidate_unique_sessions", 0)
                     )
 
+                # Exact-title exclusion re-resolves the raw title session id
+                # in-snapshot with the SAME memo/state/budget as candidates, so
+                # the title slot and the content lane share one root meaning
+                # (#68 review finding 1).  Full exclusion: the title already
+                # occupies its slot, its lineage members must not duplicate it.
                 excluded_roots = {str(root) for root in excluded_lineage_roots}
+                if title_session_id:
+                    outcome = self._resolve_compression_lineage_on_conn(
+                        conn, str(title_session_id), state
+                    )
+                    if outcome is _BUDGET_EXHAUSTED:
+                        state.bound_hit = True
+                    elif outcome is _UNRESOLVED:
+                        excluded_roots.add(str(title_session_id))
+                    else:
+                        excluded_roots.add(outcome)
+
                 current_root: Optional[str] = None
+                current_ancestors: set = set()
                 if current_session_id:
                     # Re-resolve the raw current identity inside this winner
                     # snapshot with the SAME memo/state so current-session
@@ -2320,15 +2365,28 @@ class SessionSearchMixin:
                         current_root = str(current_session_id)
                     else:
                         current_root = outcome
+                    current_ancestors = (
+                        self._current_lineage_ancestors_on_conn(
+                            conn, str(current_session_id), state
+                        )
+                    )
                 elif current_lineage_root:
                     current_root = str(current_lineage_root)
+
+                def _is_archived(candidate: Dict[str, Any]) -> bool:
+                    """True when a hit's content left the live context."""
+                    return (
+                        candidate["session_end_reason"] == "compression"
+                        or int(candidate["message_compacted"] or 0) == 1
+                    )
 
                 for candidate in candidates:
                     if len(winners) >= result_limit:
                         break
                     state.candidates_inspected += 1
+                    owner = str(candidate["owning_session_id"])
                     outcome = self._resolve_compression_lineage_on_conn(
-                        conn, str(candidate["owning_session_id"]), state
+                        conn, owner, state
                     )
                     if outcome is _BUDGET_EXHAUSTED:
                         state.bound_hit = True
@@ -2342,18 +2400,20 @@ class SessionSearchMixin:
                     if root in excluded_roots:
                         continue
                     if current_root is not None and root == current_root:
-                        # Current-lineage exclusion: live content is already in
-                        # context, but compression-archived history (an owner
-                        # that itself ended by compression, or a compacted
-                        # matched row) is no longer in live context and stays
-                        # discoverable.
-                        is_ended_session = (
-                            candidate["session_end_reason"] == "compression"
-                        )
-                        is_compacted_hit = (
-                            int(candidate["message_compacted"] or 0) == 1
-                        )
-                        if not (is_ended_session or is_compacted_hit):
+                        # Current compression-lineage exclusion: live content
+                        # is already in context, but compression-archived
+                        # history (a compression-ended owner or a compacted
+                        # matched row) is not in live context and stays
+                        # discoverable.  Per-hit: if THIS hit is rejected, a
+                        # later compacted hit of the same owner is still tried,
+                        # so compacted history is never erased by owner dedupe.
+                        if not _is_archived(candidate):
+                            continue
+                    if owner in current_ancestors:
+                        # A live-context generic ancestor of the current
+                        # session (delegation/branch parent) is still visible
+                        # to the agent; the same compression carve-out applies.
+                        if not _is_archived(candidate):
                             continue
                     if root in seen_roots:
                         continue
@@ -2361,7 +2421,7 @@ class SessionSearchMixin:
                     state.accepted_roots = len(seen_roots)
                     winners.append({
                         "id": candidate["message_id"],
-                        "session_id": candidate["owning_session_id"],
+                        "session_id": owner,
                         "role": candidate["role"],
                         "snippet": candidate["snippet"],
                         "timestamp": candidate["timestamp"],

--- a/tests/test_session_search_sql_winners.py
+++ b/tests/test_session_search_sql_winners.py
@@ -781,9 +781,11 @@ def _bulk_positive_chain(db, prefix, n, source="cli"):
     return [f"{base}-{i}" for i in range(n)]
 
 
-def test_sql_winners_title_session_excludes_lineage_in_snapshot(db):
-    # title_session_id is re-resolved inside the winner snapshot; its whole
-    # compression lineage is fully excluded from content winners.
+def test_sql_winners_title_root_excludes_compression_lineage(db):
+    # Exact-title exclusion arrives as the title's resolved root in
+    # excluded_lineage_roots (resolved by the caller with the same
+    # compression-lineage implementation): the whole compression lineage is
+    # fully excluded from content winners.
     _create(db, "troot", source="cli")
     _message(db, "troot", "needle title root")
     db.end_session("troot", "compression")
@@ -794,27 +796,11 @@ def test_sql_winners_title_session_excludes_lineage_in_snapshot(db):
 
     result = db.search_session_winners(
         "needle", role_filter=["user"], result_limit=5,
-        title_session_id="tchild",
+        excluded_lineage_roots=("troot",),
     )
+    # both the title root and its compression child are excluded
     assert [row["session_id"] for row in result["winners"]] == ["other"]
     assert result["stats"]["lineage_bound_hit"] is False
-
-
-def test_sql_winners_title_lineage_budget_shared_with_content(db, monkeypatch):
-    # title_session_id consumes the SAME budget as content candidates: a title
-    # lineage deeper than B honestly truncates instead of returning a duplicate
-    # lineage member with a stale/fabricated root.
-    monkeypatch.setattr("hermes_state_search._LINEAGE_WORK_BUDGET", 4)
-    ids = _chain_sessions(db, "tl", 6)
-    _message(db, ids[0], "needle deep title")
-    _link_positive_chain(db, ids)
-
-    result = db.search_session_winners(
-        "needle", role_filter=["user"], result_limit=5,
-        title_session_id=ids[0],
-    )
-    assert result["stats"]["lineage_bound_hit"] is True
-    assert result["winners"] == []
 
 
 def test_sql_winners_current_lineage_compacted_history_anchor_fallback(db):
@@ -1010,22 +996,3 @@ def test_sql_winners_displayable_anchor_ordering_not_live_rank(db):
     assert len(winners) == 1
     assert winners[0]["session_id"] == "other-s"
     assert winners[0]["id"] == other_id
-
-
-def test_sql_winners_title_is_current_session_unproven_contract(db, monkeypatch):
-    # When the exact-title session IS the current session on a >B chain, the
-    # snapshot cannot prove it is a distinct lineage: stats report no
-    # title/current root, bound-hit is set, and no fabricated winner survives.
-    monkeypatch.setattr("hermes_state_search._LINEAGE_WORK_BUDGET", 4)
-    ids = _chain_sessions(db, "self", 6)
-    _message(db, ids[0], "needle title content")
-    _link_positive_chain(db, ids)
-
-    result = db.search_session_winners(
-        "needle", role_filter=["user"], result_limit=5,
-        current_session_id=ids[0], title_session_id=ids[0],
-    )
-    assert result["winners"] == []
-    assert result["stats"]["lineage_bound_hit"] is True
-    assert result["stats"]["lineage_title_root"] is None
-    assert result["stats"]["lineage_current_root"] is None

--- a/tests/test_session_search_sql_winners.py
+++ b/tests/test_session_search_sql_winners.py
@@ -962,3 +962,22 @@ def test_sql_winners_concurrent_writer_does_not_tear_winner_snapshot(
     roots = {row["lineage_root_id"] for row in result["winners"]}
     assert roots == {"root", "other"}
     assert result["stats"]["lineage_bound_hit"] is False
+
+
+def test_sql_winners_candidates_inspected_counts_distinct_owners(db):
+    # The resolver consumes ranked DISTINCT owner candidates: two raw hits
+    # owned by one session count as ONE inspected candidate, even though the
+    # compacted-anchor fallback keeps all of the owner's hits available.
+    _create(db, "m1", source="cli")
+    _message(db, "m1", "needle first")
+    _message(db, "m1", "needle second")
+    _create(db, "m2", source="cli")
+    _message(db, "m2", "needle other")
+
+    result = db.search_session_winners(
+        "needle", role_filter=["user"], result_limit=5
+    )
+    assert result["stats"]["candidate_count"] == 3        # raw hits
+    assert result["stats"]["candidate_unique_sessions"] == 2  # distinct owners
+    assert result["stats"]["lineage_candidates_inspected"] == 2  # not 3
+    assert len(result["winners"]) == 2

--- a/tests/test_session_search_sql_winners.py
+++ b/tests/test_session_search_sql_winners.py
@@ -34,12 +34,12 @@ def test_sql_winners_keep_best_hit_per_lineage_and_preserve_candidate_scan(db):
     # compression, child not a tool session, no parent-bound marker)
     # collapses a child into its parent.  Generic parentage is NOT lineage.
     _create(db, "root", source="cli")
+    root_id = _message(db, "root", "needle root")
     db.end_session("root", "compression")
     _create(db, "child", source="cli", parent="root")
-    _create(db, "other", source="cli")
-    root_id = _message(db, "root", "needle root")
     child_id = _message(db, "child", "needle child")
     _message(db, "child", "needle child second")
+    _create(db, "other", source="cli")
     other_id = _message(db, "other", "needle other")
 
     result = db.search_session_winners(
@@ -69,11 +69,11 @@ def test_sql_winners_match_existing_python_oracle_for_all_temporal_orders(db):
     # the candidate ranking / owner dedupe / early-K integration, not a
     # second, generic-parent definition of lineage.
     _create(db, "oracle-root", source="telegram")
+    _message(db, "oracle-root", "oracle needle root")
     db.end_session("oracle-root", "compression")
     _create(db, "oracle-child", source="cron", parent="oracle-root")
     _create(db, "oracle-other", source="cli")
     _create(db, "oracle-cron", source="cron")
-    _message(db, "oracle-root", "oracle needle root")
     _message(db, "oracle-child", "oracle needle child")
     _message(db, "oracle-other", "oracle needle other")
     _message(db, "oracle-cron", "oracle needle cron")
@@ -148,26 +148,30 @@ def test_sql_winners_apply_source_priority_before_final_limit(db):
 
 
 def test_sql_winners_exclude_current_and_explicit_lineages(db):
-    # A compression continuation child shares the parent's root, so current
-    # exclusion removes the whole positive compression lineage.  An explicit
-    # excluded root is removed entirely.
-    _create(db, "current-root", source="cli")
-    db.end_session("current-root", "compression")
-    _create(db, "current-child", source="cli", parent="current-root")
+    # Production current-session exclusion (raw id re-resolved in-snapshot):
+    # the live continuation child is excluded, its compression-ended parent's
+    # archived content surfaces, and an explicit excluded root is removed.
+    _create(db, "s_parent", source="cli")
+    _message(db, "s_parent", "filter needle")
+    db.end_session("s_parent", "compression")
+    _create(db, "s_current", source="cli", parent="s_parent")
+    _message(db, "s_current", "filter needle")
     _create(db, "excluded", source="cli")
+    _message(db, "excluded", "filter needle")
     _create(db, "kept", source="cli")
-    for sid in ("current-root", "current-child", "excluded", "kept"):
-        _message(db, sid, "filter needle")
+    _message(db, "kept", "filter needle")
 
     result = db.search_session_winners(
         "filter",
         role_filter=["user"],
         result_limit=10,
         excluded_lineage_roots=("excluded",),
-        current_lineage_root="current-root",
+        current_session_id="s_current",
     )
 
-    assert [row["lineage_root_id"] for row in result["winners"]] == ["kept"]
+    by_root = {row["lineage_root_id"] for row in result["winners"]}
+    assert by_root == {"s_parent", "kept"}
+    assert all(row["session_id"] != "s_current" for row in result["winners"])
 
 
 def test_sql_winners_current_exclusion_generic_child_stays_distinct(db):
@@ -222,6 +226,9 @@ def test_sql_winners_handle_missing_parent_cycle_and_depth_cap(db):
     _set_parent(db, "missing-parent-child", "missing-parent")
     _create(db, "cycle-a", source="cli")
     _create(db, "cycle-b", source="cli")
+    for sid in ("cycle-a", "cycle-b"):
+        _message(db, sid, "edge needle")
+        db.end_session(sid, "compression")
     _set_parent(db, "cycle-a", "cycle-b")
     _set_parent(db, "cycle-b", "cycle-a")
     _create(db, "depth-root", source="cli")
@@ -229,8 +236,6 @@ def test_sql_winners_handle_missing_parent_cycle_and_depth_cap(db):
     _create(db, "depth-grandchild", source="cli", parent="depth-child")
     for sid in (
         "missing-parent-child",
-        "cycle-a",
-        "cycle-b",
         "depth-grandchild",
     ):
         _message(db, sid, "edge needle")
@@ -333,17 +338,23 @@ def test_sql_winners_cjk_trigram_route_when_available(db):
 # =====================================================================
 
 
-def _positive_chain(db, prefix, n, source="cli"):
-    """Create a positive compression lineage of *n* sessions.
-
-    ``ids[0]`` is the tip; ``ids[i]``'s parent ``ids[i+1]`` ended by
-    compression, so resolving ``ids[0]`` walks ``n`` successful uncached
-    point lookups to the root ``ids[n-1]``.
-    """
+def _chain_sessions(db, prefix, n, source="cli"):
+    """Create *n* sessions named ``<prefix>-<i>``; returns their ids."""
     ids = [f"{prefix}-{i}" for i in range(n)]
     for sid in ids:
         db.create_session(sid, source=source)
-    for i in range(n - 1):
+    return ids
+
+
+def _link_positive_chain(db, ids):
+    """Link ``ids[i] -> ids[i+1]`` with positive compression edges.
+
+    Each parent ends by ``'compression'``, so resolving ``ids[0]`` walks
+    ``len(ids)`` successful uncached point lookups to the root ``ids[-1]``.
+    Call AFTER appending messages (append_message refuses compression-ended
+    sessions).
+    """
+    for i in range(len(ids) - 1):
         child, parent = ids[i], ids[i + 1]
         db._conn.execute("PRAGMA foreign_keys = OFF")
         db._conn.execute(
@@ -356,15 +367,14 @@ def _positive_chain(db, prefix, n, source="cli"):
         )
         db._conn.commit()
         db._conn.execute("PRAGMA foreign_keys = ON")
-    return ids
 
 
 def test_sql_winners_branch_marker_to_parent_stays_distinct(db):
     _create(db, "broot", source="cli")
+    _message(db, "broot", "needle branch")
     db.end_session("broot", "compression")
     _create(db, "bchild", source="cli", parent="broot")
     _set_marker(db, "bchild", _branched_from="broot")
-    _message(db, "broot", "needle branch")
     _message(db, "bchild", "needle branch")
 
     winners = db.search_session_winners(
@@ -376,10 +386,10 @@ def test_sql_winners_branch_marker_to_parent_stays_distinct(db):
 
 def test_sql_winners_delegate_marker_to_parent_stays_distinct(db):
     _create(db, "droot", source="cli")
+    _message(db, "droot", "needle delegate")
     db.end_session("droot", "compression")
     _create(db, "dchild", source="cli", parent="droot")
     _set_marker(db, "dchild", _delegate_from="droot")
-    _message(db, "droot", "needle delegate")
     _message(db, "dchild", "needle delegate")
 
     winners = db.search_session_winners(
@@ -391,9 +401,9 @@ def test_sql_winners_delegate_marker_to_parent_stays_distinct(db):
 
 def test_sql_winners_tool_child_stays_distinct(db):
     _create(db, "troot", source="cli")
+    _message(db, "troot", "needle toolchild")
     db.end_session("troot", "compression")
     _create(db, "tchild", source="tool", parent="troot")
-    _message(db, "troot", "needle toolchild")
     _message(db, "tchild", "needle toolchild")
 
     winners = db.search_session_winners(
@@ -407,10 +417,10 @@ def test_sql_winners_foreign_marker_does_not_block_continuation(db):
     # A branch/delegate marker pointing somewhere OTHER than the parent is
     # foreign and must not disqualify a real compression-continuation edge.
     _create(db, "froot", source="cli")
+    _message(db, "froot", "needle foreign")
     db.end_session("froot", "compression")
     _create(db, "fchild", source="cli", parent="froot")
     _set_marker(db, "fchild", _branched_from="somewhere-else")
-    _message(db, "froot", "needle foreign")
     _message(db, "fchild", "needle foreign")
 
     winners = db.search_session_winners(
@@ -457,12 +467,15 @@ def test_sql_winners_early_k_stops_before_trailing_candidates(db):
 
 
 def test_sql_winners_missing_parent_fails_closed_and_memo_reuses(db):
-    _create(db, "m-child", source="cli")
-    _set_parent(db, "m-child", "m-missing")
-    _message(db, "m-child", "needle missing")
-    _create(db, "m-child2", source="cli")
-    _set_parent(db, "m-child2", "m-missing")
-    _message(db, "m-child2", "needle missing")
+    # A dangling parent fails closed (no fabricated root).  A descendant that
+    # enters the already-proven bad path reuses the unresolved memo at zero
+    # extra lookup cost.
+    _create(db, "m-bad", source="cli")
+    _message(db, "m-bad", "needle missing")
+    db.end_session("m-bad", "compression")
+    _set_parent(db, "m-bad", "m-missing")
+    _create(db, "m-bad-child", source="cli", parent="m-bad")
+    _message(db, "m-bad-child", "needle missing")
     _create(db, "m-ok", source="cli")
     _message(db, "m-ok", "needle missing")
 
@@ -471,22 +484,23 @@ def test_sql_winners_missing_parent_fails_closed_and_memo_reuses(db):
     )
     winners = result["winners"]
     assert [row["session_id"] for row in winners] == ["m-ok"]
-    # Both missing-parent children resolve to the SAME proven-unresolved
-    # outcome: the second reuses the memo at zero extra lookup work.
-    assert result["stats"]["lineage_work"] == 2  # m-child + m-ok
+    # m-bad resolves with one lookup; m-bad-child walks one lookup then hits
+    # m-bad's proven-unresolved memo at zero additional work.
+    assert result["stats"]["lineage_work"] == 3  # m-bad + m-bad-child + m-ok
+    assert result["stats"]["lineage_memo_hits"] >= 1
 
 
 def test_sql_winners_two_node_cycle_fails_closed(db):
     # Every edge must be a positive compression edge for the cycle to be
-    # reachable, so each member ends by compression.
+    # reachable, so each member ends by compression (messages first).
     _create(db, "c-a", source="cli")
     _create(db, "c-b", source="cli")
+    _message(db, "c-a", "needle cycle")
+    _message(db, "c-b", "needle cycle")
     db.end_session("c-a", "compression")
     db.end_session("c-b", "compression")
     _set_parent(db, "c-a", "c-b")
     _set_parent(db, "c-b", "c-a")
-    _message(db, "c-a", "needle cycle")
-    _message(db, "c-b", "needle cycle")
 
     winners = db.search_session_winners(
         "needle", role_filter=["user"], result_limit=10
@@ -499,12 +513,11 @@ def test_sql_winners_long_cycle_fails_closed(db):
     _create(db, "l-b", source="cli")
     _create(db, "l-c", source="cli")
     for sid in ("l-a", "l-b", "l-c"):
+        _message(db, sid, "needle cycle")
         db.end_session(sid, "compression")
     _set_parent(db, "l-a", "l-b")
     _set_parent(db, "l-b", "l-c")
     _set_parent(db, "l-c", "l-a")
-    for sid in ("l-a", "l-b", "l-c"):
-        _message(db, sid, "needle cycle")
 
     winners = db.search_session_winners(
         "needle", role_filter=["user"], result_limit=10
@@ -516,13 +529,14 @@ def test_sql_winners_tail_entering_cycle_fails_closed(db):
     _create(db, "t-a", source="cli")
     _create(db, "t-b", source="cli")
     _create(db, "t-c", source="cli")
+    _message(db, "t-a", "needle cycle")
+    _message(db, "t-b", "needle cycle")
+    _message(db, "t-c", "needle cycle")
     db.end_session("t-b", "compression")
     db.end_session("t-c", "compression")
     _set_parent(db, "t-a", "t-b")
     _set_parent(db, "t-b", "t-c")
     _set_parent(db, "t-c", "t-b")
-    for sid in ("t-a", "t-b", "t-c"):
-        _message(db, sid, "needle cycle")
 
     winners = db.search_session_winners(
         "needle", role_filter=["user"], result_limit=10
@@ -534,9 +548,10 @@ def test_sql_winners_positive_lineage_memo_reuse(db):
     # A 15-session positive lineage (observed depth-14/size-15 tail): every
     # candidate in the lineage resolves to the same root, and after the
     # first candidate all later ones are memo hits (zero extra lookups).
-    ids = _positive_chain(db, "memo", 15)
+    ids = _chain_sessions(db, "memo", 15)
     for sid in ids:
         _message(db, sid, "needle memo")
+    _link_positive_chain(db, ids)
 
     result = db.search_session_winners(
         "needle", role_filter=["user"], candidate_limit=100, result_limit=10
@@ -561,12 +576,11 @@ def test_sql_winners_cycle_at_work_bound_is_cycle_not_bound_hit(
     _create(db, "cb-b", source="cli")
     _create(db, "cb-c", source="cli")
     for sid in ("cb-a", "cb-b", "cb-c"):
+        _message(db, sid, "needle cycle")
         db.end_session(sid, "compression")
     _set_parent(db, "cb-a", "cb-b")
     _set_parent(db, "cb-b", "cb-c")
     _set_parent(db, "cb-c", "cb-a")
-    for sid in ("cb-a", "cb-b", "cb-c"):
-        _message(db, sid, "needle cycle")
 
     result = db.search_session_winners(
         "needle", role_filter=["user"], result_limit=10
@@ -581,7 +595,10 @@ def test_sql_winners_bound_hit_before_cycle_proof(db, monkeypatch):
     # is exhausted -> bound-hit, and the partial path must not be memoized as
     # unresolved (a fresh query resolves it).
     monkeypatch.setattr("hermes_state_search._LINEAGE_WORK_BUDGET", 4)
-    ids = _positive_chain(db, "bp", 5)
+    ids = _chain_sessions(db, "bp", 5)
+    for sid in ids:
+        _message(db, sid, "needle cycle")
+    _link_positive_chain(db, ids)
     # Close the 5-node chain into a cycle: bp-4 -> bp-0 (positive edge).
     db._conn.execute(
         "UPDATE sessions SET end_reason = 'compression' WHERE id = ?",
@@ -589,8 +606,6 @@ def test_sql_winners_bound_hit_before_cycle_proof(db, monkeypatch):
     )
     db._conn.commit()
     _set_parent(db, ids[-1], ids[0])
-    for sid in ids:
-        _message(db, sid, "needle cycle")
 
     result = db.search_session_winners(
         "needle", role_filter=["user"], result_limit=10
@@ -604,8 +619,9 @@ def test_sql_winners_root_resolved_exactly_at_work_bound(db, monkeypatch):
     # A root resolved on successful lookup number B succeeds (boundary is
     # inclusive of legitimate completed work).
     monkeypatch.setattr("hermes_state_search._LINEAGE_WORK_BUDGET", 5)
-    ids = _positive_chain(db, "b5", 5)
+    ids = _chain_sessions(db, "b5", 5)
     _message(db, ids[0], "needle exact")
+    _link_positive_chain(db, ids)
 
     result = db.search_session_winners(
         "needle", role_filter=["user"], result_limit=10
@@ -619,8 +635,9 @@ def test_sql_winners_lookup_beyond_work_bound_truncates(db, monkeypatch):
     # A resolution that requires lookup B+1 stops BEFORE that lookup,
     # flags bound-hit, and returns only already-proven safe winners.
     monkeypatch.setattr("hermes_state_search._LINEAGE_WORK_BUDGET", 5)
-    ids = _positive_chain(db, "b6", 6)
+    ids = _chain_sessions(db, "b6", 6)
     _message(db, ids[0], "needle trunc")
+    _link_positive_chain(db, ids)
     _create(db, "trunc-safe", source="cli")
     _message(db, "trunc-safe", "needle trunc")
 
@@ -635,8 +652,9 @@ def test_sql_winners_lookup_beyond_work_bound_truncates(db, monkeypatch):
 
 def test_sql_winners_bound_exhaustion_does_not_poison_memo(db, monkeypatch):
     monkeypatch.setattr("hermes_state_search._LINEAGE_WORK_BUDGET", 3)
-    ids = _positive_chain(db, "poison", 5)
+    ids = _chain_sessions(db, "poison", 5)
     _message(db, ids[0], "needle poison")
+    _link_positive_chain(db, ids)
 
     first = db.search_session_winners(
         "needle", role_filter=["user"], result_limit=10
@@ -655,9 +673,9 @@ def test_sql_winners_bound_exhaustion_does_not_poison_memo(db, monkeypatch):
 
 def test_sql_winners_stats_report_work_and_bound(db):
     _create(db, "st-root", source="cli")
+    _message(db, "st-root", "needle stats")
     db.end_session("st-root", "compression")
     _create(db, "st-child", source="cli", parent="st-root")
-    _message(db, "st-root", "needle stats")
     _message(db, "st-child", "needle stats")
     _create(db, "st-other", source="cli")
     _message(db, "st-other", "needle stats")

--- a/tests/test_session_search_sql_winners.py
+++ b/tests/test_session_search_sql_winners.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import time
 
 import pytest
 
@@ -29,7 +30,11 @@ def _create(db, session_id, source="cli", parent=None):
 
 
 def test_sql_winners_keep_best_hit_per_lineage_and_preserve_candidate_scan(db):
+    # Only a positive compression-continuation edge (parent ended by
+    # compression, child not a tool session, no parent-bound marker)
+    # collapses a child into its parent.  Generic parentage is NOT lineage.
     _create(db, "root", source="cli")
+    db.end_session("root", "compression")
     _create(db, "child", source="cli", parent="root")
     _create(db, "other", source="cli")
     root_id = _message(db, "root", "needle root")
@@ -58,7 +63,13 @@ def test_sql_winners_keep_best_hit_per_lineage_and_preserve_candidate_scan(db):
 
 
 def test_sql_winners_match_existing_python_oracle_for_all_temporal_orders(db):
+    # The Python oracle resolves lineage with the SAME positive
+    # compression-continuation semantics as the SQL winner seam (the
+    # public resolve_compression_lineage wrapper), so this test validates
+    # the candidate ranking / owner dedupe / early-K integration, not a
+    # second, generic-parent definition of lineage.
     _create(db, "oracle-root", source="telegram")
+    db.end_session("oracle-root", "compression")
     _create(db, "oracle-child", source="cron", parent="oracle-root")
     _create(db, "oracle-other", source="cli")
     _create(db, "oracle-cron", source="cron")
@@ -78,7 +89,9 @@ def test_sql_winners_match_existing_python_oracle_for_all_temporal_orders(db):
         expected = []
         seen = set()
         for hit in _order_for_recall(raw):
-            root = _resolve_to_parent(db, hit["session_id"])
+            root = db.resolve_compression_lineage(hit["session_id"])
+            if root is None:
+                continue
             if root in seen:
                 continue
             seen.add(root)
@@ -135,7 +148,11 @@ def test_sql_winners_apply_source_priority_before_final_limit(db):
 
 
 def test_sql_winners_exclude_current_and_explicit_lineages(db):
+    # A compression continuation child shares the parent's root, so current
+    # exclusion removes the whole positive compression lineage.  An explicit
+    # excluded root is removed entirely.
     _create(db, "current-root", source="cli")
+    db.end_session("current-root", "compression")
     _create(db, "current-child", source="cli", parent="current-root")
     _create(db, "excluded", source="cli")
     _create(db, "kept", source="cli")
@@ -153,28 +170,60 @@ def test_sql_winners_exclude_current_and_explicit_lineages(db):
     assert [row["lineage_root_id"] for row in result["winners"]] == ["kept"]
 
 
-def test_sql_winners_handle_missing_parent_cycle_and_depth_cap(db):
-    _create(db, "missing-parent-child", source="cli")
+def test_sql_winners_current_exclusion_generic_child_stays_distinct(db):
+    # Generic parentage is NOT compression lineage: a plain child of the
+    # current root keeps its own root and must not be swallowed by the
+    # current-session exclusion.
+    _create(db, "cur", source="cli")
+    _create(db, "gen-child", source="cli", parent="cur")
+    _message(db, "cur", "filter needle")
+    _message(db, "gen-child", "filter needle")
+
+    result = db.search_session_winners(
+        "filter",
+        role_filter=["user"],
+        result_limit=10,
+        current_lineage_root="cur",
+    )
+
+    assert [row["lineage_root_id"] for row in result["winners"]] == ["gen-child"]
+
+
+def _set_parent(db, session_id, parent):
+    """Point *session_id* at *parent* (FK-safe for dangling parents)."""
     db._conn.execute("PRAGMA foreign_keys = OFF")
     db._conn.execute(
         "UPDATE sessions SET parent_session_id = ? WHERE id = ?",
-        ("missing-parent", "missing-parent-child"),
+        (parent, session_id),
     )
     db._conn.commit()
     db._conn.execute("PRAGMA foreign_keys = ON")
+
+
+def _set_marker(db, session_id, **markers):
+    """Write branch/delegate markers into a session's model_config JSON."""
+    row = db._conn.execute(
+        "SELECT model_config FROM sessions WHERE id = ?", (session_id,)
+    ).fetchone()
+    cfg = json.loads(row["model_config"]) if row["model_config"] else {}
+    cfg.update(markers)
+    db._conn.execute(
+        "UPDATE sessions SET model_config = ? WHERE id = ?",
+        (json.dumps(cfg), session_id),
+    )
+    db._conn.commit()
+
+
+def test_sql_winners_handle_missing_parent_cycle_and_depth_cap(db):
+    # #68: missing parents and positive cycles fail closed (the candidate is
+    # dropped, never given a fabricated root), and generic parentage is not
+    # lineage identity, so lineage_depth_cap no longer participates.
+    _create(db, "missing-parent-child", source="cli")
+    _set_parent(db, "missing-parent-child", "missing-parent")
     _create(db, "cycle-a", source="cli")
     _create(db, "cycle-b", source="cli")
-    db._conn.execute("PRAGMA foreign_keys = OFF")
-    db._conn.execute(
-        "UPDATE sessions SET parent_session_id = ? WHERE id = ?",
-        ("cycle-b", "cycle-a"),
-    )
-    db._conn.execute(
-        "UPDATE sessions SET parent_session_id = ? WHERE id = ?",
-        ("cycle-a", "cycle-b"),
-    )
-    db._conn.commit()
-    db._conn.execute("PRAGMA foreign_keys = ON")
+    _set_parent(db, "cycle-a", "cycle-b")
+    _set_parent(db, "cycle-b", "cycle-a")
     _create(db, "depth-root", source="cli")
     _create(db, "depth-child", source="cli", parent="depth-root")
     _create(db, "depth-grandchild", source="cli", parent="depth-child")
@@ -194,9 +243,10 @@ def test_sql_winners_handle_missing_parent_cycle_and_depth_cap(db):
     )
     by_session = {row["session_id"]: row for row in result["winners"]}
 
-    assert by_session["missing-parent-child"]["lineage_root_id"] == "missing-parent-child"
-    assert by_session["cycle-a"]["lineage_root_id"] in {"cycle-a", "cycle-b"}
-    assert by_session["depth-grandchild"]["lineage_root_id"] == "depth-child"
+    assert "missing-parent-child" not in by_session
+    assert "cycle-a" not in by_session
+    assert "cycle-b" not in by_session
+    assert by_session["depth-grandchild"]["lineage_root_id"] == "depth-grandchild"
 
 
 def test_discovery_does_not_hydrate_candidate_context(db, caplog):
@@ -271,3 +321,406 @@ def test_sql_winners_cjk_trigram_route_when_available(db):
     assert result["stats"]["route"] == "trigram"
     assert result["winners"][0]["session_id"] == "cjk-trigram"
     assert "content" not in result["winners"][0]
+
+
+# =====================================================================
+# #68 compression-lineage resolver contract
+#
+# These tests exercise the observable winner-search contract: positive
+# compression-continuation roots, distinct-owner candidates with the best
+# preserved anchor, fail-closed missing/cycle semantics, query-local memo
+# reuse, early-K, and the B=2000 work budget.
+# =====================================================================
+
+
+def _positive_chain(db, prefix, n, source="cli"):
+    """Create a positive compression lineage of *n* sessions.
+
+    ``ids[0]`` is the tip; ``ids[i]``'s parent ``ids[i+1]`` ended by
+    compression, so resolving ``ids[0]`` walks ``n`` successful uncached
+    point lookups to the root ``ids[n-1]``.
+    """
+    ids = [f"{prefix}-{i}" for i in range(n)]
+    for sid in ids:
+        db.create_session(sid, source=source)
+    for i in range(n - 1):
+        child, parent = ids[i], ids[i + 1]
+        db._conn.execute("PRAGMA foreign_keys = OFF")
+        db._conn.execute(
+            "UPDATE sessions SET parent_session_id = ? WHERE id = ?",
+            (parent, child),
+        )
+        db._conn.execute(
+            "UPDATE sessions SET end_reason = 'compression' WHERE id = ?",
+            (parent,),
+        )
+        db._conn.commit()
+        db._conn.execute("PRAGMA foreign_keys = ON")
+    return ids
+
+
+def test_sql_winners_branch_marker_to_parent_stays_distinct(db):
+    _create(db, "broot", source="cli")
+    db.end_session("broot", "compression")
+    _create(db, "bchild", source="cli", parent="broot")
+    _set_marker(db, "bchild", _branched_from="broot")
+    _message(db, "broot", "needle branch")
+    _message(db, "bchild", "needle branch")
+
+    winners = db.search_session_winners(
+        "needle", role_filter=["user"], result_limit=5
+    )["winners"]
+    by_root = {row["lineage_root_id"] for row in winners}
+    assert {"broot", "bchild"} <= by_root
+
+
+def test_sql_winners_delegate_marker_to_parent_stays_distinct(db):
+    _create(db, "droot", source="cli")
+    db.end_session("droot", "compression")
+    _create(db, "dchild", source="cli", parent="droot")
+    _set_marker(db, "dchild", _delegate_from="droot")
+    _message(db, "droot", "needle delegate")
+    _message(db, "dchild", "needle delegate")
+
+    winners = db.search_session_winners(
+        "needle", role_filter=["user"], result_limit=5
+    )["winners"]
+    by_root = {row["lineage_root_id"] for row in winners}
+    assert {"droot", "dchild"} <= by_root
+
+
+def test_sql_winners_tool_child_stays_distinct(db):
+    _create(db, "troot", source="cli")
+    db.end_session("troot", "compression")
+    _create(db, "tchild", source="tool", parent="troot")
+    _message(db, "troot", "needle toolchild")
+    _message(db, "tchild", "needle toolchild")
+
+    winners = db.search_session_winners(
+        "needle", role_filter=["user"], result_limit=5
+    )["winners"]
+    by_root = {row["lineage_root_id"] for row in winners}
+    assert {"troot", "tchild"} <= by_root
+
+
+def test_sql_winners_foreign_marker_does_not_block_continuation(db):
+    # A branch/delegate marker pointing somewhere OTHER than the parent is
+    # foreign and must not disqualify a real compression-continuation edge.
+    _create(db, "froot", source="cli")
+    db.end_session("froot", "compression")
+    _create(db, "fchild", source="cli", parent="froot")
+    _set_marker(db, "fchild", _branched_from="somewhere-else")
+    _message(db, "froot", "needle foreign")
+    _message(db, "fchild", "needle foreign")
+
+    winners = db.search_session_winners(
+        "needle", role_filter=["user"], result_limit=5
+    )["winners"]
+    assert {row["lineage_root_id"] for row in winners} == {"froot"}
+    assert all(row["session_id"] != "fchild" for row in winners)
+
+
+def test_sql_winners_owner_dedupe_preserves_best_anchor(db):
+    # Two raw hits owned by one session become ONE owner candidate whose
+    # anchor is the earliest/highest-ranked raw hit (first by candidate
+    # order), not the last one.
+    _create(db, "multi", source="cli")
+    first_id = _message(db, "multi", "needle anchor first")
+    _message(db, "multi", "needle anchor second")
+    _create(db, "multi2", source="cli")
+    _message(db, "multi2", "needle anchor other")
+
+    winners = db.search_session_winners(
+        "needle", role_filter=["user"], result_limit=5
+    )["winners"]
+    multi_winner = next(w for w in winners if w["session_id"] == "multi")
+    assert multi_winner["id"] == first_id
+    assert len(winners) == 2
+
+
+def test_sql_winners_early_k_stops_before_trailing_candidates(db):
+    # K=1 must stop after the first accepted root even when a pathological
+    # candidate sits later in the ranked scan.
+    _create(db, "e1", source="cli")
+    _message(db, "e1", "early needle")
+    _create(db, "e2", source="cli")
+    db.end_session("e2", "compression")
+    for i in range(30):
+        _create(db, f"e2-child-{i}", source="cli", parent="e2")
+        _message(db, f"e2-child-{i}", "early needle")
+
+    result = db.search_session_winners(
+        "early", role_filter=["user"], candidate_limit=100, result_limit=1
+    )
+    assert len(result["winners"]) == 1
+    assert result["stats"]["lineage_candidates_inspected"] <= 2
+
+
+def test_sql_winners_missing_parent_fails_closed_and_memo_reuses(db):
+    _create(db, "m-child", source="cli")
+    _set_parent(db, "m-child", "m-missing")
+    _message(db, "m-child", "needle missing")
+    _create(db, "m-child2", source="cli")
+    _set_parent(db, "m-child2", "m-missing")
+    _message(db, "m-child2", "needle missing")
+    _create(db, "m-ok", source="cli")
+    _message(db, "m-ok", "needle missing")
+
+    result = db.search_session_winners(
+        "needle", role_filter=["user"], result_limit=10
+    )
+    winners = result["winners"]
+    assert [row["session_id"] for row in winners] == ["m-ok"]
+    # Both missing-parent children resolve to the SAME proven-unresolved
+    # outcome: the second reuses the memo at zero extra lookup work.
+    assert result["stats"]["lineage_work"] == 2  # m-child + m-ok
+
+
+def test_sql_winners_two_node_cycle_fails_closed(db):
+    # Every edge must be a positive compression edge for the cycle to be
+    # reachable, so each member ends by compression.
+    _create(db, "c-a", source="cli")
+    _create(db, "c-b", source="cli")
+    db.end_session("c-a", "compression")
+    db.end_session("c-b", "compression")
+    _set_parent(db, "c-a", "c-b")
+    _set_parent(db, "c-b", "c-a")
+    _message(db, "c-a", "needle cycle")
+    _message(db, "c-b", "needle cycle")
+
+    winners = db.search_session_winners(
+        "needle", role_filter=["user"], result_limit=10
+    )["winners"]
+    assert winners == []
+
+
+def test_sql_winners_long_cycle_fails_closed(db):
+    _create(db, "l-a", source="cli")
+    _create(db, "l-b", source="cli")
+    _create(db, "l-c", source="cli")
+    for sid in ("l-a", "l-b", "l-c"):
+        db.end_session(sid, "compression")
+    _set_parent(db, "l-a", "l-b")
+    _set_parent(db, "l-b", "l-c")
+    _set_parent(db, "l-c", "l-a")
+    for sid in ("l-a", "l-b", "l-c"):
+        _message(db, sid, "needle cycle")
+
+    winners = db.search_session_winners(
+        "needle", role_filter=["user"], result_limit=10
+    )["winners"]
+    assert winners == []
+
+
+def test_sql_winners_tail_entering_cycle_fails_closed(db):
+    _create(db, "t-a", source="cli")
+    _create(db, "t-b", source="cli")
+    _create(db, "t-c", source="cli")
+    db.end_session("t-b", "compression")
+    db.end_session("t-c", "compression")
+    _set_parent(db, "t-a", "t-b")
+    _set_parent(db, "t-b", "t-c")
+    _set_parent(db, "t-c", "t-b")
+    for sid in ("t-a", "t-b", "t-c"):
+        _message(db, sid, "needle cycle")
+
+    winners = db.search_session_winners(
+        "needle", role_filter=["user"], result_limit=10
+    )["winners"]
+    assert winners == []
+
+
+def test_sql_winners_positive_lineage_memo_reuse(db):
+    # A 15-session positive lineage (observed depth-14/size-15 tail): every
+    # candidate in the lineage resolves to the same root, and after the
+    # first candidate all later ones are memo hits (zero extra lookups).
+    ids = _positive_chain(db, "memo", 15)
+    for sid in ids:
+        _message(db, sid, "needle memo")
+
+    result = db.search_session_winners(
+        "needle", role_filter=["user"], candidate_limit=100, result_limit=10
+    )
+    winners = result["winners"]
+    assert len(winners) == 1
+    assert winners[0]["lineage_root_id"] == ids[-1]
+    # 15 distinct owner candidates: first walk is 15 lookups, the rest are
+    # memo hits -> 15 successful uncached row fetches total.
+    assert result["stats"]["lineage_work"] == 15
+    assert result["stats"]["lineage_memo_hits"] == 14
+    assert result["stats"]["lineage_memo_entries"] == 15
+
+
+def test_sql_winners_cycle_at_work_bound_is_cycle_not_bound_hit(
+    db, monkeypatch
+):
+    # Cycle becomes provable from the traversal-local seen-set when work has
+    # already consumed the whole budget: classify as cycle, NOT bound-hit.
+    monkeypatch.setattr("hermes_state_search._LINEAGE_WORK_BUDGET", 3)
+    _create(db, "cb-a", source="cli")
+    _create(db, "cb-b", source="cli")
+    _create(db, "cb-c", source="cli")
+    for sid in ("cb-a", "cb-b", "cb-c"):
+        db.end_session(sid, "compression")
+    _set_parent(db, "cb-a", "cb-b")
+    _set_parent(db, "cb-b", "cb-c")
+    _set_parent(db, "cb-c", "cb-a")
+    for sid in ("cb-a", "cb-b", "cb-c"):
+        _message(db, sid, "needle cycle")
+
+    result = db.search_session_winners(
+        "needle", role_filter=["user"], result_limit=10
+    )
+    assert result["winners"] == []
+    assert result["stats"]["lineage_bound_hit"] is False
+    assert result["stats"]["lineage_work"] == 3
+
+
+def test_sql_winners_bound_hit_before_cycle_proof(db, monkeypatch):
+    # Proving the cycle would need one MORE uncached lookup after the budget
+    # is exhausted -> bound-hit, and the partial path must not be memoized as
+    # unresolved (a fresh query resolves it).
+    monkeypatch.setattr("hermes_state_search._LINEAGE_WORK_BUDGET", 4)
+    ids = _positive_chain(db, "bp", 5)
+    # Close the 5-node chain into a cycle: bp-4 -> bp-0 (positive edge).
+    db._conn.execute(
+        "UPDATE sessions SET end_reason = 'compression' WHERE id = ?",
+        (ids[0],),
+    )
+    db._conn.commit()
+    _set_parent(db, ids[-1], ids[0])
+    for sid in ids:
+        _message(db, sid, "needle cycle")
+
+    result = db.search_session_winners(
+        "needle", role_filter=["user"], result_limit=10
+    )
+    assert result["winners"] == []
+    assert result["stats"]["lineage_bound_hit"] is True
+    assert result["stats"]["lineage_work"] == 4
+
+
+def test_sql_winners_root_resolved_exactly_at_work_bound(db, monkeypatch):
+    # A root resolved on successful lookup number B succeeds (boundary is
+    # inclusive of legitimate completed work).
+    monkeypatch.setattr("hermes_state_search._LINEAGE_WORK_BUDGET", 5)
+    ids = _positive_chain(db, "b5", 5)
+    _message(db, ids[0], "needle exact")
+
+    result = db.search_session_winners(
+        "needle", role_filter=["user"], result_limit=10
+    )
+    assert result["winners"][0]["lineage_root_id"] == ids[-1]
+    assert result["stats"]["lineage_work"] == 5
+    assert result["stats"]["lineage_bound_hit"] is False
+
+
+def test_sql_winners_lookup_beyond_work_bound_truncates(db, monkeypatch):
+    # A resolution that requires lookup B+1 stops BEFORE that lookup,
+    # flags bound-hit, and returns only already-proven safe winners.
+    monkeypatch.setattr("hermes_state_search._LINEAGE_WORK_BUDGET", 5)
+    ids = _positive_chain(db, "b6", 6)
+    _message(db, ids[0], "needle trunc")
+    _create(db, "trunc-safe", source="cli")
+    _message(db, "trunc-safe", "needle trunc")
+
+    result = db.search_session_winners(
+        "needle", role_filter=["user"], result_limit=10
+    )
+    assert result["stats"]["lineage_bound_hit"] is True
+    # The bound is reached on the first (higher-ranked) candidate, so the
+    # scan stops rather than accepting the later safe candidate.
+    assert result["winners"] == []
+
+
+def test_sql_winners_bound_exhaustion_does_not_poison_memo(db, monkeypatch):
+    monkeypatch.setattr("hermes_state_search._LINEAGE_WORK_BUDGET", 3)
+    ids = _positive_chain(db, "poison", 5)
+    _message(db, ids[0], "needle poison")
+
+    first = db.search_session_winners(
+        "needle", role_filter=["user"], result_limit=10
+    )
+    assert first["stats"]["lineage_bound_hit"] is True
+
+    # A fresh query (new memo + restored budget) resolves the same chain
+    # normally, proving the exhausted partial path was never memoized.
+    monkeypatch.setattr("hermes_state_search._LINEAGE_WORK_BUDGET", 2000)
+    second = db.search_session_winners(
+        "needle", role_filter=["user"], result_limit=10
+    )
+    assert second["stats"]["lineage_bound_hit"] is False
+    assert second["winners"][0]["lineage_root_id"] == ids[-1]
+
+
+def test_sql_winners_stats_report_work_and_bound(db):
+    _create(db, "st-root", source="cli")
+    db.end_session("st-root", "compression")
+    _create(db, "st-child", source="cli", parent="st-root")
+    _message(db, "st-root", "needle stats")
+    _message(db, "st-child", "needle stats")
+    _create(db, "st-other", source="cli")
+    _message(db, "st-other", "needle stats")
+
+    result = db.search_session_winners(
+        "needle", role_filter=["user"], result_limit=5
+    )
+    stats = result["stats"]
+    assert stats["candidate_count"] == 3
+    assert stats["candidate_unique_sessions"] == 3
+    assert stats["lineage_count"] == 2
+    assert stats["winner_count"] == 2
+    assert stats["lineage_work"] >= 1
+    assert stats["lineage_candidates_inspected"] == 3
+    assert stats["lineage_bound_hit"] is False
+
+
+def test_sql_winners_k1_k3_k10_early_stop(db):
+    _create(db, "k0", source="cli")
+    db.end_session("k0", "compression")
+    for i in range(12):
+        _create(db, f"k0-child-{i}", source="cli", parent="k0")
+        _message(db, f"k0-child-{i}", "needle k")
+    for i in range(1, 15):
+        _create(db, f"k{i}", source="cli")
+        _message(db, f"k{i}", "needle k")
+
+    for k in (1, 3, 10):
+        result = db.search_session_winners(
+            "needle", role_filter=["user"], candidate_limit=100, result_limit=k
+        )
+        assert len(result["winners"]) == k
+        assert result["stats"]["lineage_bound_hit"] is False
+
+
+def test_sql_winners_long_acyclic_chain_cut_by_budget_not_depth_cap(
+    db, monkeypatch,
+):
+    # A long acyclic chain is cut by the work budget, not by any semantic
+    # depth cap.  The resolver is iterative + memoized, so a chain longer
+    # than B simply stops at B successful lookups.  (Fixture stays small by
+    # monkeypatching B; the default 2000 is just that same constant.)
+    monkeypatch.setattr("hermes_state_search._LINEAGE_WORK_BUDGET", 40)
+    n = 50
+    now = time.time()
+    base = "path"
+    db._conn.executemany(
+        "INSERT INTO sessions (id, source, started_at) VALUES (?, ?, ?)",
+        [(f"{base}-{i}", "cli", now) for i in range(n)],
+    )
+    for i in range(n - 1):
+        child, parent = f"{base}-{i}", f"{base}-{i + 1}"
+        db._conn.execute(
+            "UPDATE sessions SET parent_session_id = ?, "
+            "end_reason = 'compression' WHERE id = ?",
+            (parent, child),
+        )
+    db._conn.commit()
+    _message(db, f"{base}-0", "needle path")
+
+    result = db.search_session_winners(
+        "needle", role_filter=["user"], result_limit=10
+    )
+    assert result["stats"]["lineage_bound_hit"] is True
+    assert result["stats"]["lineage_work"] == 40
+    assert result["winners"] == []

--- a/tests/test_session_search_sql_winners.py
+++ b/tests/test_session_search_sql_winners.py
@@ -7,7 +7,7 @@ import time
 import pytest
 
 from hermes_state import SessionDB
-from tools.session_search_tool import _order_for_recall, _resolve_to_parent, session_search
+from tools.session_search_tool import _order_for_recall, session_search
 
 
 @pytest.fixture

--- a/tests/test_session_search_sql_winners.py
+++ b/tests/test_session_search_sql_winners.py
@@ -981,3 +981,51 @@ def test_sql_winners_candidates_inspected_counts_distinct_owners(db):
     assert result["stats"]["candidate_unique_sessions"] == 2  # distinct owners
     assert result["stats"]["lineage_candidates_inspected"] == 2  # not 3
     assert len(result["winners"]) == 2
+
+
+def test_sql_winners_displayable_anchor_ordering_not_live_rank(db):
+    # Winner ordering follows the rank of each owner's FIRST DISPLAYABLE
+    # anchor.  With K=1 and 'cur-live(#1) -> other(#2) -> cur-compacted(#3)',
+    # the higher-ranked displayable 'other' must win — cur's live #1 hit is
+    # current-excluded and must NOT let cur's later compacted anchor jump
+    # ahead of a genuinely higher-ranked winner.
+    db.create_session("cur", source="cli")
+    compacted_id = _message(db, "cur", "old compacted needle")
+    db.archive_and_compact("cur", [{"role": "assistant", "content": "summary"}])
+    live_id = _message(db, "cur", "new live needle")
+    _create(db, "other-s", source="cli")
+    other_id = _message(db, "other-s", "needle other")
+    now = time.time()
+    # newest-first: cur-live(#1) -> other(#2) -> cur-compacted(#3)
+    db._conn.execute("UPDATE messages SET timestamp = ? WHERE id = ?", (now - 100, live_id))
+    db._conn.execute("UPDATE messages SET timestamp = ? WHERE id = ?", (now - 200, other_id))
+    db._conn.execute("UPDATE messages SET timestamp = ? WHERE id = ?", (now - 300, compacted_id))
+    db._conn.commit()
+
+    result = db.search_session_winners(
+        "needle", role_filter=["user"], result_limit=1, sort="newest",
+        current_session_id="cur",
+    )
+    winners = result["winners"]
+    assert len(winners) == 1
+    assert winners[0]["session_id"] == "other-s"
+    assert winners[0]["id"] == other_id
+
+
+def test_sql_winners_title_is_current_session_unproven_contract(db, monkeypatch):
+    # When the exact-title session IS the current session on a >B chain, the
+    # snapshot cannot prove it is a distinct lineage: stats report no
+    # title/current root, bound-hit is set, and no fabricated winner survives.
+    monkeypatch.setattr("hermes_state_search._LINEAGE_WORK_BUDGET", 4)
+    ids = _chain_sessions(db, "self", 6)
+    _message(db, ids[0], "needle title content")
+    _link_positive_chain(db, ids)
+
+    result = db.search_session_winners(
+        "needle", role_filter=["user"], result_limit=5,
+        current_session_id=ids[0], title_session_id=ids[0],
+    )
+    assert result["winners"] == []
+    assert result["stats"]["lineage_bound_hit"] is True
+    assert result["stats"]["lineage_title_root"] is None
+    assert result["stats"]["lineage_current_root"] is None

--- a/tests/test_session_search_sql_winners.py
+++ b/tests/test_session_search_sql_winners.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import threading
 import time
 
 import pytest
@@ -742,3 +743,222 @@ def test_sql_winners_long_acyclic_chain_cut_by_budget_not_depth_cap(
     assert result["stats"]["lineage_bound_hit"] is True
     assert result["stats"]["lineage_work"] == 40
     assert result["winners"] == []
+
+
+# =====================================================================
+# #68 review round: title in-snapshot parity, compacted-history anchor
+# fallback, and the mandated acceptance matrix (real B boundaries,
+# concurrency snapshot, 10k chain, internal-K stress).
+# =====================================================================
+
+
+def _bulk_positive_chain(db, prefix, n, source="cli"):
+    """Bulk-build a positive compression chain of *n* sessions.
+
+    SessionDB's writer connection is autocommit, so a per-row insert would
+    fsync every row (~40x slower).  Wrapping the inserts + parent links in
+    one explicit BEGIN/COMMIT keeps the fixture fast enough for real
+    B=2000-boundary chains.
+    """
+    base = prefix
+    now = time.time()
+    db._conn.execute("BEGIN")
+    db._conn.executemany(
+        "INSERT INTO sessions (id, source, started_at) VALUES (?, ?, ?)",
+        [(f"{base}-{i}", source, now) for i in range(n)],
+    )
+    for i in range(n - 1):
+        child, parent = f"{base}-{i}", f"{base}-{i + 1}"
+        db._conn.execute(
+            "UPDATE sessions SET parent_session_id = ? WHERE id = ?",
+            (parent, child),
+        )
+        db._conn.execute(
+            "UPDATE sessions SET end_reason = 'compression' WHERE id = ?",
+            (parent,),
+        )
+    db._conn.execute("COMMIT")
+    return [f"{base}-{i}" for i in range(n)]
+
+
+def test_sql_winners_title_session_excludes_lineage_in_snapshot(db):
+    # title_session_id is re-resolved inside the winner snapshot; its whole
+    # compression lineage is fully excluded from content winners.
+    _create(db, "troot", source="cli")
+    _message(db, "troot", "needle title root")
+    db.end_session("troot", "compression")
+    _create(db, "tchild", source="cli", parent="troot")
+    _message(db, "tchild", "needle title child")
+    _create(db, "other", source="cli")
+    _message(db, "other", "needle title other")
+
+    result = db.search_session_winners(
+        "needle", role_filter=["user"], result_limit=5,
+        title_session_id="tchild",
+    )
+    assert [row["session_id"] for row in result["winners"]] == ["other"]
+    assert result["stats"]["lineage_bound_hit"] is False
+
+
+def test_sql_winners_title_lineage_budget_shared_with_content(db, monkeypatch):
+    # title_session_id consumes the SAME budget as content candidates: a title
+    # lineage deeper than B honestly truncates instead of returning a duplicate
+    # lineage member with a stale/fabricated root.
+    monkeypatch.setattr("hermes_state_search._LINEAGE_WORK_BUDGET", 4)
+    ids = _chain_sessions(db, "tl", 6)
+    _message(db, ids[0], "needle deep title")
+    _link_positive_chain(db, ids)
+
+    result = db.search_session_winners(
+        "needle", role_filter=["user"], result_limit=5,
+        title_session_id=ids[0],
+    )
+    assert result["stats"]["lineage_bound_hit"] is True
+    assert result["winners"] == []
+
+
+def test_sql_winners_current_lineage_compacted_history_anchor_fallback(db):
+    # In the current lineage, the NEWEST hit is live (current-excluded), but
+    # the older compacted hit of the same owner must still surface AS THE
+    # ANCHOR — per-owner dedupe must never erase compacted history.
+    db.create_session("cur", source="cli")
+    compacted_id = _message(db, "cur", "old compacted needle")
+    db.archive_and_compact("cur", [{"role": "assistant", "content": "summary"}])
+    _message(db, "cur", "new live needle")
+
+    result = db.search_session_winners(
+        "needle", role_filter=["user", "assistant"], result_limit=5,
+        sort="newest", current_session_id="cur",
+    )
+    winners = result["winners"]
+    assert len(winners) == 1
+    assert winners[0]["session_id"] == "cur"
+    assert winners[0]["id"] == compacted_id
+
+
+def test_sql_winners_default_budget_1999_succeeds(db):
+    # A root resolved on successful lookup 1999 succeeds with the default B.
+    ids = _bulk_positive_chain(db, "b1999", 1999)
+    _message(db, ids[0], "needle 1999")
+
+    result = db.search_session_winners(
+        "needle", role_filter=["user"], result_limit=5
+    )
+    assert result["winners"][0]["lineage_root_id"] == ids[-1]
+    assert result["stats"]["lineage_work"] == 1999
+    assert result["stats"]["lineage_bound_hit"] is False
+
+
+def test_sql_winners_default_budget_2000_succeeds(db):
+    # A root resolved on successful lookup 2000 (the boundary) succeeds.
+    ids = _bulk_positive_chain(db, "b2000", 2000)
+    _message(db, ids[0], "needle 2000")
+
+    result = db.search_session_winners(
+        "needle", role_filter=["user"], result_limit=5
+    )
+    assert result["winners"][0]["lineage_root_id"] == ids[-1]
+    assert result["stats"]["lineage_work"] == 2000
+    assert result["stats"]["lineage_bound_hit"] is False
+
+
+def test_sql_winners_default_budget_2001_truncates(db):
+    # A resolution that would need lookup 2001 stops BEFORE it with the
+    # default B, flags bound-hit, and returns no fabricated winner.
+    ids = _bulk_positive_chain(db, "b2001", 2001)
+    _message(db, ids[0], "needle 2001")
+
+    result = db.search_session_winners(
+        "needle", role_filter=["user"], result_limit=5
+    )
+    assert result["stats"]["lineage_bound_hit"] is True
+    assert result["winners"] == []
+
+
+def test_sql_winners_10k_acyclic_chain_cut_by_default_budget(db):
+    # A real 10k-node acyclic chain is cut by the default B=2000 work budget,
+    # not by any semantic depth cap.
+    ids = _bulk_positive_chain(db, "path10k", 10000)
+    _message(db, ids[0], "needle path")
+
+    result = db.search_session_winners(
+        "needle", role_filter=["user"], result_limit=5
+    )
+    assert result["stats"]["lineage_bound_hit"] is True
+    assert result["stats"]["lineage_work"] == 2000
+    assert result["winners"] == []
+
+
+def test_sql_winners_internal_k_stress(db):
+    # Larger internal K (beyond the public K<=10 tool path) is a defensive DB
+    # contract, not the normal product path.
+    for i in range(60):
+        _create(db, f"ik-{i}", source="cli")
+        _message(db, f"ik-{i}", "needle internal k")
+
+    result = db.search_session_winners(
+        "needle", role_filter=["user"], candidate_limit=200, result_limit=60
+    )
+    assert len(result["winners"]) == 60
+    assert result["stats"]["lineage_bound_hit"] is False
+
+
+def test_sql_winners_lineage_lookups_in_one_explicit_read_transaction(
+    db, monkeypatch,
+):
+    # Candidate selection plus every lineage point lookup for one logical
+    # search must run inside ONE explicit read transaction (one coherent
+    # logical snapshot), not separate autocommit statements.
+    original = SessionDB._resolve_compression_lineage_on_conn
+    observed = []
+
+    def spy(self, conn, session_id, state):
+        observed.append(conn.in_transaction)
+        return original(self, conn, session_id, state)
+
+    monkeypatch.setattr(SessionDB, "_resolve_compression_lineage_on_conn", spy)
+    _create(db, "root", source="cli")
+    _message(db, "root", "snap needle")
+    db.end_session("root", "compression")
+    _create(db, "child", source="cli", parent="root")
+    _message(db, "child", "snap needle")
+
+    db.search_session_winners("snap", role_filter=["user"], result_limit=5)
+
+    assert observed
+    assert all(observed)
+
+
+def test_sql_winners_concurrent_writer_does_not_tear_winner_snapshot(
+    db, monkeypatch,
+):
+    # A writer hammering the locked write path during a winner search cannot
+    # interleave into the winner snapshot: the search observes a coherent
+    # root set from one logical moment.
+    original = SessionDB._resolve_compression_lineage_on_conn
+
+    def slow(self, conn, session_id, state):
+        time.sleep(0.02)
+        return original(self, conn, session_id, state)
+
+    monkeypatch.setattr(SessionDB, "_resolve_compression_lineage_on_conn", slow)
+    _create(db, "root", source="cli")
+    _message(db, "root", "snap needle")
+    db.end_session("root", "compression")
+    _create(db, "child", source="cli", parent="root")
+    _message(db, "child", "snap needle")
+    _create(db, "other", source="cli")
+    _message(db, "other", "snap needle")
+
+    def writer():
+        for i in range(10):
+            db.create_session(f"cw-{i}", source="cli")
+
+    t = threading.Thread(target=writer)
+    t.start()
+    result = db.search_session_winners("snap", role_filter=["user"], result_limit=5)
+    t.join()
+
+    roots = {row["lineage_root_id"] for row in result["winners"]}
+    assert roots == {"root", "other"}
+    assert result["stats"]["lineage_bound_hit"] is False

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -987,12 +987,20 @@ class TestCompressionRootToolParity:
         assert result.get("truncated") is True
         assert "warning" in result
 
-    def test_title_equal_to_current_session_excluded_and_truncated(self, db, monkeypatch):
-        """When the exact-title session IS the current session, its title is
-        excluded by the current-lineage guard (a session never surfaces as its
-        own result) — NOT by any proof gate.  The winner phase still runs and
-        honestly surfaces B exhaustion on the >B current chain via truncation
-        (#68 review round-5)."""
+    def test_title_equal_to_current_session_excluded_when_same_lineage(self, db, monkeypatch):
+        """The exact-title session IS the current session on a compression
+        chain: the title is excluded by the existing current-lineage guard (a
+        session never surfaces as its own result), and the winner phase still
+        runs and surfaces its own bound exhaustion via truncation.
+
+        Scope note (#68 review round-5): ``resolve_compression_lineage``'
+        default ``work_budget`` is captured at def time, so the B=4
+        monkeypatch below affects ONLY the winner phase (which reads the
+        module global dynamically).  The tool-side resolver here runs at the
+        real B=2000 and resolves the chain normally — this test does NOT
+        exercise "tool-side resolver itself B-hits on a >B chain".  That
+        edge is deliberately out of scope: no proof protocol is re-added to
+        cover it."""
         import hermes_state_search
         monkeypatch.setattr(hermes_state_search, "_LINEAGE_WORK_BUDGET", 4)
         for i in range(6):
@@ -1020,8 +1028,8 @@ class TestCompressionRootToolParity:
         ))
 
         assert result["success"] is True
-        # current session is never its own result; the >B current chain is
-        # honestly truncated
+        # current session is never its own result; the winner phase's >B
+        # current chain is honestly truncated
         assert result["count"] == 0
         assert result["results"] == []
         assert result.get("truncated") is True

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -921,9 +921,11 @@ class TestCompressionRootToolParity:
         assert hit["match_message_id"] != live_id
 
     def test_title_and_content_share_compression_root_in_snapshot(self, db):
-        """Exact-title exclusion is re-resolved in the winner snapshot: a
-        content hit in the title's compression lineage is excluded even though
-        its own session id differs from the title session id."""
+        """Exact-title exclusion resolves the title's compression lineage
+        (same implementation as the winner phase) and excludes it from the
+        content lane: a content hit in the title's compression lineage is
+        excluded even though its own session id differs from the title session
+        id (#68 review round-5)."""
         db.create_session("t_parent", source="cli")
         db.set_session_title("t_parent", "needle-title")
         db.append_message("t_parent", role="user", content="parent filler")
@@ -943,11 +945,11 @@ class TestCompressionRootToolParity:
         assert result.get("truncated") is False
 
     def test_title_only_limit_one_surfaces_bound_exhaustion(self, db, monkeypatch):
-        """A title-only K=1 search must still run the winner phase with the raw
-        current/title ids.  If the snapshot cannot prove the title is a
-        distinct lineage (current chain deeper than B), the title is NOT a
-        safe winner and must be dropped — the answer is truncated, never a
-        complete 'title matched' (#68 review round-2/3)."""
+        """A title-only K=1 search must still run the winner phase with the
+        current session id.  When the current chain is deeper than B the
+        answer is honestly truncated, but the exact-title result is preserved
+        (no proof-gate drops it) — the title lane and the content lane are
+        independent (#68 review round-5)."""
         import hermes_state_search
         monkeypatch.setattr(hermes_state_search, "_LINEAGE_WORK_BUDGET", 4)
         # current session is the tip of a compression chain deeper than B
@@ -978,26 +980,21 @@ class TestCompressionRootToolParity:
         ))
 
         assert result["success"] is True
-        # B exhaustion is surfaced and the unproven title is dropped: this is
-        # an incomplete answer (safe prefix only), never a complete top-K.
-        assert result["count"] == 0
-        assert result["results"] == []
+        # the exact title is preserved; B exhaustion on the current chain is
+        # surfaced as truncation, not as a silently complete answer
+        assert result["count"] == 1
+        assert [r["session_id"] for r in result["results"]] == ["title-session"]
         assert result.get("truncated") is True
         assert "warning" in result
 
-    def test_title_equal_to_current_session_dropped_when_unproven(self, db, monkeypatch):
-        """When the exact-title session IS the current session (on a >B chain)
-        and the tool-side resolver cannot prove lineage, the winner snapshot
-        also cannot — the title is NOT a proven-safe winner and must be
-        dropped, not returned as the current session (#68 review round-3)."""
+    def test_title_equal_to_current_session_excluded_and_truncated(self, db, monkeypatch):
+        """When the exact-title session IS the current session, its title is
+        excluded by the current-lineage guard (a session never surfaces as its
+        own result) — NOT by any proof gate.  The winner phase still runs and
+        honestly surfaces B exhaustion on the >B current chain via truncation
+        (#68 review round-5)."""
         import hermes_state_search
         monkeypatch.setattr(hermes_state_search, "_LINEAGE_WORK_BUDGET", 4)
-        # simulate tool-side B exhaustion (production: a >2000 chain makes the
-        # public resolver return None)
-        monkeypatch.setattr(
-            SessionDB, "resolve_compression_lineage",
-            lambda self, session_id, **kwargs: None,
-        )
         for i in range(6):
             db.create_session(f"cur-{i}", source="cli")
         for i in range(5):
@@ -1023,7 +1020,8 @@ class TestCompressionRootToolParity:
         ))
 
         assert result["success"] is True
-        # the current session is never a safe result; B exhaustion surfaces
+        # current session is never its own result; the >B current chain is
+        # honestly truncated
         assert result["count"] == 0
         assert result["results"] == []
         assert result.get("truncated") is True

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -1029,6 +1029,30 @@ class TestCompressionRootToolParity:
         assert result.get("truncated") is True
         assert "warning" in result
 
+    def test_title_preserved_when_content_lane_unavailable(self, db):
+        """When the content FTS lane cannot run (FTS disabled / empty query /
+        MATCH error), the winner phase early-returns with no root stats.  The
+        title safety gate must NOT kill the already-found exact-title — that
+        is the designed title-only fallback, not a B-limited unproven result
+        (#68 review round-4)."""
+        db._fts_enabled = False
+        db.create_session("cur", source="cli")
+        db.create_session("title-session", source="cli")
+        db.set_session_title("title-session", "foo AND OR bar")
+        db.append_message("title-session", role="user",
+                          content="some content")
+
+        result = json.loads(session_search(
+            query="foo AND OR bar", db=db, limit=1,
+            current_session_id="cur",
+        ))
+
+        assert result["success"] is True
+        assert result["count"] == 1
+        assert result["results"][0]["session_id"] == "title-session"
+        assert result.get("truncated") is False
+        assert "No matching sessions found" not in (result.get("message") or "")
+
 
 class TestDiscoveryTruncation:
     """B-hit responses are explicitly incomplete, never a silent top-K."""

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -113,23 +113,21 @@ class TestBrowseShape:
 # =========================================================================
 
 class TestDiscoveryShape:
-    def test_discovery_field_plan_preserves_full_default_result(self, db, monkeypatch):
+    def test_discovery_does_not_use_search_messages(self, db, monkeypatch):
+        # Discovery winner selection runs through the SQL winner seam, not
+        # the per-message search_messages() path, so candidate context is
+        # never projected.  (Replaced the pre-SQL era field-plan test.)
         _seed_modpack_sessions(db)
         original = db.search_messages
-        requested_fields = None
 
-        def search_spy(*args, **kwargs):
-            nonlocal requested_fields
-            requested_fields = kwargs.get("fields")
-            return original(*args, **kwargs)
+        def fail_if_called(*args, **kwargs):
+            raise AssertionError("discovery must not call search_messages()")
 
-        monkeypatch.setattr(db, "search_messages", search_spy)
+        monkeypatch.setattr(db, "search_messages", fail_if_called)
 
         result = json.loads(session_search(query="modpack", limit=1, db=db))
 
         assert result["success"] is True
-        assert requested_fields is not None
-        assert "context" not in requested_fields
         assert len(result["results"]) == 1
         hit = result["results"][0]
         assert "bookend_start" in hit
@@ -823,3 +821,131 @@ class TestLegacyContinuationPlusDelegation:
 
         # Delegation child must NOT appear
         assert "s_delegate" not in sids
+
+
+# =========================================================================
+# #68 compression-root parity at the tool layer
+# =========================================================================
+
+class TestCompressionRootToolParity:
+    """Current-session / exact-title exclusion shares the DB winner seam's
+    positive compression-continuation root semantics."""
+
+    def test_current_compression_child_live_content_excluded_ancestor_surfaces(self, db):
+        """Searching from a compression continuation child: the child's own
+        live content is in context (excluded), but the compression-ended
+        ancestor's archived content surfaces."""
+        db.create_session("s_parent", source="cli")
+        db.append_message("s_parent", role="user",
+                          content="parent needle archived")
+        db.end_session("s_parent", "compression")
+        db.create_session("s_current", source="cli", parent_session_id="s_parent")
+        db.append_message("s_current", role="user",
+                          content="current live needle")
+
+        result = json.loads(session_search(
+            query="needle", db=db, current_session_id="s_current",
+        ))
+        sids = [r["session_id"] for r in result["results"]]
+        assert "s_current" not in sids
+        assert "s_parent" in sids
+
+    def test_branch_child_under_current_lineage_stays_distinct(self, db):
+        """A branch child (parent-bound _branched_from marker) is NOT part of
+        the current compression lineage, so it surfaces as its own result."""
+        db.create_session("s_parent", source="cli")
+        db.append_message("s_parent", role="user",
+                          content="parent needle content")
+        db.end_session("s_parent", "compression")
+        db.create_session("s_current", source="cli", parent_session_id="s_parent")
+        db.create_session("s_branch", source="cli", parent_session_id="s_parent")
+        db._conn.execute(
+            "UPDATE sessions SET model_config = ? WHERE id = ?",
+            (json.dumps({"_branched_from": "s_parent"}), "s_branch"),
+        )
+        db._conn.commit()
+        db.append_message("s_branch", role="user",
+                          content="branch needle content")
+
+        result = json.loads(session_search(
+            query="needle", db=db, current_session_id="s_current",
+        ))
+        sids = [r["session_id"] for r in result["results"]]
+        assert "s_parent" in sids
+        assert "s_branch" in sids
+
+    def test_title_and_content_lanes_share_compression_root_semantics(self, db):
+        """A generic (non-compression) child of the title-matched session is
+        NOT in the title's compression lineage, so the content lane surfaces it
+        instead of swallowing it into the title slot's exclusion."""
+        db.create_session("t_parent", source="cli")
+        db.set_session_title("t_parent", "quartzgate")
+        db.append_message("t_parent", role="user",
+                          content="irrelevant filler content")
+        db.create_session("t_generic_child", source="cli",
+                          parent_session_id="t_parent")
+        db.append_message("t_generic_child", role="user",
+                          content="quartzgate is the key here")
+
+        result = json.loads(session_search(query="quartzgate", db=db, limit=5))
+        sids = [r["session_id"] for r in result["results"]]
+        assert "t_parent" in sids
+        assert "t_generic_child" in sids
+        assert result["count"] == 2
+
+
+class TestDiscoveryTruncation:
+    """B-hit responses are explicitly incomplete, never a silent top-K."""
+
+    def _seed_bound_chain(self, db, n=6):
+        """A positive compression chain longer than the monkeypatched budget."""
+        base = "bhit"
+        for i in range(n):
+            db.create_session(f"{base}-{i}", source="cli")
+        for i in range(n - 1):
+            child, parent = f"{base}-{i}", f"{base}-{i + 1}"
+            db._conn.execute("PRAGMA foreign_keys = OFF")
+            db._conn.execute(
+                "UPDATE sessions SET parent_session_id = ?, "
+                "end_reason = 'compression' WHERE id = ?",
+                (parent, child),
+            )
+            db._conn.commit()
+            db._conn.execute("PRAGMA foreign_keys = ON")
+        db.append_message(f"{base}-0", role="user",
+                          content="bound needle chain")
+
+    def test_bound_hit_returns_truncated_safe_prefix(self, db, monkeypatch):
+        import hermes_state_search
+        monkeypatch.setattr(hermes_state_search, "_LINEAGE_WORK_BUDGET", 5)
+        # Safe winner ranks first and is accepted before the bound chain hits.
+        db.create_session("safe", source="cli")
+        db.append_message("safe", role="user", content="bound needle safe")
+        self._seed_bound_chain(db)
+
+        result = json.loads(session_search(query="bound needle", db=db))
+
+        assert result["success"] is True
+        assert result.get("truncated") is True
+        assert "warning" in result
+        assert result["count"] == 1
+        assert [r["session_id"] for r in result["results"]] == ["safe"]
+
+    def test_bound_hit_with_zero_winners_is_incomplete_not_no_match(self, db, monkeypatch):
+        import hermes_state_search
+        monkeypatch.setattr(hermes_state_search, "_LINEAGE_WORK_BUDGET", 5)
+        self._seed_bound_chain(db)
+
+        result = json.loads(session_search(query="bound needle", db=db))
+
+        assert result["success"] is True
+        assert result.get("truncated") is True
+        assert result["count"] == 0
+        assert "No matching sessions found" not in (result.get("message") or "")
+
+    def test_normal_discovery_truncated_false(self, db):
+        _seed_modpack_sessions(db)
+        result = json.loads(session_search(query="modpack", db=db))
+        assert result["success"] is True
+        assert result.get("truncated") is False
+        assert "warning" not in result

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -893,6 +893,55 @@ class TestCompressionRootToolParity:
         assert "t_generic_child" in sids
         assert result["count"] == 2
 
+    def test_compacted_history_discoverable_even_when_best_hit_is_live(self, db):
+        """sort=newest ranks the LIVE needle first; the older compacted needle
+        of the same current session must still surface (with the compacted
+        anchor) instead of being erased by per-owner dedupe (#68 review)."""
+        db.create_session("s_cur", source="cli")
+        compacted_id = db.append_message(
+            "s_cur", role="user", content="old compacted needle content"
+        )
+        db.archive_and_compact("s_cur", [
+            {"role": "assistant", "content": "summary"},
+        ])
+        live_id = db.append_message(
+            "s_cur", role="user", content="new live needle content"
+        )
+
+        result = json.loads(session_search(
+            query="needle", db=db, current_session_id="s_cur", sort="newest",
+        ))
+
+        assert result["success"] is True
+        assert result["count"] >= 1
+        hit = result["results"][0]
+        assert hit["session_id"] == "s_cur"
+        # the anchor is the compacted (archived) message, not the live one
+        assert hit["match_message_id"] == compacted_id
+        assert hit["match_message_id"] != live_id
+
+    def test_title_and_content_share_compression_root_in_snapshot(self, db):
+        """Exact-title exclusion is re-resolved in the winner snapshot: a
+        content hit in the title's compression lineage is excluded even though
+        its own session id differs from the title session id."""
+        db.create_session("t_parent", source="cli")
+        db.set_session_title("t_parent", "needle-title")
+        db.append_message("t_parent", role="user", content="parent filler")
+        db.end_session("t_parent", "compression")
+        db.create_session("t_child", source="cli",
+                          parent_session_id="t_parent")
+        db.append_message("t_child", role="user",
+                          content="needle-title appears in child")
+
+        result = json.loads(session_search(query="needle-title", db=db, limit=5))
+
+        assert result["success"] is True
+        sids = [r["session_id"] for r in result["results"]]
+        # Title slot: t_parent. Content lane: t_child is the same compression
+        # lineage -> excluded, so the title is the only result.
+        assert sids == ["t_parent"]
+        assert result.get("truncated") is False
+
 
 class TestDiscoveryTruncation:
     """B-hit responses are explicitly incomplete, never a silent top-K."""

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -945,8 +945,9 @@ class TestCompressionRootToolParity:
     def test_title_only_limit_one_surfaces_bound_exhaustion(self, db, monkeypatch):
         """A title-only K=1 search must still run the winner phase with the raw
         current/title ids.  If the snapshot cannot prove the title is a
-        distinct lineage (current chain deeper than B), the answer is
-        truncated, not a complete 'title matched' (#68 review round-2)."""
+        distinct lineage (current chain deeper than B), the title is NOT a
+        safe winner and must be dropped — the answer is truncated, never a
+        complete 'title matched' (#68 review round-2/3)."""
         import hermes_state_search
         monkeypatch.setattr(hermes_state_search, "_LINEAGE_WORK_BUDGET", 4)
         # current session is the tip of a compression chain deeper than B
@@ -977,9 +978,54 @@ class TestCompressionRootToolParity:
         ))
 
         assert result["success"] is True
-        # the title is still returned, but B exhaustion is surfaced: this is
-        # an incomplete answer, never a complete top-K / no-match
-        assert result["count"] == 1
+        # B exhaustion is surfaced and the unproven title is dropped: this is
+        # an incomplete answer (safe prefix only), never a complete top-K.
+        assert result["count"] == 0
+        assert result["results"] == []
+        assert result.get("truncated") is True
+        assert "warning" in result
+
+    def test_title_equal_to_current_session_dropped_when_unproven(self, db, monkeypatch):
+        """When the exact-title session IS the current session (on a >B chain)
+        and the tool-side resolver cannot prove lineage, the winner snapshot
+        also cannot — the title is NOT a proven-safe winner and must be
+        dropped, not returned as the current session (#68 review round-3)."""
+        import hermes_state_search
+        monkeypatch.setattr(hermes_state_search, "_LINEAGE_WORK_BUDGET", 4)
+        # simulate tool-side B exhaustion (production: a >2000 chain makes the
+        # public resolver return None)
+        monkeypatch.setattr(
+            SessionDB, "resolve_compression_lineage",
+            lambda self, session_id, **kwargs: None,
+        )
+        for i in range(6):
+            db.create_session(f"cur-{i}", source="cli")
+        for i in range(5):
+            child, parent = f"cur-{i}", f"cur-{i + 1}"
+            db._conn.execute("PRAGMA foreign_keys = OFF")
+            db._conn.execute(
+                "UPDATE sessions SET parent_session_id = ? WHERE id = ?",
+                (parent, child),
+            )
+            db._conn.execute(
+                "UPDATE sessions SET end_reason = 'compression' WHERE id = ?",
+                (parent,),
+            )
+            db._conn.commit()
+            db._conn.execute("PRAGMA foreign_keys = ON")
+        db.set_session_title("cur-0", "needle-title")
+        db.append_message("cur-0", role="user",
+                          content="needle-title content")
+
+        result = json.loads(session_search(
+            query="needle-title", db=db, limit=3,
+            current_session_id="cur-0",
+        ))
+
+        assert result["success"] is True
+        # the current session is never a safe result; B exhaustion surfaces
+        assert result["count"] == 0
+        assert result["results"] == []
         assert result.get("truncated") is True
         assert "warning" in result
 

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -906,9 +906,12 @@ class TestDiscoveryTruncation:
             child, parent = f"{base}-{i}", f"{base}-{i + 1}"
             db._conn.execute("PRAGMA foreign_keys = OFF")
             db._conn.execute(
-                "UPDATE sessions SET parent_session_id = ?, "
-                "end_reason = 'compression' WHERE id = ?",
+                "UPDATE sessions SET parent_session_id = ? WHERE id = ?",
                 (parent, child),
+            )
+            db._conn.execute(
+                "UPDATE sessions SET end_reason = 'compression' WHERE id = ?",
+                (parent,),
             )
             db._conn.commit()
             db._conn.execute("PRAGMA foreign_keys = ON")

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -942,6 +942,47 @@ class TestCompressionRootToolParity:
         assert sids == ["t_parent"]
         assert result.get("truncated") is False
 
+    def test_title_only_limit_one_surfaces_bound_exhaustion(self, db, monkeypatch):
+        """A title-only K=1 search must still run the winner phase with the raw
+        current/title ids.  If the snapshot cannot prove the title is a
+        distinct lineage (current chain deeper than B), the answer is
+        truncated, not a complete 'title matched' (#68 review round-2)."""
+        import hermes_state_search
+        monkeypatch.setattr(hermes_state_search, "_LINEAGE_WORK_BUDGET", 4)
+        # current session is the tip of a compression chain deeper than B
+        for i in range(6):
+            db.create_session(f"cur-{i}", source="cli")
+        for i in range(5):
+            child, parent = f"cur-{i}", f"cur-{i + 1}"
+            db._conn.execute("PRAGMA foreign_keys = OFF")
+            db._conn.execute(
+                "UPDATE sessions SET parent_session_id = ? WHERE id = ?",
+                (parent, child),
+            )
+            db._conn.execute(
+                "UPDATE sessions SET end_reason = 'compression' WHERE id = ?",
+                (parent,),
+            )
+            db._conn.commit()
+            db._conn.execute("PRAGMA foreign_keys = ON")
+        # a separate exact-title session
+        db.create_session("title-session", source="cli")
+        db.set_session_title("title-session", "needle-title")
+        db.append_message("title-session", role="user",
+                          content="title content filler")
+
+        result = json.loads(session_search(
+            query="needle-title", db=db, limit=1,
+            current_session_id="cur-0",
+        ))
+
+        assert result["success"] is True
+        # the title is still returned, but B exhaustion is surfaced: this is
+        # an incomplete answer, never a complete top-K / no-match
+        assert result["count"] == 1
+        assert result.get("truncated") is True
+        assert "warning" in result
+
 
 class TestDiscoveryTruncation:
     """B-hit responses are explicitly incomplete, never a silent top-K."""

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -741,17 +741,19 @@ def _discover(
 
     _title_t0 = time.perf_counter()
     title_result = _title_match_result(db, query, current_lineage_root)
+    title_lineage = title_result.get("_lineage_root") if title_result else None
     _title_ms = (time.perf_counter() - _title_t0) * 1000
 
+    excluded_lineages = (title_lineage,) if title_lineage else ()
     _search_t0 = time.perf_counter()
     try:
         # Always run the winner phase — even when an exact-title result already
-        # fills the only slot (result_limit becomes 0) — so the RAW current and
-        # title session ids are re-resolved inside one snapshot with the SAME
-        # memo/state/budget used for candidate roots (#68).  A title-only K=1
-        # search must still surface B exhaustion: if the snapshot cannot prove
-        # the title is a distinct lineage, the answer is truncated, not a
-        # complete "title matched".
+        # fills the only slot (result_limit becomes 0) — so the current session
+        # is still re-resolved inside the winner snapshot and a title-only K=1
+        # search surfaces B exhaustion instead of silently claiming a complete
+        # answer.  Exact-title exclusion uses the same compression-lineage
+        # implementation: the title lineage is resolved here with
+        # resolve_compression_lineage() and passed as excluded_lineage_roots.
         winner_response = db.search_session_winners(
             query=query,
             role_filter=role_list,
@@ -759,10 +761,8 @@ def _discover(
             candidate_limit=_DISCOVER_SCAN_LIMIT,
             result_limit=max(0, limit - (1 if title_result else 0)),
             sort=sort,
+            excluded_lineage_roots=excluded_lineages,
             current_session_id=current_session_id or None,
-            title_session_id=(
-                title_result["session_id"] if title_result else None
-            ),
             request_id=_request_id,
         )
     except Exception as e:
@@ -779,22 +779,6 @@ def _discover(
     _raw_hits = int(winner_stats.get("candidate_count", 0))
     _unique_raw_sessions = int(winner_stats.get("candidate_unique_sessions", 0))
     _truncated = bool(winner_stats.get("lineage_bound_hit"))
-    # A title result is only a SAFE winner when the winner snapshot PROVED it
-    # is a distinct lineage from the current session.  This gate applies ONLY
-    # when the winner phase actually ran the in-snapshot resolution
-    # (lineage_snapshot_ran): when the content FTS lane could not run at all
-    # (FTS unavailable / empty query / MATCH error), the DB early-returns with
-    # no root stats, and title-only discovery is the designed fallback — it
-    # must be preserved, not killed by a gate that never had a chance to prove
-    # anything (#68 review round-4).  When the snapshot DID run but could not
-    # prove the title distinct (B exhaustion / unresolved), or proved it equal,
-    # the title may actually BE the current session — drop it so a B-limited
-    # answer is never packaged as a complete title match.
-    if title_result and current_session_id and winner_stats.get("lineage_snapshot_ran"):
-        title_root = winner_stats.get("lineage_title_root")
-        current_root = winner_stats.get("lineage_current_root")
-        if not (title_root and current_root) or title_root == current_root:
-            title_result = None
     _order_ms = 0
 
     if not winner_rows and not title_result:

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -149,8 +149,30 @@ def _resolve_to_parent(db, session_id: str) -> tuple[str, bool]:
 
 
 def _resolve_lineage(db, session_id: str) -> str:
-    """Convenience: return only the lineage root (ignores compression hop)."""
-    return _resolve_to_parent(db, session_id)[0]
+    """Resolve the session-search compression lineage root.
+
+    Production ``SessionDB`` exposes the same positive compression-continuation
+    resolver used by SQL winner selection, so current-session / exact-title
+    exclusion and DB winner dedupe share one root meaning (#68).  The old
+    generic-parent walk is kept only as a compatibility fallback for small
+    test doubles / older DB objects.  A failed production resolution is
+    conservative: the session stays its own root instead of broadening
+    exclusion to an unproven ancestor.
+    """
+    if not session_id:
+        return session_id
+    resolver = getattr(db, "resolve_compression_lineage", None)
+    if resolver is None:
+        return _resolve_to_parent(db, session_id)[0]
+    try:
+        return resolver(session_id) or session_id
+    except Exception:
+        logging.debug(
+            "compression lineage resolution failed for %s",
+            session_id,
+            exc_info=True,
+        )
+        return session_id
 
 
 def _is_compression_ended(db, session_id: str) -> bool:
@@ -522,8 +544,12 @@ def _scroll(
 
     if current_session_id:
         anchor_session_id = owning_session_id or session_id
-        a_root = _resolve_lineage(db, anchor_session_id)
-        c_root = _resolve_lineage(db, current_session_id)
+        # Scroll's guard is about LIVE CONTEXT, not search lineage (#68): a
+        # delegation/branch child is still visible to the parent agent, so its
+        # content must be rejected even though it is a DISTINCT compression
+        # lineage in discovery.  Generic parentage is the correct model here.
+        a_root, _ = _resolve_to_parent(db, anchor_session_id)
+        c_root, _ = _resolve_to_parent(db, current_session_id)
         if a_root and c_root and a_root == c_root:
             is_compacted_anchor = (
                 anchor_state is not None
@@ -570,8 +596,11 @@ def _scroll(
     if not messages:
         owning = owning_session_id
         if owning and owning != session_id:
-            a_root = _resolve_lineage(db, session_id)
-            o_root = _resolve_lineage(db, owning)
+            # Same live-context rationale as the guard above: rebind across
+            # any parentage (compression or delegation), not just positive
+            # compression-continuation lineage.
+            a_root, _ = _resolve_to_parent(db, session_id)
+            o_root, _ = _resolve_to_parent(db, owning)
             if a_root and o_root and a_root == o_root:
                 try:
                     rebind_view = db.get_messages_around(owning, around_message_id, window=window)
@@ -652,13 +681,17 @@ def _title_match_result(
     if session_meta.get("source") in _HIDDEN_SESSION_SOURCES:
         return None
 
+    # Title matching only needs a lightweight anchor before bounded hydration.
+    # Do not load the whole transcript via get_messages() (#68 salvage).
     try:
-        messages = db.get_messages(session_id)
+        anchor_id = db.get_first_message_id(session_id)
     except Exception:
-        logging.debug("get_messages failed for title match %s", session_id, exc_info=True)
-        messages = []
-
-    anchor_id = messages[0].get("id") if messages else None
+        logging.debug(
+            "first-message anchor lookup failed for title match %s",
+            session_id,
+            exc_info=True,
+        )
+        anchor_id = None
     if anchor_id is not None:
         try:
             view = db.get_anchored_view(session_id, anchor_id, window=5, bookend=3)
@@ -677,11 +710,11 @@ def _title_match_result(
         "matched_role": "session_title",
         "match_message_id": anchor_id,
         "snippet": f"Session title matched: {session_meta.get('title') or title_query}",
-        "bookend_start": [_shape_message(m) for m in (view.get("bookend_start") or messages[:3])],
-        "messages": [_shape_message(m, anchor_id=anchor_id) for m in (view.get("window") or messages[:5])],
-        "bookend_end": [_shape_message(m) for m in (view.get("bookend_end") or messages[-3:])],
+        "bookend_start": [_shape_message(m) for m in (view.get("bookend_start") or [])],
+        "messages": [_shape_message(m, anchor_id=anchor_id) for m in (view.get("window") or [])],
+        "bookend_end": [_shape_message(m) for m in (view.get("bookend_end") or [])],
         "messages_before": view.get("messages_before", 0),
-        "messages_after": view.get("messages_after", max(len(messages) - 5, 0)),
+        "messages_after": view.get("messages_after", 0),
         "_lineage_root": lineage_root,
     }
     if lineage_root and lineage_root != session_id:
@@ -722,11 +755,20 @@ def _discover(
                 "candidate_unique_sessions": 0,
                 "lineage_count": 0,
                 "winner_count": 0,
+                "lineage_work": 0,
+                "lineage_memo_hits": 0,
+                "lineage_memo_entries": 0,
+                "lineage_candidates_inspected": 0,
+                "lineage_bound_hit": False,
                 "route": "none",
             },
         }
     else:
         try:
+            # Pass the raw current-session id so the winner phase re-resolves
+            # it with the SAME memo/state/snapshot used for candidate roots
+            # (#68): current-session exclusion shares the DB compression-root
+            # semantics instead of trusting a stale precomputed root string.
             winner_response = db.search_session_winners(
                 query=query,
                 role_filter=role_list,
@@ -735,7 +777,7 @@ def _discover(
                 result_limit=max(0, limit - (1 if title_result else 0)),
                 sort=sort,
                 excluded_lineage_roots=excluded_lineages,
-                current_lineage_root=current_lineage_root,
+                current_session_id=current_session_id or None,
                 request_id=_request_id,
             )
         except Exception as e:
@@ -751,25 +793,45 @@ def _discover(
     winner_stats = winner_response.get("stats", {})
     _raw_hits = int(winner_stats.get("candidate_count", 0))
     _unique_raw_sessions = int(winner_stats.get("candidate_unique_sessions", 0))
+    _truncated = bool(winner_stats.get("lineage_bound_hit"))
     _order_ms = 0
 
     if not winner_rows and not title_result:
-        _empty_payload = {
-            "success": True,
-            "mode": "discover",
-            "query": query,
-            "results": [],
-            "count": 0,
-            "message": "No matching sessions found.",
-        }
+        if _truncated:
+            # The lineage safety work bound stopped the scan before any
+            # winner: this is an incomplete result, never "no matches".
+            _empty_payload = {
+                "success": True,
+                "mode": "discover",
+                "query": query,
+                "results": [],
+                "count": 0,
+                "truncated": True,
+                "warning": (
+                    "Session search stopped at the lineage safety work bound; "
+                    "results are a safe ranked prefix and may be incomplete."
+                ),
+            }
+        else:
+            _empty_payload = {
+                "success": True,
+                "mode": "discover",
+                "query": query,
+                "results": [],
+                "count": 0,
+                "truncated": False,
+                "message": "No matching sessions found.",
+            }
         _annotate_rebuild_status(db, _empty_payload)
         _elapsed = (time.perf_counter() - _t0) * 1000
         logging.info(
             "DISCOVER_DONE request_id=%s total_ms=%d resolve_ms=%d title_ms=%d "
             "search_ms=%d order_ms=0 view_ms=0 json_ms=0 results=0 "
-            "raw_hits=%d unique_raw_sessions=%d unique_lineages=0",
+            "raw_hits=%d unique_raw_sessions=%d unique_lineages=0 "
+            "lineage_work=%d lineage_bound_hit=%s",
             _request_id, int(_elapsed), int(_resolve_ms), int(_title_ms),
             int(_search_ms), _raw_hits, _unique_raw_sessions,
+            int(winner_stats.get("lineage_work", 0)), _truncated,
         )
         return json.dumps(_empty_payload, ensure_ascii=False)
 
@@ -842,8 +904,15 @@ def _discover(
         "query": query,
         "results": results,
         "count": len(results),
+        "truncated": _truncated,
         "sessions_searched": len(winner_rows) + (1 if title_result else 0),
     }
+    if _truncated:
+        # A partial safe prefix must never be presented as a complete top-K.
+        _final_payload["warning"] = (
+            "Session search stopped at the lineage safety work bound; "
+            "results are a safe ranked prefix and may be incomplete."
+        )
     _annotate_rebuild_status(db, _final_payload)
     _json = json.dumps(_final_payload, ensure_ascii=False)
     _json_ms = (time.perf_counter() - _json_t0) * 1000
@@ -851,11 +920,13 @@ def _discover(
     logging.info(
         "DISCOVER_DONE request_id=%s total_ms=%d resolve_ms=%d title_ms=%d search_ms=%d "
         "order_ms=%d view_ms=%d json_ms=%d results=%d raw_hits=%d "
-        "unique_raw_sessions=%d unique_lineages=%d",
+        "unique_raw_sessions=%d unique_lineages=%d "
+        "lineage_work=%d lineage_bound_hit=%s",
         _request_id, int(_elapsed), int(_resolve_ms), int(_title_ms), int(_search_ms),
         _order_ms, int(_view_ms), int(_json_ms), len(results), _raw_hits,
         _unique_raw_sessions,
         int(winner_stats.get("lineage_count", 0)) + (1 if title_result else 0),
+        int(winner_stats.get("lineage_work", 0)), _truncated,
     )
     return _json
 

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -744,51 +744,35 @@ def _discover(
     _title_ms = (time.perf_counter() - _title_t0) * 1000
 
     _search_t0 = time.perf_counter()
-    if title_result and limit <= 1:
-        winner_response = {
-            "winners": [],
-            "stats": {
-                "candidate_count": 0,
-                "candidate_unique_sessions": 0,
-                "lineage_count": 0,
-                "winner_count": 0,
-                "lineage_work": 0,
-                "lineage_memo_hits": 0,
-                "lineage_memo_entries": 0,
-                "lineage_candidates_inspected": 0,
-                "lineage_bound_hit": False,
-                "route": "none",
-            },
-        }
-    else:
-        try:
-            # Pass the RAW current and title session ids so the winner phase
-            # re-resolves both inside its own snapshot with the SAME
-            # memo/state/budget used for candidate roots (#68): current and
-            # title exclusion share the DB compression-root semantics instead
-            # of trusting stale precomputed root strings, and a B-limited
-            # resolution is never rewritten into a fabricated root.
-            winner_response = db.search_session_winners(
-                query=query,
-                role_filter=role_list,
-                exclude_sources=list(_HIDDEN_SESSION_SOURCES),
-                candidate_limit=_DISCOVER_SCAN_LIMIT,
-                result_limit=max(0, limit - (1 if title_result else 0)),
-                sort=sort,
-                current_session_id=current_session_id or None,
-                title_session_id=(
-                    title_result["session_id"] if title_result else None
-                ),
-                request_id=_request_id,
-            )
-        except Exception as e:
-            _elapsed = (time.perf_counter() - _t0) * 1000
-            logging.error(
-                "DISCOVER_FAIL total_ms=%d resolve_ms=%d title_ms=%d error=%s",
-                int(_elapsed), int(_resolve_ms), int(_title_ms), e,
-            )
-            logging.error("SQL session winner search failed: %s", e, exc_info=True)
-            return tool_error(f"Search failed: {e}", success=False)
+    try:
+        # Always run the winner phase — even when an exact-title result already
+        # fills the only slot (result_limit becomes 0) — so the RAW current and
+        # title session ids are re-resolved inside one snapshot with the SAME
+        # memo/state/budget used for candidate roots (#68).  A title-only K=1
+        # search must still surface B exhaustion: if the snapshot cannot prove
+        # the title is a distinct lineage, the answer is truncated, not a
+        # complete "title matched".
+        winner_response = db.search_session_winners(
+            query=query,
+            role_filter=role_list,
+            exclude_sources=list(_HIDDEN_SESSION_SOURCES),
+            candidate_limit=_DISCOVER_SCAN_LIMIT,
+            result_limit=max(0, limit - (1 if title_result else 0)),
+            sort=sort,
+            current_session_id=current_session_id or None,
+            title_session_id=(
+                title_result["session_id"] if title_result else None
+            ),
+            request_id=_request_id,
+        )
+    except Exception as e:
+        _elapsed = (time.perf_counter() - _t0) * 1000
+        logging.error(
+            "DISCOVER_FAIL total_ms=%d resolve_ms=%d title_ms=%d error=%s",
+            int(_elapsed), int(_resolve_ms), int(_title_ms), e,
+        )
+        logging.error("SQL session winner search failed: %s", e, exc_info=True)
+        return tool_error(f"Search failed: {e}", success=False)
     _search_ms = (time.perf_counter() - _search_t0) * 1000
     winner_rows = winner_response.get("winners", [])
     winner_stats = winner_response.get("stats", {})

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -148,16 +148,15 @@ def _resolve_to_parent(db, session_id: str) -> tuple[str, bool]:
     return cur, has_compression
 
 
-def _resolve_lineage(db, session_id: str) -> str:
+def _resolve_lineage(db, session_id: str) -> Optional[str]:
     """Resolve the session-search compression lineage root.
 
     Production ``SessionDB`` exposes the same positive compression-continuation
-    resolver used by SQL winner selection, so current-session / exact-title
-    exclusion and DB winner dedupe share one root meaning (#68).  The old
-    generic-parent walk is kept only as a compatibility fallback for small
-    test doubles / older DB objects.  A failed production resolution is
-    conservative: the session stays its own root instead of broadening
-    exclusion to an unproven ancestor.
+    resolver used by SQL winner selection.  Returns ``None`` when the outcome
+    is unresolved / budget-exhausted — never a fabricated root (#68): a
+    resource limit is not evidence, so a B-limited resolution must not pretend
+    the session is its own root.  The old generic-parent walk is kept only as
+    a compatibility fallback for small test doubles / older DB objects.
     """
     if not session_id:
         return session_id
@@ -165,14 +164,14 @@ def _resolve_lineage(db, session_id: str) -> str:
     if resolver is None:
         return _resolve_to_parent(db, session_id)[0]
     try:
-        return resolver(session_id) or session_id
+        return resolver(session_id)
     except Exception:
         logging.debug(
             "compression lineage resolution failed for %s",
             session_id,
             exc_info=True,
         )
-        return session_id
+        return None
 
 
 def _is_compression_ended(db, session_id: str) -> bool:
@@ -742,10 +741,8 @@ def _discover(
 
     _title_t0 = time.perf_counter()
     title_result = _title_match_result(db, query, current_lineage_root)
-    title_lineage = title_result.get("_lineage_root") if title_result else None
     _title_ms = (time.perf_counter() - _title_t0) * 1000
 
-    excluded_lineages = (title_lineage,) if title_lineage else ()
     _search_t0 = time.perf_counter()
     if title_result and limit <= 1:
         winner_response = {
@@ -765,10 +762,12 @@ def _discover(
         }
     else:
         try:
-            # Pass the raw current-session id so the winner phase re-resolves
-            # it with the SAME memo/state/snapshot used for candidate roots
-            # (#68): current-session exclusion shares the DB compression-root
-            # semantics instead of trusting a stale precomputed root string.
+            # Pass the RAW current and title session ids so the winner phase
+            # re-resolves both inside its own snapshot with the SAME
+            # memo/state/budget used for candidate roots (#68): current and
+            # title exclusion share the DB compression-root semantics instead
+            # of trusting stale precomputed root strings, and a B-limited
+            # resolution is never rewritten into a fabricated root.
             winner_response = db.search_session_winners(
                 query=query,
                 role_filter=role_list,
@@ -776,8 +775,10 @@ def _discover(
                 candidate_limit=_DISCOVER_SCAN_LIMIT,
                 result_limit=max(0, limit - (1 if title_result else 0)),
                 sort=sort,
-                excluded_lineage_roots=excluded_lineages,
                 current_session_id=current_session_id or None,
+                title_session_id=(
+                    title_result["session_id"] if title_result else None
+                ),
                 request_id=_request_id,
             )
         except Exception as e:

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -779,6 +779,18 @@ def _discover(
     _raw_hits = int(winner_stats.get("candidate_count", 0))
     _unique_raw_sessions = int(winner_stats.get("candidate_unique_sessions", 0))
     _truncated = bool(winner_stats.get("lineage_bound_hit"))
+    # A title result is only a SAFE winner when the winner snapshot PROVED it
+    # is a distinct lineage from the current session.  When the snapshot could
+    # not resolve both identities (B exhaustion / unresolved), the title may
+    # actually BE the current session (e.g. it sits on a >B compression chain)
+    # — returning it would violate current-session exclusion and the #68
+    # bound-hit contract ("only already-proven safe winners").  Drop it so a
+    # B-limited answer is never packaged as a complete title match.
+    if title_result and current_session_id:
+        title_root = winner_stats.get("lineage_title_root")
+        current_root = winner_stats.get("lineage_current_root")
+        if not (title_root and current_root) or title_root == current_root:
+            title_result = None
     _order_ms = 0
 
     if not winner_rows and not title_result:

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -780,13 +780,17 @@ def _discover(
     _unique_raw_sessions = int(winner_stats.get("candidate_unique_sessions", 0))
     _truncated = bool(winner_stats.get("lineage_bound_hit"))
     # A title result is only a SAFE winner when the winner snapshot PROVED it
-    # is a distinct lineage from the current session.  When the snapshot could
-    # not resolve both identities (B exhaustion / unresolved), the title may
-    # actually BE the current session (e.g. it sits on a >B compression chain)
-    # — returning it would violate current-session exclusion and the #68
-    # bound-hit contract ("only already-proven safe winners").  Drop it so a
-    # B-limited answer is never packaged as a complete title match.
-    if title_result and current_session_id:
+    # is a distinct lineage from the current session.  This gate applies ONLY
+    # when the winner phase actually ran the in-snapshot resolution
+    # (lineage_snapshot_ran): when the content FTS lane could not run at all
+    # (FTS unavailable / empty query / MATCH error), the DB early-returns with
+    # no root stats, and title-only discovery is the designed fallback — it
+    # must be preserved, not killed by a gate that never had a chance to prove
+    # anything (#68 review round-4).  When the snapshot DID run but could not
+    # prove the title distinct (B exhaustion / unresolved), or proved it equal,
+    # the title may actually BE the current session — drop it so a B-limited
+    # answer is never packaged as a complete title match.
+    if title_result and current_session_id and winner_stats.get("lineage_snapshot_ran"):
         title_root = winner_stats.get("lineage_title_root")
         current_root = winner_stats.get("lineage_current_root")
         if not (title_root and current_root) or title_root == current_root:

--- a/website/docs/developer-guide/session-storage.md
+++ b/website/docs/developer-guide/session-storage.md
@@ -313,6 +313,28 @@ The `_sanitize_fts5_query()` method handles edge cases:
 Sessions can form chains via `parent_session_id`. This happens when context
 compression triggers a session split in the gateway.
 
+### Search-lineage resolution (`resolve_compression_lineage`)
+
+Session *search* does **not** treat every `parent_session_id` chain as one
+lineage (issue #68). `SessionDB.resolve_compression_lineage()` follows only
+**positive compression-continuation edges**:
+
+1. the parent row exists;
+2. the parent ended with `end_reason = 'compression'`;
+3. the child is not a `tool` session;
+4. the child's `model_config` `_branched_from` / `_delegate_from` markers do
+   **not** explicitly point at that parent (foreign markers pointing
+   elsewhere do not disqualify the edge).
+
+Generic parentage — branch / delegation / tool children — is therefore a
+**distinct** session, not a lineage member. `search_session_winners()`
+dedupes discovery results by this compression root, and current-session /
+exact-title exclusion use the same meaning. A missing parent or a positive
+cycle fails closed (the candidate is dropped, never given a fabricated
+root), and a per-query successful-row work budget (`B = 2000`) caps
+pathological graphs with an explicit truncation signal instead of a depth
+cap.
+
 ### Query: Find Session Lineage
 
 ```sql


### PR DESCRIPTION
## Production compression-lineage resolver for session search (#68)

Implements the query-local compression-lineage resolver specified in #68,
based on the implementation map from #70/#71.

### What it does

Rewrites `SessionSearchMixin.search_session_winners()` to select discovery
winners without candidate hydration, replacing the recursive generic-parent
CTE + `lineage_depth_cap` with a query-local, memoized, path-compressing
resolver:

```
ranked hits → owner/rank eligibility → compression lineage resolver
→ root dedupe → early K → hydration
```

- **Compression-only positive edges** — a hit's owner resolves to its root
  only through parent chains where the parent exists, `parent.end_reason ==
  'compression'`, the child is not a `tool` session, and `_branched_from` /
  `_delegate_from` do not point at that parent (foreign markers don't
  disqualify).
- **Fail closed** — a missing parent or a positive cycle memoizes the node as
  unresolved (`_UNRESOLVED`); a B-exhausted partial path is never memoized as
  unresolved and stops the entire ranked scan (explicit truncation).
- **B = 2000** successful uncached lineage-node row fetches per logical query;
  B exhaustion is surfaced as `truncated: true` + warning, never as a
  fabricated root or a silent "no matches".
- **Current-session exclusion** — the raw current session id is re-resolved
  in-snapshot with the same memo/state/budget; live content of the current
  lineage stays hidden while compacted-history anchors of the current owner
  still surface.
- **Exact-title exclusion** — the title lineage is resolved tool-side with the
  same `resolve_compression_lineage()` implementation and passed as
  `excluded_lineage_roots`; title and content lanes stay independent (FTS
  failure is not compensated by lineage proof).
- **One coherent logical read snapshot** (`_read_ctx()` + explicit `BEGIN`);
  the resolver never re-enters `_read_ctx`/`get_session` (non-WAL fallback
  holds a non-reentrant lock).

### Files

- `hermes_state_search.py` — resolver kernel + winner selection
- `tools/session_search_tool.py` — title discovery via bounded
  `get_first_message_id()`, `_resolve_lineage()` → compression root,
  `truncated`/`warning` handling
- `tests/test_session_search_sql_winners.py`, `tests/tools/test_session_search.py`
  — B-boundary (1999/2000/2001), 10k chain, cycle/missing fail-closed, owner
  dedupe, displayable-anchor ranking, concurrent writer, snapshot spy, etc.

### Review history

Implemented + 5 review rounds on issue #68 (rounds 1-4 fixed correctness
findings; round-5 was subtractive — removed the title/current lineage-proof
protocol and froze the resolver kernel per reviewer ruling `5240099804`).

### Validation

- `test_session_search_sql_winners.py` — 40 passed
- `tests/tools/test_session_search.py` — 50 passed
- Neighbors (`test_hermes_state.py`, `test_session_metadata_fts.py`,
  `test_tool_search.py`, `test_api_server_toolset.py`) — 260 passed
- `ruff check` clean
- Reviewer: **Standards PASS / subtraction scope PASS / 0 production blockers /
  merge-ready**
