### PR TITLE
feat(fts): unified six-index FTS lifecycle membership (#27)

### DIFF
--- a/docs/research/issue-27-unified-fts-lifecycle.md
+++ b/docs/research/issue-27-unified-fts-lifecycle.md
@@ -1,0 +1,162 @@
+# #27 implementation — unified six-index FTS lifecycle membership
+
+Status: **implemented (2026-08-11)**  
+Code base: **`919f4469e832bc2b38bba0ea5af26b842bf91acd`** (post-#30 `dev` snapshot, per the #35 research handoff)  
+Branch: `feat/27-unified-fts-lifecycle`  
+Research artifact: `docs/research/issue-35-unified-fts-lifecycle.md` (PR #75)
+
+> This is the implementation record for #35's handoff. #27 owns **unified
+> lifecycle membership only** for the six modern FTS indexes — it is NOT a
+> search-routing or migration-state framework, and storage-v2 settlement
+> stays with #31 (no `FTS_STORAGE_VERSION` change here).
+
+## The six authoritative members
+
+1. `messages_fts`
+2. `messages_fts_trigram`
+3. `messages_fts_cjk`
+4. `sessions_fts`
+5. `sessions_fts_cjk`
+6. `sessions_fts_trigram`
+
+## Descriptor / registry
+
+A single **data-only module-level descriptor registry** lives in
+`hermes_state_common.py`:
+
+```python
+@dataclass(frozen=True)
+class FtsIndexDescriptor:
+    table: str
+    source: str
+    row_key: str
+    columns: tuple[str, ...]
+    trigger_names: tuple[str, ...]
+    capability: Literal["fts5", "trigram", "cjk"]
+    derived_objects: tuple[tuple[str, str], ...] = ()   # owned source VIEWs
+
+FTS_INDEXES: tuple[FtsIndexDescriptor, ...] = (... six members ...)
+```
+
+- Module-level so offline repair and the SessionDB mixins consume the same
+  membership source without importing `hermes_state` (cycle-free).
+- `derived_objects` names owned source VIEWs (`messages_fts_trigram_src`,
+  `messages_fts_cjk_src`, `sessions_fts_trigram_src`) needed by destructive
+  repair.
+- Dynamic concerns stay in their existing owners: H/P markers + stale
+  breadcrumbs (rebuild lanes), worker-vs-serving state, #30 exact same-name
+  ownership, search routing, storage settlement.
+- **Registry membership is NOT authorization to mutate `sessions_fts_trigram`**
+  — #30's ownership classifier remains the gate; `unknown_same_name` stays
+  fail-closed everywhere (ordinary maintenance, repair, read-only discovery).
+
+## Rebuild specs reference the registry
+
+`_FTS_MESSAGE_SPEC` / `_FTS_SESSION_SPEC` / `_FTS_SESSION_TRIGRAM_SPEC` /
+`_FTS_SESSION_CJK_SPEC` derive their static identity (`descriptor`,
+`fts_table`, `source_table`, `row_key`, `fts_columns`, `source_columns`,
+`trigram_descriptor`) from `FTS_INDEXES` instead of repeating it, so
+membership can never drift from the lifecycle consumers. Lane-specific H/P
+keys, availability callbacks, reset targets, and finish hooks stay in the
+specs. A new generic `_FTS_MESSAGE_CJK_SPEC` folds the bespoke message-CJK
+rebuild onto the shared status/step/finish engine — its own H/P pair and
+stale breadcrumb (`FTS_CJK_STALE_KEY`) are preserved, and the backfill now
+reads through the `messages_fts_cjk_src` VIEW (equivalent to the old
+`messages` + `role <> 'tool'` filter).
+
+## Commit plan → what landed
+
+1. **`00e680a8c` — registry + ordinary maintenance.** `FtsIndexDescriptor` /
+   `FTS_INDEXES` / `_fts_descriptor()`; specs reference descriptors; generic
+   message-CJK spec + delegating `fts_cjk_rebuild_*` wrappers; removed
+   `SessionDB._FTS_TABLES`; new `_fts_maintenance_tables()` applicability
+   helper drives `optimize_fts` / `rebuild_fts` / `_merge_fts_incrementally`
+   across all six members (required Unicode indexes always, tokenizer-gated
+   members only when operable/owned). VACUUM reaches session indexes through
+   the existing `optimize_fts()` call — no session-specific VACUUM hook.
+2. **`e64af5e0f` — health + trigger inventory/convergence.** `_db_opens_cleanly`
+   read probe iterates `FTS_INDEXES` (detects corrupt session Unicode/CJK/
+   trigram indexes); the rollback-only write probe now inserts non-null
+   `title`/`display_name` so session INSERT triggers execute their real
+   projection; `_drop_fts_triggers` derives all owned modern triggers from
+   the registry (message-scoped `_drop_message_fts_triggers` added for the
+   v22→v23 demote path); `_fts_trigger_count` derives from message
+   descriptors; `_migrate_broad_fts_update_triggers` converges owned
+   `sessions_fts_update` / `sessions_fts_cjk_update` from broad to canonical
+   narrow `AFTER UPDATE OF title, id, display_name` (trigram update triggers
+   remain under #30 exact identity).
+3. **`474b88fe7` — repair + degraded runtime.** Module-level
+   `_owned_fts_object_names` (six-index tables + shadows + triggers + source
+   VIEWs, with #30 trigram fail-closed) and `_drop_owned_fts_derived_schema`;
+   `repair_state_db_schema` strategy 0 (in-place `rebuild`) iterates
+   `FTS_INDEXES` (session trigram rebuilds through its derived compact VIEW —
+   no compact SQL duplicated); strategy 2 (destructive) removes owned derived
+   schema for all six members while preserving canonical `sessions`/`messages`
+   and never touching an unknown same-name trigram object. Runtime recovery
+   continues through the now-registry-driven `rebuild_fts()` (covers session
+   indexes via the existing one-shot seam).
+4. **`f9ade6baf` — read-only + operational status.** Read-only init
+   SELECT-only discovers `sessions_fts` and `sessions_fts_trigram`
+   (ownership-classified, tokenizer-probed, stale-checked) in addition to the
+   existing message/session-CJK probes — no DDL, no mutation; worker-vs-serving
+   preserved. A shared rebuild-lane surface `_FTS_REBUILD_LANES` +
+   `_fts_lane_pending` / `_fts_first_pending_lane_status` /
+   `_fts_run_pending_lane_steps` drives `optimize_fts_storage`'s progress
+   emitter + foreground phase driver and `fts_optimize_available`'s
+   marker/stale checks (removes the hard-coded per-lane ladders).
+5. **`e64ad007b` — six-index regression matrix.** `tests/test_fts_lifecycle_registry.py`
+   pins: registry shape, spec-descriptor derivation, maintenance coverage,
+   explicit-rebuild through the compact VIEW, VACUUM row-id preservation,
+   health read/write probes, trigger inventory/convergence, offline +
+   destructive repair with canonical-row preservation, read-only discovery,
+   shared-lane sequencing, and runtime recovery. Message-only lifecycle
+   assertions in `test_hermes_state.py::TestOptimizeFts` were updated to the
+   six-index expectation.
+
+## Contracts preserved (not redesigned)
+
+- #25 raw-`(title, id, display_name)` Unicode document, named `row_id`, H/P
+  three-region ownership; #26 session-CJK worker-vs-serving distinction +
+  stale semantics; #30 exact same-name root/source/trigger identity,
+  quarantine/recovery, derived compact VIEW representation.
+- The shared chunk/finish engine, #76832 crash-safe claim ordering, #77629
+  "optional capability gates finish exactly as step".
+- No new core-tool / framework abstraction: the registry is data-only;
+  search routing/ranking/fallback stays in #14/#28.
+
+## Known limitation (documented, not hidden)
+
+A session-metadata **UPDATE** that fires `sessions_fts_update`'s `'delete'`
+half against a corrupt `sessions_fts` index hits an FTS5 in-transaction
+connection-state quirk: after the failed delete + rollback, an in-place
+`rebuild` fails on the SAME connection (verified in isolation; the message
+UPDATE path and the session INSERT path both recover fine). That path
+degrades to the registry-driven offline repair / startup auto-heal (fresh
+connection), which now covers session indexes — a strict improvement over
+base, where session FTS had no runtime recovery at all.
+
+## Validation
+
+Focused lifecycle matrix (research §9) + the new registry suite:
+
+```bash
+pytest -q \
+  tests/test_hermes_state.py \
+  tests/test_fts_update_of_narrowing.py \
+  tests/test_fts_cjk_bigram.py \
+  tests/test_session_metadata_fts.py \
+  tests/test_session_metadata_cjk_fts.py \
+  tests/test_session_metadata_trigram_fts.py \
+  tests/test_state_db_malformed_repair.py \
+  tests/test_session_db_read_path_split.py \
+  tests/test_fts_lifecycle_registry.py
+```
+
+Result: **339 passed, 43 skipped** (CJK capability-skipped on this host; not
+capability evidence per the research). Plus broader regression sweep
+(`tests/state/test_fts_runtime_rebuild.py`, `test_session_search_sql_winners.py`,
+`test_session_listing.py`, `tools/test_session_search.py`,
+`tools/test_tool_search*.py`, `gateway/test_session.py`,
+`gateway/test_api_server_toolset.py`, `state/test_compression_lineage_guard.py`,
+`state/test_no_more_rows_retry.py`) — all green. `ruff check` clean on every
+touched production/test file.

--- a/docs/research/issue-27-unified-fts-lifecycle.md
+++ b/docs/research/issue-27-unified-fts-lifecycle.md
@@ -63,6 +63,24 @@ Research artifact: `docs/research/issue-35-unified-fts-lifecycle.md` (PR #75)
 > narrowing suites 116 passed / 29 skipped, `test_hermes_state.py` 178 passed,
 > ruff clean.
 
+> **Review round 3 (2026-08-12, issue comment `5260385052`, fixed in
+> `ed5ab2e8e`).** One P1 — a sibling path of the R2 ownership gate.
+> Read-only discovery classified `sessions_fts_trigram` with
+> `_classify_sessions_fts_trigram == "modern_trigram"` only (root + derived
+> source VIEW), skipping the trigger namespace. A canonical root/source with a
+> foreign same-name trigger occupant could then publish
+> `_sessions_trigram_available = True` on a mode=ro connection — serving an
+> index whose live-maintenance contract is no longer trusted. Fix: read-only
+> discovery now uses `_sessions_trigram_owned()` (the R2 composition; no new
+> abstraction), so a foreign occupant anywhere in root / source VIEW / trigger
+> namespace fails closed. Tests: replaced the monkeypatched
+> `test_read_only_unknown_trigram_fail_closed` (classifier mock) with real
+> mixed-DDL read-only fixtures — foreign trigger occupant and foreign source
+> VIEW both assert `_sessions_trigram_available is False`; the owned-serving
+> case stays pinned by `test_read_only_discovers_session_unicode_and_trigram`.
+> Validation: registry + trigram/CJK + repair + narrowing suites
+> 117 passed / 29 skipped, `test_hermes_state.py` 178 passed, ruff clean.
+
 ## The six authoritative members
 
 1. `messages_fts`

--- a/docs/research/issue-27-unified-fts-lifecycle.md
+++ b/docs/research/issue-27-unified-fts-lifecycle.md
@@ -10,76 +10,10 @@ Research artifact: `docs/research/issue-35-unified-fts-lifecycle.md` (PR #75)
 > search-routing or migration-state framework, and storage-v2 settlement
 > stays with #31 (no `FTS_STORAGE_VERSION` change here).
 
-> **Review round 1 (2026-08-11, ponytail + code-review, issue comment
-> `5253715082`, fixed in `0400c66f0`).** All over-engineering/standards
-> findings were within #27 scope and implemented: removed the never-read
-> `"name"` key from `_FTS_REBUILD_LANES`; merged `_drop_fts_triggers` /
-> `_drop_message_fts_triggers` into `_drop_fts_triggers(cursor, names=None)`
-> (demote passes the message subset); parameterized the message/session CJK
-> UPDATE-narrowing + quarantine helpers by `(trigger_name, stale_key)`
-> (caller clears its own availability flag); deleted the now-dead
-> `_FTS_TRIGGERS` membership tuple (+ its back-compat re-export) per research
-> §4.1 Q2. Net −35 lines. Kept (spec-required, not a finding to fix): the
-> spec `"descriptor"` / `"trigram_descriptor"` keys — they are the explicit
-> "specs reference authoritative descriptors" seam from the research and the
-> drift-prevention test anchor. Validation after the round: 149 + 187 focused
-> tests green, ruff clean.
-
-> **Review round 2 (2026-08-11, issue comment `5254482988`, fixed in
-> `933a2ce86`).** One P1 (merge blocker), one P2, one S1.
->
-> **P1 — registry membership ≠ ownership in offline/global paths.** The
-> module-level health read probe (`_db_opens_cleanly`), repair strategy 0,
-> `_owned_fts_object_names`, and `_drop_fts_triggers` all touched
-> `sessions_fts_trigram` without #30 classification. A foreign same-name FTS5
-> table can legally accept `'rebuild'`, so this was a real mutation — #30
-> explicitly requires leaving foreign same-name schema untouched. Fix: reuse
-> the existing #30 classifiers via a thin composition
-> `SessionDB._sessions_trigram_owned` (root must classify as canonical modern
-> trigram **and** the trigger namespace must have no foreign occupant; a
-> missing owned trigger does not disqualify). Applied as the gate in all four
-> paths; `_drop_fts_triggers` additionally gates per-name via
-> `_sessions_trigram_trigger_status` (only `exact_modern` trigram triggers are
-> ever dropped). No new abstraction, no new state.
->
-> **P2 — read-only CJK worker flag.** The mode=ro `SessionDB` set
-> `_sessions_cjk_worker_operable = load_fts5_cjk_extension(...)`, publishing a
-> read-only connection as a mutating worker. The load result is now a local
-> used only for search-serving availability; the worker flag stays `False` on
-> read-only.
->
-> **S1 — real mixed-DDL ownership fixtures.** The ownership-boundary test
-> monkeypatched `_sessions_trigram_modern_definition_matches = False` (only
-> covered "root is foreign"). Replaced with real DDL fixtures: a foreign
-> (uncompacted) `sessions_fts_trigram_src` VIEW and foreign same-name trigger
-> occupants on a canonical root/source namespace. New tests assert foreign
-> objects stay byte/DDL-identical through `_drop_owned_fts_derived_schema` and
-> `_drop_fts_triggers`, and that offline repair **fails closed** — it never
-> reports success while foreign-gated corruption survives (a
-> `PRAGMA integrity_check` premise correction: the read probe cannot be
-> isolated via `_db_opens_cleanly is None` because integrity_check already
-> catches corrupt `_data`; the gate is pinned end-to-end via the repair
-> path). Validation after the round: registry + trigram/CJK + repair +
-> narrowing suites 116 passed / 29 skipped, `test_hermes_state.py` 178 passed,
-> ruff clean.
-
-> **Review round 3 (2026-08-12, issue comment `5260385052`, fixed in
-> `ed5ab2e8e`).** One P1 — a sibling path of the R2 ownership gate.
-> Read-only discovery classified `sessions_fts_trigram` with
-> `_classify_sessions_fts_trigram == "modern_trigram"` only (root + derived
-> source VIEW), skipping the trigger namespace. A canonical root/source with a
-> foreign same-name trigger occupant could then publish
-> `_sessions_trigram_available = True` on a mode=ro connection — serving an
-> index whose live-maintenance contract is no longer trusted. Fix: read-only
-> discovery now uses `_sessions_trigram_owned()` (the R2 composition; no new
-> abstraction), so a foreign occupant anywhere in root / source VIEW / trigger
-> namespace fails closed. Tests: replaced the monkeypatched
-> `test_read_only_unknown_trigram_fail_closed` (classifier mock) with real
-> mixed-DDL read-only fixtures — foreign trigger occupant and foreign source
-> VIEW both assert `_sessions_trigram_available is False`; the owned-serving
-> case stays pinned by `test_read_only_discovers_session_unicode_and_trigram`.
-> Validation: registry + trigram/CJK + repair + narrowing suites
-> 117 passed / 29 skipped, `test_hermes_state.py` 178 passed, ruff clean.
+> Review history (full detail lives in the issue comments + fix commits):
+> - R1 ponytail + code-review (`5253715082`, fixed `0400c66f0`) — over-engineering/standards cleanups, net −35 lines.
+> - R2 (`5254482988`, fixed `933a2ce86`) — ownership gate reused in offline/global paths (P1), read-only CJK worker flag (P2), real mixed-DDL fixtures (S1).
+> - R3 (`5260385052`, fixed `ed5ab2e8e`) — read-only trigram discovery gates on full #30 namespace ownership.
 
 ## The six authoritative members
 

--- a/docs/research/issue-27-unified-fts-lifecycle.md
+++ b/docs/research/issue-27-unified-fts-lifecycle.md
@@ -14,6 +14,7 @@ Research artifact: `docs/research/issue-35-unified-fts-lifecycle.md` (PR #75)
 > - R1 ponytail + code-review (`5253715082`, fixed `0400c66f0`) — over-engineering/standards cleanups, net −35 lines.
 > - R2 (`5254482988`, fixed `933a2ce86`) — ownership gate reused in offline/global paths (P1), read-only CJK worker flag (P2), real mixed-DDL fixtures (S1).
 > - R3 (`5260385052`, fixed `ed5ab2e8e`) — read-only trigram discovery gates on full #30 namespace ownership.
+> - R4 (`5264349085`, fixed `d6a4d7048`) — read-only trigram serving requires a complete trigger set (missing live trigger → unavailable).
 
 ## The six authoritative members
 

--- a/docs/research/issue-27-unified-fts-lifecycle.md
+++ b/docs/research/issue-27-unified-fts-lifecycle.md
@@ -10,6 +10,21 @@ Research artifact: `docs/research/issue-35-unified-fts-lifecycle.md` (PR #75)
 > search-routing or migration-state framework, and storage-v2 settlement
 > stays with #31 (no `FTS_STORAGE_VERSION` change here).
 
+> **Review round 1 (2026-08-11, ponytail + code-review, issue comment
+> `5253715082`, fixed in `0400c66f0`).** All over-engineering/standards
+> findings were within #27 scope and implemented: removed the never-read
+> `"name"` key from `_FTS_REBUILD_LANES`; merged `_drop_fts_triggers` /
+> `_drop_message_fts_triggers` into `_drop_fts_triggers(cursor, names=None)`
+> (demote passes the message subset); parameterized the message/session CJK
+> UPDATE-narrowing + quarantine helpers by `(trigger_name, stale_key)`
+> (caller clears its own availability flag); deleted the now-dead
+> `_FTS_TRIGGERS` membership tuple (+ its back-compat re-export) per research
+> §4.1 Q2. Net −35 lines. Kept (spec-required, not a finding to fix): the
+> spec `"descriptor"` / `"trigram_descriptor"` keys — they are the explicit
+> "specs reference authoritative descriptors" seam from the research and the
+> drift-prevention test anchor. Validation after the round: 149 + 187 focused
+> tests green, ruff clean.
+
 ## The six authoritative members
 
 1. `messages_fts`

--- a/docs/research/issue-27-unified-fts-lifecycle.md
+++ b/docs/research/issue-27-unified-fts-lifecycle.md
@@ -25,6 +25,44 @@ Research artifact: `docs/research/issue-35-unified-fts-lifecycle.md` (PR #75)
 > drift-prevention test anchor. Validation after the round: 149 + 187 focused
 > tests green, ruff clean.
 
+> **Review round 2 (2026-08-11, issue comment `5254482988`, fixed in
+> `933a2ce86`).** One P1 (merge blocker), one P2, one S1.
+>
+> **P1 — registry membership ≠ ownership in offline/global paths.** The
+> module-level health read probe (`_db_opens_cleanly`), repair strategy 0,
+> `_owned_fts_object_names`, and `_drop_fts_triggers` all touched
+> `sessions_fts_trigram` without #30 classification. A foreign same-name FTS5
+> table can legally accept `'rebuild'`, so this was a real mutation — #30
+> explicitly requires leaving foreign same-name schema untouched. Fix: reuse
+> the existing #30 classifiers via a thin composition
+> `SessionDB._sessions_trigram_owned` (root must classify as canonical modern
+> trigram **and** the trigger namespace must have no foreign occupant; a
+> missing owned trigger does not disqualify). Applied as the gate in all four
+> paths; `_drop_fts_triggers` additionally gates per-name via
+> `_sessions_trigram_trigger_status` (only `exact_modern` trigram triggers are
+> ever dropped). No new abstraction, no new state.
+>
+> **P2 — read-only CJK worker flag.** The mode=ro `SessionDB` set
+> `_sessions_cjk_worker_operable = load_fts5_cjk_extension(...)`, publishing a
+> read-only connection as a mutating worker. The load result is now a local
+> used only for search-serving availability; the worker flag stays `False` on
+> read-only.
+>
+> **S1 — real mixed-DDL ownership fixtures.** The ownership-boundary test
+> monkeypatched `_sessions_trigram_modern_definition_matches = False` (only
+> covered "root is foreign"). Replaced with real DDL fixtures: a foreign
+> (uncompacted) `sessions_fts_trigram_src` VIEW and foreign same-name trigger
+> occupants on a canonical root/source namespace. New tests assert foreign
+> objects stay byte/DDL-identical through `_drop_owned_fts_derived_schema` and
+> `_drop_fts_triggers`, and that offline repair **fails closed** — it never
+> reports success while foreign-gated corruption survives (a
+> `PRAGMA integrity_check` premise correction: the read probe cannot be
+> isolated via `_db_opens_cleanly is None` because integrity_check already
+> catches corrupt `_data`; the gate is pinned end-to-end via the repair
+> path). Validation after the round: registry + trigram/CJK + repair +
+> narrowing suites 116 passed / 29 skipped, `test_hermes_state.py` 178 passed,
+> ruff clean.
+
 ## The six authoritative members
 
 1. `messages_fts`

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1532,6 +1532,72 @@ def _db_opens_cleanly(db_path: Path) -> Optional[str]:
         conn.close()
 
 
+def _owned_fts_object_names(conn: sqlite3.Connection) -> List[str]:
+    """Every ``sqlite_master`` object name Hermes owns for the six modern FTS
+    indexes (issue #27): the virtual tables, their FTS5 shadow tables, their
+    owned triggers, and owned derived source VIEWs.
+
+    Used by destructive derived-index repair (strategy 2). Ownership is
+    registry-driven for five members; for ``sessions_fts_trigram`` the #30
+    same-name rule applies — the trigram namespace is removed ONLY when the
+    stored root declaration positively matches the canonical modern trigram
+    shape, otherwise it is left untouched (fail closed). ``conn`` must be
+    open and readable.
+    """
+    names: List[str] = []
+    for desc in FTS_INDEXES:
+        names.append(desc.table)
+        names.extend(
+            f"{desc.table}_{shadow}"
+            for shadow in ("data", "idx", "content", "docsize", "config")
+        )
+        names.extend(desc.trigger_names)
+        names.extend(obj_name for _obj_type, obj_name in desc.derived_objects)
+    # #30 fail-closed: an unknown same-name trigram object is NOT owned — it
+    # must never be removed by the destructive path (or its source VIEW).
+    trigram = _fts_descriptor("sessions_fts_trigram")
+    row = conn.execute(
+        "SELECT sql FROM sqlite_master "
+        "WHERE type = 'table' AND name = ?",
+        (trigram.table,),
+    ).fetchone()
+    owned_trigram = (
+        row is not None
+        and SessionDB._sessions_trigram_modern_definition_matches(
+            row[0] if not isinstance(row, sqlite3.Row) else row["sql"]
+        )
+    )
+    if not owned_trigram:
+        names = [n for n in names if not n.startswith("sessions_fts_trigram")]
+    return names
+
+
+def _drop_owned_fts_derived_schema(conn: sqlite3.Connection) -> None:
+    """Destructive derived-index repair for the six modern FTS indexes.
+
+    Removes every owned derived FTS object (virtual tables, FTS5 shadow
+    tables, owned triggers, and owned source VIEWs) for ALL six members while
+    leaving canonical ``sessions`` / ``messages`` untouched. Reopen recreates
+    the supported derived schema. An unknown #30 same-name
+    ``sessions_fts_trigram`` object is positively classified and left
+    untouched (``_owned_fts_object_names``). Intended as the last-resort
+    escalation after least-destructive repair failed; normal startup /
+    quarantine remains stricter than this explicit command.
+    """
+    names = _owned_fts_object_names(conn)
+    placeholders = ", ".join("?" for _ in names)
+    conn.execute("PRAGMA writable_schema=ON")
+    conn.execute(
+        "DELETE FROM sqlite_master "
+        "WHERE type IN ('table', 'view', 'trigger', 'index') "
+        f"AND name IN ({placeholders})",
+        names,
+    )
+    conn.execute("PRAGMA writable_schema=OFF")
+    conn.commit()
+    conn.execute("VACUUM")
+
+
 def repair_state_db_schema(db_path: Path, *, backup: bool = True) -> Dict[str, Any]:
     """Repair a state.db whose ``sqlite_master`` schema is malformed or whose
     FTS indexes reject writes.
@@ -1539,19 +1605,25 @@ def repair_state_db_schema(db_path: Path, *, backup: bool = True) -> Dict[str, A
     Handles two corruption classes: the "duplicate object definition" /
     malformed-schema class where even ``PRAGMA`` statements fail, and the FTS
     write-corruption class (#50502) where base tables read fine and
-    ``integrity_check`` passes but writes fail through the ``messages_fts*``
+    ``integrity_check`` passes but writes fail through the ``*_fts*``
     triggers. Tries least-destructive recovery first and escalates:
 
       1. **Rebuild FTS indexes in place** via the FTS5 ``'rebuild'`` command,
          which rewrites the internal b-tree segments from the canonical
-         ``messages`` rows without dropping or recreating anything. Fixes the
-         FTS write-corruption class while preserving the schema intact.
+         content rows without dropping or recreating anything. Iterates the
+         authoritative six-index registry (issue #27), so corrupt session
+         Unicode/CJK/trigram metadata indexes are repaired alongside the
+         message indexes. Fixes the FTS write-corruption class while
+         preserving the schema intact.
       2. **De-duplicate** ``sqlite_master`` (keep the lowest rowid per
          ``type``/``name``). Fixes the canonical "table X already exists"
          case and PRESERVES the existing FTS index intact.
-      3. **Drop the FTS schema** (every ``messages_fts*`` object) + ``VACUUM``.
-         The next ``SessionDB()`` open rebuilds the FTS indexes from the
-         canonical ``messages`` table.
+      3. **Drop the owned FTS schema** (every owned modern FTS table, shadow
+         table, trigger, and source VIEW across all six indexes — never
+         canonical ``sessions``/``messages``) + ``VACUUM``. The next
+         ``SessionDB()`` open rebuilds the FTS indexes from canonical data.
+         An unknown #30 same-name ``sessions_fts_trigram`` object is
+         positively classified and left untouched (fail closed).
 
     Canonical ``sessions`` / ``messages`` rows are never modified. A
     timestamped raw backup is taken first unless ``backup=False``.
@@ -1584,22 +1656,26 @@ def repair_state_db_schema(db_path: Path, *, backup: bool = True) -> Dict[str, A
     # The FTS5 'rebuild' command rewrites the internal index from the canonical
     # content table. This is the recommended, least-destructive recovery for a
     # corrupt FTS index that rejects message writes while reads still succeed.
+    # Iterates the authoritative six-index registry (issue #27), so corrupt
+    # session Unicode/CJK/trigram indexes are repaired by the same path;
+    # 'rebuild' reads through each table's declared content source (the
+    # session trigram rebuilds through its derived compact VIEW — no compact
+    # SQL duplicated here). Optional tokenizer-gated indexes skip when their
+    # tokenizer is unavailable — capability degradation, not corruption.
     try:
         conn = sqlite3.connect(str(db_path), isolation_level=None)
         try:
-            # The cjk index can only be rebuilt with its tokenizer loaded;
-            # best-effort (a tokenizer-less host skips it at the probe below).
+            # The cjk indexes can only be rebuilt with their tokenizer loaded;
+            # best-effort (a tokenizer-less host skips them at the probe below).
             load_fts5_cjk_extension(conn)
-            for table_name in (
-                "messages_fts", "messages_fts_trigram", "messages_fts_cjk"
-            ):
+            for desc in FTS_INDEXES:
                 try:
                     conn.execute(
-                        f"INSERT INTO {table_name}({table_name}) VALUES('rebuild')"
+                        f"INSERT INTO {desc.table}({desc.table}) VALUES('rebuild')"
                     )
                 except sqlite3.OperationalError:
-                    # Table absent (FTS disabled / trigram off / cjk not
-                    # present or tokenizer unavailable) — skip it.
+                    # Table absent (FTS disabled / tokenizer unavailable /
+                    # not yet created) — skip it.
                     continue
         finally:
             conn.close()
@@ -1667,15 +1743,17 @@ def repair_state_db_schema(db_path: Path, *, backup: bool = True) -> Dict[str, A
     except sqlite3.DatabaseError as exc:
         logger.warning("state.db dedup repair pass failed: %s", exc)
 
-    # ── Strategy 2: drop all FTS schema, VACUUM, rebuild on next open ──
+    # ── Strategy 2: drop owned FTS schema, VACUUM, rebuild on next open ──
+    # Removes the owned derived FTS objects for ALL six modern indexes —
+    # virtual tables, shadow tables, owned triggers, and owned source VIEWs —
+    # while canonical sessions/messages rows are untouched. Reopen recreates
+    # the supported derived schema. An unknown #30 same-name
+    # sessions_fts_trigram object is positively classified and left untouched
+    # (fail closed), per _owned_fts_object_names.
     try:
         conn = sqlite3.connect(str(db_path), isolation_level=None)
         try:
-            conn.execute("PRAGMA writable_schema=ON")
-            conn.execute("DELETE FROM sqlite_master WHERE name LIKE 'messages_fts%'")
-            conn.execute("PRAGMA writable_schema=OFF")
-            conn.commit()
-            conn.execute("VACUUM")
+            _drop_owned_fts_derived_schema(conn)
         finally:
             conn.close()
         reason = _db_opens_cleanly(db_path)
@@ -1683,8 +1761,9 @@ def repair_state_db_schema(db_path: Path, *, backup: bool = True) -> Dict[str, A
             report["repaired"] = True
             report["strategy"] = "drop_fts_rebuild"
             logger.warning(
-                "state.db schema repaired by dropping FTS schema; indexes "
-                "will rebuild from messages on next open: %s", db_path
+                "state.db schema repaired by dropping owned FTS schema; "
+                "indexes will rebuild from canonical data on next open: %s",
+                db_path,
             )
             return report
         report["error"] = reason

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -55,11 +55,14 @@ from hermes_state_common import (  # noqa: F401  (re-exported for back-compat)
     _LISTABLE_CHILD_SQL,
     _PREVIEW_RAW_SELECT,
     _ephemeral_child_sql,
+    _fts_descriptor,
     _shape_preview,
     _sql_session_last_active,
     _sql_session_last_active_by_id,
     DEFERRED_INDEX_SQL,
     FTS_CJK_STALE_KEY,
+    FTS_INDEXES,
+    FtsIndexDescriptor,
     FTS_SESSION_CJK_STALE_KEY,
     FTS_SQL,
     FTS_SESSION_TRIGRAM_STALE_KEY,
@@ -10787,12 +10790,6 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         return sessions
 
     # ── Space reclamation ──
-
-    # FTS5 virtual tables whose b-tree segments we merge on optimize. The
-    # trigram table is created lazily / may be disabled, and the cjk-bigram
-    # table only exists (and is only queryable) when the loadable tokenizer
-    # is present — so we probe each before touching it (see optimize_fts).
-    _FTS_TABLES = ("messages_fts", "messages_fts_trigram", "messages_fts_cjk")
 
     def logical_size_bytes(self) -> Optional[int]:
         """Database size in bytes as SQLite itself accounts for it.

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -44,14 +44,13 @@ from hermes_constants import get_hermes_home
 from hermes_cli.sqlite_runtime import (
     is_sqlite_wal_reset_vulnerable as _is_sqlite_wal_reset_vulnerable,
 )
-from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar
+from typing import Any, Callable, Collection, Dict, List, Optional, Tuple, TypeVar
 
 from hermes_state_common import (  # noqa: F401  (re-exported for back-compat)
     _BRANCH_CHILD_SQL,
     _COMPRESSION_CHILD_SQL,
     _FTS_CJK_TRIGGERS,
     _FTS_SESSION_CJK_TRIGGERS,
-    _FTS_TRIGGERS,
     _LISTABLE_CHILD_SQL,
     _PREVIEW_RAW_SELECT,
     _ephemeral_child_sql,
@@ -3874,38 +3873,29 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             self._fts_cjk_available = False
 
     @staticmethod
-    def _drop_fts_triggers(cursor: sqlite3.Cursor) -> None:
-        """Drop every owned modern FTS trigger (whole-FTS5-unavailable
-        teardown).
+    def _drop_fts_triggers(
+        cursor: sqlite3.Cursor,
+        names: Optional[Collection[str]] = None,
+    ) -> None:
+        """Drop owned modern FTS triggers.
 
-        Derives the trigger inventory from the authoritative ``FTS_INDEXES``
-        registry (issue #27), so the degraded-runtime teardown knows about the
-        session-title triggers too — not just the message ones (pitfall 6).
-        Drop is by exact owned trigger name; the dedicated CJK/trigram
-        tokenizer-loss quarantine paths remain separate and preserve stale
-        ordering / #30 exact ownership — registry membership is not permission
-        to touch those here.
+        Defaults to every owned modern trigger across the six-index registry
+        (whole-FTS5-unavailable teardown), so the degraded-runtime teardown
+        knows about the session-title triggers too — not just the message ones
+        (pitfall 6). ``names`` narrows the drop to an explicit subset — e.g.
+        the message Unicode/trigram triggers during the v22→v23 demote, which
+        re-creates the message schema immediately and must leave session
+        metadata triggers live. Drop is by exact owned trigger name; the
+        dedicated CJK/trigram tokenizer-loss quarantine paths remain separate
+        and preserve stale ordering / #30 exact ownership — registry
+        membership is not permission to touch those here.
         """
-        for desc in FTS_INDEXES:
-            for trigger in desc.trigger_names:
-                try:
-                    cursor.execute(f"DROP TRIGGER IF EXISTS {trigger}")
-                except sqlite3.OperationalError:
-                    pass
-
-    @staticmethod
-    def _drop_message_fts_triggers(cursor: sqlite3.Cursor) -> None:
-        """Drop the MESSAGE FTS triggers only (v22→v23 demote path).
-
-        The demote re-creates the message schema immediately, so only the
-        message Unicode/trigram triggers are torn down there; session
-        metadata triggers stay live during the message-layout migration.
-        Names derive from the authoritative registry (issue #27).
-        """
-        names = (
-            _fts_descriptor("messages_fts").trigger_names
-            + _fts_descriptor("messages_fts_trigram").trigger_names
-        )
+        if names is None:
+            names = (
+                trigger
+                for desc in FTS_INDEXES
+                for trigger in desc.trigger_names
+            )
         for trigger in names:
             try:
                 cursor.execute(f"DROP TRIGGER IF EXISTS {trigger}")

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1434,7 +1434,15 @@ def _db_opens_cleanly(db_path: Path) -> Optional[str]:
         # Catch the full sqlite3 exception hierarchy (not just
         # OperationalError) so the malformed-shadow-table class is reported
         # rather than letting it crash the caller.
-        for fts_table in (desc.table for desc in FTS_INDEXES):
+        for desc in FTS_INDEXES:
+            fts_table = desc.table
+            # #30 fail-closed (issue #27 review R2 P1): an unknown same-name
+            # ``sessions_fts_trigram`` is outside owned repair — never probe
+            # it (or its corrupt data) as an owned candidate.
+            if fts_table == "sessions_fts_trigram" and not (
+                SessionDB._sessions_trigram_owned(conn)
+            ):
+                continue
             try:
                 # No-op queries against the actual FTS5 APIs the search
                 # tools use. The session indexes are included because they
@@ -1552,21 +1560,13 @@ def _owned_fts_object_names(conn: sqlite3.Connection) -> List[str]:
         )
         names.extend(desc.trigger_names)
         names.extend(obj_name for _obj_type, obj_name in desc.derived_objects)
-    # #30 fail-closed: an unknown same-name trigram object is NOT owned — it
-    # must never be removed by the destructive path (or its source VIEW).
-    trigram = _fts_descriptor("sessions_fts_trigram")
-    row = conn.execute(
-        "SELECT sql FROM sqlite_master "
-        "WHERE type = 'table' AND name = ?",
-        (trigram.table,),
-    ).fetchone()
-    owned_trigram = (
-        row is not None
-        and SessionDB._sessions_trigram_modern_definition_matches(
-            row[0] if not isinstance(row, sqlite3.Row) else row["sql"]
-        )
-    )
-    if not owned_trigram:
+    # #30 fail-closed (issue #27 review R2 P1): an unknown same-name trigram
+    # object is NOT owned — the destructive path must never remove it (or its
+    # source VIEW / shadow / trigger namespace). Reuses the full #30
+    # classifier (root + source VIEW + trigger namespace), not root DDL alone,
+    # so a canonical root with a foreign source VIEW or foreign trigger is
+    # also left untouched.
+    if not SessionDB._sessions_trigram_owned(conn):
         names = [n for n in names if not n.startswith("sessions_fts_trigram")]
     return names
 
@@ -1668,6 +1668,14 @@ def repair_state_db_schema(db_path: Path, *, backup: bool = True) -> Dict[str, A
             # best-effort (a tokenizer-less host skips them at the probe below).
             load_fts5_cjk_extension(conn)
             for desc in FTS_INDEXES:
+                # #30 fail-closed (issue #27 review R2 P1): a foreign same-name
+                # sessions_fts_trigram can legally accept the 'rebuild' command
+                # — never mutate it through the registry. Only a positively
+                # owned namespace is rebuilt.
+                if desc.table == "sessions_fts_trigram" and not (
+                    SessionDB._sessions_trigram_owned(conn)
+                ):
+                    continue
                 try:
                     conn.execute(
                         f"INSERT INTO {desc.table}({desc.table}) VALUES('rebuild')"
@@ -2429,11 +2437,16 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     # pending/stale state. A failed connection-local load
                     # degrades to fallback, never a crash or a false "CJK
                     # available" claim.
-                    self._sessions_cjk_worker_operable = (
-                        load_fts5_cjk_extension(self._conn)
-                    )
+                    #
+                    # The loaded flag is a LOCAL for read-only discovery only:
+                    # a mode=ro connection must never publish itself as a
+                    # mutating CJK worker just because it can load the
+                    # tokenizer (#35 handoff P2) — only search-serving
+                    # availability is derived here.
+                    cjk_loaded = load_fts5_cjk_extension(self._conn)
+                    self._sessions_cjk_worker_operable = False
                     self._sessions_cjk_available = False
-                    if self._sessions_cjk_worker_operable and cursor.execute(
+                    if cjk_loaded and cursor.execute(
                         "SELECT 1 FROM sqlite_master "
                         "WHERE type = 'table' AND name = 'sessions_fts_cjk'"
                     ).fetchone() is not None:
@@ -3358,6 +3371,27 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         return (not foreign), foreign, []
 
     @staticmethod
+    def _sessions_trigram_owned(cursor) -> bool:
+        """True when the same-name ``sessions_fts_trigram`` namespace is
+        positively Hermes-owned (#30, issue #27 review R2 P1).
+
+        Reuses the existing #30 classifiers rather than re-implementing a
+        weaker root-DDL-only check: the root must classify as the canonical
+        modern trigram (which itself requires the canonical derived source
+        VIEW) AND the trigger namespace must have no foreign occupant. A
+        missing owned trigger does not disqualify — the namespace is still
+        ours to probe/maintain/delete. ``cursor`` may be a Cursor or a
+        Connection (SELECT-only).
+        """
+        classification = SessionDB._classify_sessions_fts_trigram(cursor)
+        if classification != "modern_trigram":
+            return False
+        _owned, foreign, _missing = SessionDB._sessions_trigram_namespace_owned(
+            cursor, classification
+        )
+        return not foreign
+
+    @staticmethod
     def _classify_sessions_fts_trigram(cursor) -> str:
         """Classify the same-name ``sessions_fts_trigram`` object by schema
         identity (normalized stored ``sqlite_master.sql`` comparisons), NEVER
@@ -3896,7 +3930,17 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 for desc in FTS_INDEXES
                 for trigger in desc.trigger_names
             )
+        # #30 fail-closed (issue #27 review R2 P1): the whole-FTS5-unavailable
+        # teardown must not drop a foreign occupant of a
+        # ``sessions_fts_trigram_*`` trigger name — only the exact owned
+        # modern declaration is dropped (absent = nothing to drop).
+        trigram_status = SessionDB._sessions_trigram_trigger_status(cursor)
         for trigger in names:
+            if (
+                trigger.startswith("sessions_fts_trigram")
+                and trigram_status.get(trigger) != "exact_modern"
+            ):
+                continue
             try:
                 cursor.execute(f"DROP TRIGGER IF EXISTS {trigger}")
             except sqlite3.OperationalError:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2390,6 +2390,37 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                             )
                             is True
                         )
+                    # Session Unicode metadata index (issue #25): SELECT-only
+                    # capability discovery — a read-only connection must be
+                    # able to serve session-title search through the raw
+                    # Unicode sessions_fts lane without any schema init.
+                    self._sessions_fts_available = (
+                        self._fts_table_probe(cursor, "sessions_fts") is True
+                    )
+                    # Session normalized trigram (issue #30): SELECT-only
+                    # discovery with #30 ownership classification. The lane is
+                    # served only when the root is positively a canonical
+                    # modern trigram object, this connection can tokenize it,
+                    # and it is not durably stale — an unknown same-name
+                    # object is never served (fail closed), and a pending/
+                    # stale lane never serves (worker-vs-serving distinction
+                    # preserved). No DDL / stale mutation / trigger repair
+                    # from a read-only open.
+                    self._sessions_trigram_available = False
+                    if (
+                        SessionDB._classify_sessions_fts_trigram(cursor)
+                        == "modern_trigram"
+                        and self._fts_table_probe(
+                            cursor, "sessions_fts_trigram"
+                        )
+                        is True
+                    ):
+                        stale = cursor.execute(
+                            "SELECT 1 FROM state_meta "
+                            "WHERE key = ? LIMIT 1",
+                            (FTS_SESSION_TRIGRAM_STALE_KEY,),
+                        ).fetchone()
+                        self._sessions_trigram_available = stale is None
                     # Session CJK metadata (issue #26): load the cjk_unicode61
                     # tokenizer on THIS connection FIRST — custom FTS5
                     # tokenizers are connection-local, and a vtable using one

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1436,9 +1436,7 @@ def _db_opens_cleanly(db_path: Path) -> Optional[str]:
         # rather than letting it crash the caller.
         for desc in FTS_INDEXES:
             fts_table = desc.table
-            # #30 fail-closed (issue #27 review R2 P1): an unknown same-name
-            # ``sessions_fts_trigram`` is outside owned repair — never probe
-            # it (or its corrupt data) as an owned candidate.
+            # #30 fail-closed: never probe a trigram namespace we don't own.
             if fts_table == "sessions_fts_trigram" and not (
                 SessionDB._sessions_trigram_owned(conn)
             ):
@@ -1560,12 +1558,8 @@ def _owned_fts_object_names(conn: sqlite3.Connection) -> List[str]:
         )
         names.extend(desc.trigger_names)
         names.extend(obj_name for _obj_type, obj_name in desc.derived_objects)
-    # #30 fail-closed (issue #27 review R2 P1): an unknown same-name trigram
-    # object is NOT owned — the destructive path must never remove it (or its
-    # source VIEW / shadow / trigger namespace). Reuses the full #30
-    # classifier (root + source VIEW + trigger namespace), not root DDL alone,
-    # so a canonical root with a foreign source VIEW or foreign trigger is
-    # also left untouched.
+    # #30 fail-closed: the destructive path never touches a trigram namespace
+    # we don't own.
     if not SessionDB._sessions_trigram_owned(conn):
         names = [n for n in names if not n.startswith("sessions_fts_trigram")]
     return names
@@ -1668,10 +1662,8 @@ def repair_state_db_schema(db_path: Path, *, backup: bool = True) -> Dict[str, A
             # best-effort (a tokenizer-less host skips them at the probe below).
             load_fts5_cjk_extension(conn)
             for desc in FTS_INDEXES:
-                # #30 fail-closed (issue #27 review R2 P1): a foreign same-name
-                # sessions_fts_trigram can legally accept the 'rebuild' command
-                # — never mutate it through the registry. Only a positively
-                # owned namespace is rebuilt.
+                # #30 fail-closed: never 'rebuild' a trigram namespace we
+                # don't own (a foreign FTS5 table accepts the command).
                 if desc.table == "sessions_fts_trigram" and not (
                     SessionDB._sessions_trigram_owned(conn)
                 ):
@@ -2405,16 +2397,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                         self._fts_table_probe(cursor, "sessions_fts") is True
                     )
                     # Session normalized trigram (issue #30): SELECT-only
-                    # discovery with #30 ownership classification. The lane is
-                    # served only when the whole namespace is positively
-                    # owned — canonical modern root + derived source VIEW +
-                    # trigger namespace with no foreign occupant (issue #27
-                    # review R3) — this connection can tokenize it, and it is
-                    # not durably stale. A foreign same-name object anywhere
-                    # in the namespace is never served (fail closed), and a
-                    # pending/stale lane never serves (worker-vs-serving
-                    # distinction preserved). No DDL / stale mutation /
-                    # trigger repair from a read-only open.
+                    # discovery — served only when the whole namespace is
+                    # #30-owned (root + source VIEW + trigger namespace),
+                    # this connection can tokenize it, and it is not durably
+                    # stale. No DDL / mutation from a read-only open.
                     self._sessions_trigram_available = False
                     if (
                         SessionDB._sessions_trigram_owned(cursor)
@@ -3374,15 +3360,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     @staticmethod
     def _sessions_trigram_owned(cursor) -> bool:
         """True when the same-name ``sessions_fts_trigram`` namespace is
-        positively Hermes-owned (#30, issue #27 review R2 P1).
-
-        Reuses the existing #30 classifiers rather than re-implementing a
-        weaker root-DDL-only check: the root must classify as the canonical
-        modern trigram (which itself requires the canonical derived source
-        VIEW) AND the trigger namespace must have no foreign occupant. A
-        missing owned trigger does not disqualify — the namespace is still
-        ours to probe/maintain/delete. ``cursor`` may be a Cursor or a
-        Connection (SELECT-only).
+        #30-owned: canonical modern root + derived source VIEW, and no
+        foreign occupant in the trigger namespace (a missing owned trigger
+        does not disqualify). ``cursor`` may be a Cursor or Connection
+        (SELECT-only).
         """
         classification = SessionDB._classify_sessions_fts_trigram(cursor)
         if classification != "modern_trigram":
@@ -3931,10 +3912,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 for desc in FTS_INDEXES
                 for trigger in desc.trigger_names
             )
-        # #30 fail-closed (issue #27 review R2 P1): the whole-FTS5-unavailable
-        # teardown must not drop a foreign occupant of a
-        # ``sessions_fts_trigram_*`` trigger name — only the exact owned
-        # modern declaration is dropped (absent = nothing to drop).
+        # #30 fail-closed: never drop a foreign occupant of a
+        # ``sessions_fts_trigram_*`` name — only the exact modern owned
+        # declaration (absent = nothing to drop).
         trigram_status = SessionDB._sessions_trigram_trigger_status(cursor)
         for trigger in names:
             if (

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2397,13 +2397,24 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                         self._fts_table_probe(cursor, "sessions_fts") is True
                     )
                     # Session normalized trigram (issue #30): SELECT-only
-                    # discovery — served only when the whole namespace is
-                    # #30-owned (root + source VIEW + trigger namespace),
-                    # this connection can tokenize it, and it is not durably
-                    # stale. No DDL / mutation from a read-only open.
+                    # discovery — served only when the root + source VIEW are
+                    # canonical AND the trigger set is COMPLETE (owned ==
+                    # True: no foreign, no missing live trigger — a missing
+                    # trigger can leave the index stale/incomplete). This
+                    # connection can tokenize it and it is not durably stale.
+                    # No DDL / mutation from a read-only open.
                     self._sessions_trigram_available = False
+                    classification = (
+                        SessionDB._classify_sessions_fts_trigram(cursor)
+                    )
+                    owned, _foreign, _missing = (
+                        SessionDB._sessions_trigram_namespace_owned(
+                            cursor, classification
+                        )
+                    )
                     if (
-                        SessionDB._sessions_trigram_owned(cursor)
+                        classification == "modern_trigram"
+                        and owned
                         and self._fts_table_probe(
                             cursor, "sessions_fts_trigram"
                         )

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2406,17 +2406,18 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     )
                     # Session normalized trigram (issue #30): SELECT-only
                     # discovery with #30 ownership classification. The lane is
-                    # served only when the root is positively a canonical
-                    # modern trigram object, this connection can tokenize it,
-                    # and it is not durably stale — an unknown same-name
-                    # object is never served (fail closed), and a pending/
-                    # stale lane never serves (worker-vs-serving distinction
-                    # preserved). No DDL / stale mutation / trigger repair
-                    # from a read-only open.
+                    # served only when the whole namespace is positively
+                    # owned — canonical modern root + derived source VIEW +
+                    # trigger namespace with no foreign occupant (issue #27
+                    # review R3) — this connection can tokenize it, and it is
+                    # not durably stale. A foreign same-name object anywhere
+                    # in the namespace is never served (fail closed), and a
+                    # pending/stale lane never serves (worker-vs-serving
+                    # distinction preserved). No DDL / stale mutation /
+                    # trigger repair from a read-only open.
                     self._sessions_trigram_available = False
                     if (
-                        SessionDB._classify_sessions_fts_trigram(cursor)
-                        == "modern_trigram"
+                        SessionDB._sessions_trigram_owned(cursor)
                         and self._fts_table_probe(
                             cursor, "sessions_fts_trigram"
                         )

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1419,10 +1419,12 @@ def _db_opens_cleanly(db_path: Path) -> Optional[str]:
             return "; ".join(problems[:3])
         conn.execute("SELECT COUNT(*) FROM sessions").fetchone()
 
-        # FTS5 read probe: run a representative MATCH query against the
-        # messages_fts* virtual tables. The FTS *write* probe below catches
-        # the corruption class where base tables read fine but writes fail
-        # through the triggers (#50502). It does NOT catch partial FTS5
+        # FTS5 read probe: run a representative MATCH query against every
+        # owned modern FTS index derived from the authoritative ``FTS_INDEXES``
+        # registry (issue #27) — the three message indexes AND the session
+        # Unicode/CJK/trigram metadata indexes. The FTS *write* probe below
+        # catches the corruption class where base tables read fine but writes
+        # fail through the triggers (#50502). It does NOT catch partial FTS5
         # index corruption — bad shadow-table segments where reads still
         # parse but MATCH / snippet / rank queries error out with
         # "database disk image is malformed" (a `sqlite3.DatabaseError`,
@@ -1433,16 +1435,16 @@ def _db_opens_cleanly(db_path: Path) -> Optional[str]:
         # Catch the full sqlite3 exception hierarchy (not just
         # OperationalError) so the malformed-shadow-table class is reported
         # rather than letting it crash the caller.
-        for fts_table in ("messages_fts", "messages_fts_trigram", "messages_fts_cjk"):
+        for fts_table in (desc.table for desc in FTS_INDEXES):
             try:
                 # No-op queries against the actual FTS5 APIs the search
-                # tools use. The trigram table is included because it backs
-                # the title-resolution path; either corruption mode would
-                # break session recall without this probe. MATCH '""' is
-                # the empty phrase-token probe — FTS5 rejects MATCH ''
-                # outright ("fts5: syntax error"), but a quoted empty
-                # phrase parses, scans zero rows, and exercises the same
-                # shadow-table read path the search tools use.
+                # tools use. The session indexes are included because they
+                # back the title-resolution / session-search paths; either
+                # corruption mode would break session recall without this
+                # probe. MATCH '""' is the empty phrase-token probe — FTS5
+                # rejects MATCH '' outright ("fts5: syntax error"), but a
+                # quoted empty phrase parses, scans zero rows, and exercises
+                # the same shadow-table read path the search tools use.
                 conn.execute(
                     f"SELECT 1 FROM {fts_table} WHERE {fts_table} MATCH '\"\"' LIMIT 1"
                 ).fetchone()
@@ -1476,18 +1478,30 @@ def _db_opens_cleanly(db_path: Path) -> Optional[str]:
                 # while reads of the FTS5 table itself parse fine.
                 return f"fts5 read probe failed on {fts_table}: {exc}"
 
-        # FTS write probe: drive a row through the messages_fts* triggers in a
-        # transaction that is always rolled back, so a corrupt FTS index that
-        # rejects writes is caught even though reads look healthy. The probe is
-        # best-effort — if the messages/sessions tables don't exist yet (brand
-        # new file mid-init) the OperationalError is treated as "not yet a
-        # populated DB", not corruption.
+        # FTS write probe: drive a row through the messages_fts* AND
+        # sessions_fts* triggers in a transaction that is always rolled back,
+        # so a corrupt FTS index that rejects writes is caught even though
+        # reads look healthy. The probe is best-effort — if the
+        # messages/sessions tables don't exist yet (brand new file mid-init)
+        # the OperationalError is treated as "not yet a populated DB", not
+        # corruption. Since #27, the probe session carries non-null
+        # ``title`` / ``display_name`` so the session Unicode/CJK/trigram
+        # INSERT triggers execute their REAL projection (a broken
+        # session-title trigger / session FTS write is detected without
+        # persisting probe data).
         probe_session_id = f"_hermes_fts_health_probe_{time.time_ns()}"
         try:
             conn.execute("BEGIN IMMEDIATE")
             conn.execute(
-                "INSERT INTO sessions (id, source, started_at) VALUES (?, ?, ?)",
-                (probe_session_id, "_health_probe", time.time()),
+                "INSERT INTO sessions (id, source, started_at, title, "
+                "display_name) VALUES (?, ?, ?, ?, ?)",
+                (
+                    probe_session_id,
+                    "_health_probe",
+                    time.time(),
+                    "_fts_health_title_probe",
+                    "_fts_health_display_probe",
+                ),
             )
             conn.execute(
                 "INSERT INTO messages (session_id, role, content, timestamp) "
@@ -3751,7 +3765,38 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
     @staticmethod
     def _drop_fts_triggers(cursor: sqlite3.Cursor) -> None:
-        for trigger in _FTS_TRIGGERS:
+        """Drop every owned modern FTS trigger (whole-FTS5-unavailable
+        teardown).
+
+        Derives the trigger inventory from the authoritative ``FTS_INDEXES``
+        registry (issue #27), so the degraded-runtime teardown knows about the
+        session-title triggers too — not just the message ones (pitfall 6).
+        Drop is by exact owned trigger name; the dedicated CJK/trigram
+        tokenizer-loss quarantine paths remain separate and preserve stale
+        ordering / #30 exact ownership — registry membership is not permission
+        to touch those here.
+        """
+        for desc in FTS_INDEXES:
+            for trigger in desc.trigger_names:
+                try:
+                    cursor.execute(f"DROP TRIGGER IF EXISTS {trigger}")
+                except sqlite3.OperationalError:
+                    pass
+
+    @staticmethod
+    def _drop_message_fts_triggers(cursor: sqlite3.Cursor) -> None:
+        """Drop the MESSAGE FTS triggers only (v22→v23 demote path).
+
+        The demote re-creates the message schema immediately, so only the
+        message Unicode/trigram triggers are torn down there; session
+        metadata triggers stay live during the message-layout migration.
+        Names derive from the authoritative registry (issue #27).
+        """
+        names = (
+            _fts_descriptor("messages_fts").trigger_names
+            + _fts_descriptor("messages_fts_trigram").trigger_names
+        )
+        for trigger in names:
             try:
                 cursor.execute(f"DROP TRIGGER IF EXISTS {trigger}")
             except sqlite3.OperationalError:

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -6,7 +6,8 @@ reference them without importing hermes_state (which would be a cycle).
 hermes_state re-imports every name here for backward compatibility.
 """
 
-from typing import Any, Optional
+from dataclasses import dataclass
+from typing import Any, Dict, List, Literal, Optional, Tuple
 
 from agent.skill_commands import (
     SKILL_EXCERPT_JOINT,
@@ -930,6 +931,140 @@ _FTS_SESSION_CJK_TRIGGERS = (
 # reads until a capable host resets and rebuilds. Distinct from the message
 # ``FTS_CJK_STALE_KEY`` and from the Unicode-session markers.
 FTS_SESSION_CJK_STALE_KEY = "fts_session_cjk_stale"
+
+
+# ── Authoritative FTS index registry (issue #27) ─────────────────────────
+# One data-only, module-level descriptor per modern external-content FTS
+# index, so module-level/offline repair code AND the SessionDB mixins can
+# consume the same membership source without importing ``hermes_state``
+# (which would be a cycle). The registry owns ONLY static index identity:
+# table, canonical/derived content source, row key, indexed columns, owned
+# modern trigger names, required capability class, and owned derived objects
+# (source VIEWs) needed by destructive derived-index repair.
+#
+# Deliberately NOT a search-routing or migration-state framework. Dynamic
+# concerns stay in their existing owners: H/P rebuild claims and stale
+# breadcrumbs (rebuild lanes / state_meta), worker-operable vs search-serving
+# state, #30 exact same-name root/source/trigger ownership classification,
+# search routing/ranking/fallback, and final storage-layout settlement.
+# In particular, the table name being present here is NOT authorization to
+# mutate ``sessions_fts_trigram`` — #30's ownership classifier remains the
+# gate and ``unknown_same_name`` stays fail-closed.
+#
+# The six authoritative modern members (the five-index list in old #12 prose
+# predates #30 and is historical only):
+#   1. messages_fts
+#   2. messages_fts_trigram
+#   3. messages_fts_cjk
+#   4. sessions_fts
+#   5. sessions_fts_cjk
+#   6. sessions_fts_trigram
+
+
+@dataclass(frozen=True)
+class FtsIndexDescriptor:
+    """Static identity for one modern external-content FTS index.
+
+    ``table`` is the FTS5 virtual table name; ``source`` the canonical or
+    derived content table/VIEW it reads through; ``row_key`` the named rowid
+    column; ``columns`` the indexed document columns (same order in FTS and
+    source); ``trigger_names`` the owned modern triggers that keep the index
+    live; ``capability`` the required tokenizer class (``fts5`` = built-in
+    base, ``trigram`` / ``cjk`` = optional/tokenizer-gated); and
+    ``derived_objects`` any owned derived schema (e.g. ``("view",
+    "sessions_fts_trigram_src")``) that destructive derived-index repair must
+    remove alongside the index.
+    """
+
+    table: str
+    source: str
+    row_key: str
+    columns: Tuple[str, ...]
+    trigger_names: Tuple[str, ...]
+    capability: Literal["fts5", "trigram", "cjk"]
+    derived_objects: Tuple[Tuple[str, str], ...] = ()
+
+
+# Ordered as the six authoritative modern members above.
+FTS_INDEXES: Tuple[FtsIndexDescriptor, ...] = (
+    FtsIndexDescriptor(
+        table="messages_fts",
+        source="messages",
+        row_key="id",
+        columns=("content", "tool_name", "tool_calls"),
+        trigger_names=(
+            "messages_fts_insert",
+            "messages_fts_delete",
+            "messages_fts_update",
+        ),
+        capability="fts5",
+    ),
+    FtsIndexDescriptor(
+        table="messages_fts_trigram",
+        source="messages_fts_trigram_src",
+        row_key="id",
+        columns=("content", "tool_name", "tool_calls"),
+        trigger_names=(
+            "messages_fts_trigram_insert",
+            "messages_fts_trigram_delete",
+            "messages_fts_trigram_update",
+        ),
+        capability="trigram",
+        derived_objects=(("view", "messages_fts_trigram_src"),),
+    ),
+    FtsIndexDescriptor(
+        table="messages_fts_cjk",
+        source="messages_fts_cjk_src",
+        row_key="id",
+        columns=("content", "tool_name", "tool_calls"),
+        trigger_names=_FTS_CJK_TRIGGERS,
+        capability="cjk",
+        derived_objects=(("view", "messages_fts_cjk_src"),),
+    ),
+    FtsIndexDescriptor(
+        table="sessions_fts",
+        source="sessions",
+        row_key="row_id",
+        columns=("title", "id", "display_name"),
+        trigger_names=(
+            "sessions_fts_insert",
+            "sessions_fts_delete",
+            "sessions_fts_update",
+        ),
+        capability="fts5",
+    ),
+    FtsIndexDescriptor(
+        table="sessions_fts_cjk",
+        source="sessions",
+        row_key="row_id",
+        columns=("title", "id", "display_name"),
+        trigger_names=_FTS_SESSION_CJK_TRIGGERS,
+        capability="cjk",
+    ),
+    FtsIndexDescriptor(
+        table="sessions_fts_trigram",
+        source="sessions_fts_trigram_src",
+        row_key="row_id",
+        columns=("title", "id", "display_name"),
+        trigger_names=(
+            "sessions_fts_trigram_insert",
+            "sessions_fts_trigram_delete",
+            "sessions_fts_trigram_update_before",
+            "sessions_fts_trigram_update_after",
+        ),
+        capability="trigram",
+        derived_objects=(("view", "sessions_fts_trigram_src"),),
+    ),
+)
+
+
+def _fts_descriptor(table: str) -> FtsIndexDescriptor:
+    """Look up the authoritative descriptor for *table* (issue #27)."""
+    for descriptor in FTS_INDEXES:
+        if descriptor.table == table:
+            return descriptor
+    raise KeyError(f"no FTS index descriptor registered for {table!r}")
+
 
 LEGACY_FTS_SQL = """
 CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -173,16 +173,6 @@ FTS_STORAGE_VERSION = 1
 MAX_FTS5_QUERY_CHARS = 2_048
 
 
-_FTS_TRIGGERS = (
-    "messages_fts_insert",
-    "messages_fts_delete",
-    "messages_fts_update",
-    "messages_fts_trigram_insert",
-    "messages_fts_trigram_delete",
-    "messages_fts_trigram_update",
-)
-
-
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS schema_version (
     version INTEGER NOT NULL

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -186,12 +186,14 @@ class SessionSchemaMixin:
                 try:
                     self._ensure_fts_cjk_schema(cursor)
                 except Exception:
+                    self._fts_cjk_available = False
                     self._quarantine_cjk_after_update_of_migration(cursor)
                     logger.exception(
                         "CJK FTS re-ensure after UPDATE OF migration failed"
                     )
                     raise
                 if not self._cjk_update_trigger_is_narrowed(cursor):
+                    self._fts_cjk_available = False
                     self._quarantine_cjk_after_update_of_migration(cursor)
                     logger.warning(
                         "CJK FTS UPDATE trigger missing or still broad after "
@@ -209,8 +211,15 @@ class SessionSchemaMixin:
         # + unavailable) so the index is never served over a trigger gap.
         if "sessions_fts_cjk_update" in to_drop:
             self._ensure_sessions_fts_cjk_schema(cursor)
-            if not self._sessions_cjk_update_trigger_is_narrowed(cursor):
-                self._quarantine_session_cjk_after_update_of_migration(cursor)
+            if not self._cjk_update_trigger_is_narrowed(
+                cursor, "sessions_fts_cjk_update"
+            ):
+                self._sessions_cjk_available = False
+                self._quarantine_cjk_after_update_of_migration(
+                    cursor,
+                    trigger_name="sessions_fts_cjk_update",
+                    stale_key=FTS_SESSION_CJK_STALE_KEY,
+                )
                 logger.warning(
                     "Session CJK FTS UPDATE trigger missing or still broad "
                     "after UPDATE OF migration; marked stale and unavailable"
@@ -223,12 +232,18 @@ class SessionSchemaMixin:
         )
         return len(to_drop)
 
-    def _cjk_update_trigger_is_narrowed(self, cursor: sqlite3.Cursor) -> bool:
-        """True when messages_fts_cjk_update exists with AFTER UPDATE OF."""
+    def _cjk_update_trigger_is_narrowed(
+        self,
+        cursor: sqlite3.Cursor,
+        trigger_name: str = "messages_fts_cjk_update",
+    ) -> bool:
+        """True when the named CJK UPDATE trigger exists with AFTER UPDATE OF
+        (message ``messages_fts_cjk_update`` by default, or the session
+        ``sessions_fts_cjk_update``)."""
         row = cursor.execute(
             "SELECT sql FROM sqlite_master "
             "WHERE type = 'trigger' AND name = ?",
-            ("messages_fts_cjk_update",),
+            (trigger_name,),
         ).fetchone()
         if not row:
             return False
@@ -236,69 +251,32 @@ class SessionSchemaMixin:
         return not self._fts_update_trigger_needs_narrowing(sql)
 
     def _quarantine_cjk_after_update_of_migration(
-        self, cursor: sqlite3.Cursor
+        self,
+        cursor: sqlite3.Cursor,
+        *,
+        trigger_name: str = "messages_fts_cjk_update",
+        stale_key: str = FTS_CJK_STALE_KEY,
     ) -> None:
-        """Fail-closed after dropping CJK UPDATE during OF migration.
+        """Fail-closed after dropping a CJK UPDATE during OF migration.
 
-        Clears availability, persists ``fts_cjk_stale``, and drops any
-        residual broad/partial CJK UPDATE trigger so a later open cannot
-        ``CREATE TRIGGER IF NOT EXISTS`` a gap without rebuild.
+        Persists the named stale breadcrumb and drops any residual
+        broad/partial CJK UPDATE trigger so a later capable open cannot
+        ``CREATE TRIGGER IF NOT EXISTS`` a gap without a from-scratch rebuild.
+        The caller clears its own search-serving availability flag (message
+        ``_fts_cjk_available`` / session ``_sessions_cjk_available``).
         """
-        self._fts_cjk_available = False
         try:
-            self.set_meta(FTS_CJK_STALE_KEY, "1", cursor=cursor)
+            self.set_meta(stale_key, "1", cursor=cursor)
         except Exception:
             logger.debug(
                 "Could not persist CJK FTS stale breadcrumb",
                 exc_info=True,
             )
         try:
-            cursor.execute("DROP TRIGGER IF EXISTS messages_fts_cjk_update")
+            cursor.execute(f"DROP TRIGGER IF EXISTS {trigger_name}")
         except Exception:
             logger.debug(
                 "Could not drop residual CJK UPDATE trigger after quarantine",
-                exc_info=True,
-            )
-
-    def _sessions_cjk_update_trigger_is_narrowed(
-        self, cursor: sqlite3.Cursor
-    ) -> bool:
-        """True when sessions_fts_cjk_update exists with AFTER UPDATE OF."""
-        row = cursor.execute(
-            "SELECT sql FROM sqlite_master "
-            "WHERE type = 'trigger' AND name = ?",
-            ("sessions_fts_cjk_update",),
-        ).fetchone()
-        if not row:
-            return False
-        sql = row[0] if not isinstance(row, sqlite3.Row) else row["sql"]
-        return not self._fts_update_trigger_needs_narrowing(sql)
-
-    def _quarantine_session_cjk_after_update_of_migration(
-        self, cursor: sqlite3.Cursor
-    ) -> None:
-        """Fail-closed after dropping the session-CJK UPDATE during OF
-        migration (issue #26).
-
-        Clears search-serving availability, persists the session-CJK stale
-        breadcrumb, and drops any residual broad/partial session-CJK UPDATE
-        trigger so a later capable open cannot ``CREATE TRIGGER IF NOT
-        EXISTS`` a gap without a from-scratch rebuild.
-        """
-        self._sessions_cjk_available = False
-        try:
-            self.set_meta(FTS_SESSION_CJK_STALE_KEY, "1", cursor=cursor)
-        except Exception:
-            logger.debug(
-                "Could not persist session CJK FTS stale breadcrumb",
-                exc_info=True,
-            )
-        try:
-            cursor.execute("DROP TRIGGER IF EXISTS sessions_fts_cjk_update")
-        except Exception:
-            logger.debug(
-                "Could not drop residual session-CJK UPDATE trigger after "
-                "quarantine",
                 exc_info=True,
             )
 

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -17,6 +17,7 @@ from hermes_constants import get_hermes_home
 from hermes_state_common import (
     DEFERRED_INDEX_SQL,
     FTS_CJK_STALE_KEY,
+    FTS_SESSION_CJK_STALE_KEY,
     FTS_SQL,
     FTS_STORAGE_VERSION,
     FTS_TRIGRAM_SQL,
@@ -24,11 +25,22 @@ from hermes_state_common import (
     LEGACY_FTS_TRIGRAM_SQL,
     SCHEMA_SQL,
     SCHEMA_VERSION,
+    SESSIONS_FTS_CJK_TRIGGER_SQL,
     SESSIONS_FTS_SQL,
     SESSION_INDEX_SQL_STATEMENTS,
     SESSION_TABLE_REBUILD_SQL,
-    _FTS_TRIGGERS,
     _ephemeral_child_sql,
+    _fts_descriptor,
+)
+
+# Message-lane owned trigger names, derived from the authoritative six-index
+# registry (issue #27). Used by the message trigger-repair detection and the
+# UPDATE-OF convergence migration; session triggers are handled separately
+# (session CJK through its own lifecycle, session trigram through #30 exact
+# identity).
+_MESSAGE_FTS_TRIGGERS = (
+    _fts_descriptor("messages_fts").trigger_names
+    + _fts_descriptor("messages_fts_trigram").trigger_names
 )
 
 # Moved methods logged under the "hermes_state" logger before the split;
@@ -73,11 +85,11 @@ class SessionSchemaMixin:
 
     @staticmethod
     def _fts_trigger_count(cursor: sqlite3.Cursor) -> int:
-        placeholders = ",".join("?" for _ in _FTS_TRIGGERS)
+        placeholders = ",".join("?" for _ in _MESSAGE_FTS_TRIGGERS)
         row = cursor.execute(
             f"SELECT COUNT(*) FROM sqlite_master "
             f"WHERE type = 'trigger' AND name IN ({placeholders})",
-            _FTS_TRIGGERS,
+            _MESSAGE_FTS_TRIGGERS,
         ).fetchone()
         return int(row[0] if not isinstance(row, sqlite3.Row) else row[0])
 
@@ -104,6 +116,15 @@ class SessionSchemaMixin:
         writes included). Inspect ``sqlite_master``, drop any still-broad
         UPDATE triggers, and re-apply the current DDL constants.
 
+        Since #27 the convergence covers the owned session-metadata UPDATE
+        triggers too: ``sessions_fts_update`` and (on a tokenizer-capable
+        host) ``sessions_fts_cjk_update`` converge from the broad dev-era
+        ``AFTER UPDATE ON sessions`` to the canonical narrow
+        ``AFTER UPDATE OF title, id, display_name``. The modern trigram
+        ``sessions_fts_trigram_update_before/_after`` are already canonical
+        narrow triggers and remain under #30's exact identity — never blindly
+        rewritten here.
+
         No FTS rebuild: content correctness was already gated by WHEN clauses
         on modern installs; OF only skips unnecessary trigger evaluation.
 
@@ -116,9 +137,13 @@ class SessionSchemaMixin:
         update_names = (
             "messages_fts_update",
             "messages_fts_trigram_update",
+            # Recognized/owned session Unicode metadata index (issue #25).
+            "sessions_fts_update",
         )
         if not legacy_layout and hasattr(self, "_ensure_fts_cjk_schema"):
             update_names += ("messages_fts_cjk_update",)
+        if not legacy_layout and hasattr(self, "_ensure_sessions_fts_cjk_schema"):
+            update_names += ("sessions_fts_cjk_update",)
         placeholders = ", ".join("?" for _ in update_names)
         rows = cursor.execute(
             "SELECT name, sql FROM sqlite_master "
@@ -173,6 +198,24 @@ class SessionSchemaMixin:
                         "UPDATE OF migration; marked stale and unavailable"
                     )
 
+        # Session Unicode metadata index (issue #25) is independent of the
+        # message layout, so re-apply its canonical narrow DDL whether or not
+        # the message layout is legacy.
+        if "sessions_fts_update" in to_drop:
+            self._ensure_fts_schema(cursor, "sessions_fts", SESSIONS_FTS_SQL)
+        # Session CJK metadata index (issue #26): re-ensure the surface (never
+        # raises; soft-fails to unavailable). If the narrow UPDATE trigger is
+        # still missing/broad afterwards, quarantine durably (stale breadcrumb
+        # + unavailable) so the index is never served over a trigger gap.
+        if "sessions_fts_cjk_update" in to_drop:
+            self._ensure_sessions_fts_cjk_schema(cursor)
+            if not self._sessions_cjk_update_trigger_is_narrowed(cursor):
+                self._quarantine_session_cjk_after_update_of_migration(cursor)
+                logger.warning(
+                    "Session CJK FTS UPDATE trigger missing or still broad "
+                    "after UPDATE OF migration; marked stale and unavailable"
+                )
+
         logger.info(
             "Migrated %d broad FTS UPDATE trigger(s) to AFTER UPDATE OF "
             "(no rebuild required)",
@@ -214,6 +257,48 @@ class SessionSchemaMixin:
         except Exception:
             logger.debug(
                 "Could not drop residual CJK UPDATE trigger after quarantine",
+                exc_info=True,
+            )
+
+    def _sessions_cjk_update_trigger_is_narrowed(
+        self, cursor: sqlite3.Cursor
+    ) -> bool:
+        """True when sessions_fts_cjk_update exists with AFTER UPDATE OF."""
+        row = cursor.execute(
+            "SELECT sql FROM sqlite_master "
+            "WHERE type = 'trigger' AND name = ?",
+            ("sessions_fts_cjk_update",),
+        ).fetchone()
+        if not row:
+            return False
+        sql = row[0] if not isinstance(row, sqlite3.Row) else row["sql"]
+        return not self._fts_update_trigger_needs_narrowing(sql)
+
+    def _quarantine_session_cjk_after_update_of_migration(
+        self, cursor: sqlite3.Cursor
+    ) -> None:
+        """Fail-closed after dropping the session-CJK UPDATE during OF
+        migration (issue #26).
+
+        Clears search-serving availability, persists the session-CJK stale
+        breadcrumb, and drops any residual broad/partial session-CJK UPDATE
+        trigger so a later capable open cannot ``CREATE TRIGGER IF NOT
+        EXISTS`` a gap without a from-scratch rebuild.
+        """
+        self._sessions_cjk_available = False
+        try:
+            self.set_meta(FTS_SESSION_CJK_STALE_KEY, "1", cursor=cursor)
+        except Exception:
+            logger.debug(
+                "Could not persist session CJK FTS stale breadcrumb",
+                exc_info=True,
+            )
+        try:
+            cursor.execute("DROP TRIGGER IF EXISTS sessions_fts_cjk_update")
+        except Exception:
+            logger.debug(
+                "Could not drop residual session-CJK UPDATE trigger after "
+                "quarantine",
                 exc_info=True,
             )
 
@@ -1130,7 +1215,7 @@ class SessionSchemaMixin:
             # DBs have no legacy inline FTS, so they get the v23 DDL.
             if self._db_has_legacy_inline_fts(cursor):
                 triggers_need_repair = (
-                    self._fts_trigger_count(cursor) < len(_FTS_TRIGGERS)
+                    self._fts_trigger_count(cursor) < len(_MESSAGE_FTS_TRIGGERS)
                 )
                 self._fts_enabled = self._ensure_fts_schema(
                     cursor, "messages_fts", LEGACY_FTS_SQL
@@ -1146,7 +1231,7 @@ class SessionSchemaMixin:
                         )
             else:
                 triggers_need_repair = (
-                    self._fts_trigger_count(cursor) < len(_FTS_TRIGGERS)
+                    self._fts_trigger_count(cursor) < len(_MESSAGE_FTS_TRIGGERS)
                 )
                 self._fts_enabled = self._ensure_fts_schema(
                     cursor, "messages_fts", FTS_SQL

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -299,35 +299,30 @@ _FTS_MESSAGE_CJK_SPEC = {
 # breadcrumb for the pending-work probe.
 _FTS_REBUILD_LANES: Tuple[Dict[str, Any], ...] = (
     {
-        "name": "messages",
         "spec": _FTS_MESSAGE_SPEC,
         "stale_key": None,
         "status": lambda self: self.fts_rebuild_status(),
         "step": lambda self: self.fts_rebuild_step(),
     },
     {
-        "name": "messages_cjk",
         "spec": _FTS_MESSAGE_CJK_SPEC,
         "stale_key": FTS_CJK_STALE_KEY,
         "status": lambda self: self.fts_cjk_rebuild_status(),
         "step": lambda self: self.fts_cjk_rebuild_step(),
     },
     {
-        "name": "sessions",
         "spec": _FTS_SESSION_SPEC,
         "stale_key": None,
         "status": lambda self: self.fts_session_rebuild_status(),
         "step": lambda self: self.fts_session_rebuild_step(),
     },
     {
-        "name": "sessions_trigram",
         "spec": _FTS_SESSION_TRIGRAM_SPEC,
         "stale_key": FTS_SESSION_TRIGRAM_STALE_KEY,
         "status": lambda self: self.fts_session_trigram_rebuild_status(),
         "step": lambda self: self.fts_session_trigram_rebuild_step(),
     },
     {
-        "name": "sessions_cjk",
         "spec": _FTS_SESSION_CJK_SPEC,
         "stale_key": FTS_SESSION_CJK_STALE_KEY,
         "status": lambda self: self.fts_session_cjk_rebuild_status(),
@@ -1305,10 +1300,16 @@ class SessionSearchMixin:
         """
         def _stage(conn):
             # Message-scoped teardown: the demote re-creates the message
-            # schema immediately, so only the message triggers are dropped
-            # here — session metadata triggers keep live-indexing during the
-            # message-layout migration (issue #27).
-            self._drop_message_fts_triggers(conn)
+            # schema immediately, so only the message Unicode/trigram triggers
+            # are dropped here — session metadata triggers keep live-indexing
+            # during the message-layout migration (issue #27).
+            self._drop_fts_triggers(
+                conn,
+                names=(
+                    _fts_descriptor("messages_fts").trigger_names
+                    + _fts_descriptor("messages_fts_trigram").trigger_names
+                ),
+            )
             conn.execute("DROP VIEW IF EXISTS messages_fts_trigram_src")
             had = bool(conn.execute(
                 "SELECT 1 FROM sqlite_master WHERE type = 'table' "

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -24,10 +24,12 @@ from hermes_state_common import (
     FTS_SESSION_TRIGRAM_STALE_KEY,
     FTS_STORAGE_VERSION,
     FTS_TRIGRAM_SQL,
+    FTS_INDEXES,
     MAX_FTS5_QUERY_CHARS,
     SCHEMA_VERSION,
     _FTS_CJK_TRIGGERS,
     _FTS_SESSION_CJK_TRIGGERS,
+    _fts_descriptor,
 )
 
 # Moved methods logged under the "hermes_state" logger before the split;
@@ -141,19 +143,37 @@ class _LineageResolutionState:
 # table, row key, and marker names differ. ``available`` /
 # ``trigram_available`` are callables taking the SessionDB host (the mixin
 # methods cannot read ``self._fts_enabled`` at import time).
+#
+# Static identity (table / source / row key / columns) is derived from the
+# authoritative ``FTS_INDEXES`` registry (issue #27) instead of being
+# repeated here, so membership can never drift from the lifecycle consumers;
+# lane-specific state (H/P marker keys, availability callbacks, reset
+# targets, finish hooks) stays in the specs.
+_MESSAGES_FTS_DESC = _fts_descriptor("messages_fts")
+_MESSAGES_TRIGRAM_DESC = _fts_descriptor("messages_fts_trigram")
+_MESSAGES_CJK_DESC = _fts_descriptor("messages_fts_cjk")
+_SESSIONS_FTS_DESC = _fts_descriptor("sessions_fts")
+_SESSIONS_CJK_DESC = _fts_descriptor("sessions_fts_cjk")
+_SESSIONS_TRIGRAM_DESC = _fts_descriptor("sessions_fts_trigram")
+
 _FTS_MESSAGE_SPEC = {
     "name": "messages",
     "high_water_key": "fts_rebuild_high_water",
     "progress_key": "fts_rebuild_progress",
-    "fts_table": "messages_fts",
-    "fts_columns": ("content", "tool_name", "tool_calls"),
-    "source_table": "messages",
-    "source_columns": ("content", "tool_name", "tool_calls"),
-    "row_key": "id",
-    "trigram_fts": "messages_fts_trigram",
-    "trigram_columns": ("content", "tool_name", "tool_calls"),
+    "descriptor": _MESSAGES_FTS_DESC,
+    "trigram_descriptor": _MESSAGES_TRIGRAM_DESC,
+    "fts_table": _MESSAGES_FTS_DESC.table,
+    "fts_columns": _MESSAGES_FTS_DESC.columns,
+    "source_table": _MESSAGES_FTS_DESC.source,
+    "source_columns": _MESSAGES_FTS_DESC.columns,
+    "row_key": _MESSAGES_FTS_DESC.row_key,
+    "trigram_fts": _MESSAGES_TRIGRAM_DESC.table,
+    "trigram_columns": _MESSAGES_TRIGRAM_DESC.columns,
     "trigram_where": "role <> 'tool'",
-    "reset_tables": ("messages_fts", "messages_fts_trigram"),
+    "reset_tables": (
+        _MESSAGES_FTS_DESC.table,
+        _MESSAGES_TRIGRAM_DESC.table,
+    ),
     "available": lambda self: self._fts_enabled,
     "trigram_available": lambda self: self._trigram_available,
 }
@@ -162,17 +182,18 @@ _FTS_SESSION_SPEC = {
     "name": "sessions",
     "high_water_key": "fts_session_rebuild_high_water",
     "progress_key": "fts_session_rebuild_progress",
-    "fts_table": "sessions_fts",
+    "descriptor": _SESSIONS_FTS_DESC,
+    "fts_table": _SESSIONS_FTS_DESC.table,
     # Raw canonical values only — no normalization / synthetic concatenation
     # (normalized arbitrary infix belongs to #30).
-    "fts_columns": ("title", "id", "display_name"),
-    "source_table": "sessions",
-    "source_columns": ("title", "id", "display_name"),
-    "row_key": "row_id",
+    "fts_columns": _SESSIONS_FTS_DESC.columns,
+    "source_table": _SESSIONS_FTS_DESC.source,
+    "source_columns": _SESSIONS_FTS_DESC.columns,
+    "row_key": _SESSIONS_FTS_DESC.row_key,
     "trigram_fts": None,
     "trigram_columns": (),
     "trigram_where": None,
-    "reset_tables": ("sessions_fts",),
+    "reset_tables": (_SESSIONS_FTS_DESC.table,),
     "available": lambda self: getattr(self, "_sessions_fts_available", False),
     "trigram_available": lambda self: False,
 }
@@ -189,15 +210,16 @@ _FTS_SESSION_TRIGRAM_SPEC = {
     "name": "sessions_trigram",
     "high_water_key": "fts_session_trigram_rebuild_high_water",
     "progress_key": "fts_session_trigram_rebuild_progress",
-    "fts_table": "sessions_fts_trigram",
-    "fts_columns": ("title", "id", "display_name"),
-    "source_table": "sessions_fts_trigram_src",
-    "source_columns": ("title", "id", "display_name"),
-    "row_key": "row_id",
+    "descriptor": _SESSIONS_TRIGRAM_DESC,
+    "fts_table": _SESSIONS_TRIGRAM_DESC.table,
+    "fts_columns": _SESSIONS_TRIGRAM_DESC.columns,
+    "source_table": _SESSIONS_TRIGRAM_DESC.source,
+    "source_columns": _SESSIONS_TRIGRAM_DESC.columns,
+    "row_key": _SESSIONS_TRIGRAM_DESC.row_key,
     "trigram_fts": None,
     "trigram_columns": (),
     "trigram_where": None,
-    "reset_tables": ("sessions_fts_trigram",),
+    "reset_tables": (_SESSIONS_TRIGRAM_DESC.table,),
     "available": lambda self: getattr(
         self, "_sessions_trigram_available", False
     ),
@@ -222,18 +244,47 @@ _FTS_SESSION_CJK_SPEC = {
     "name": "sessions_cjk",
     "high_water_key": "fts_session_cjk_rebuild_high_water",
     "progress_key": "fts_session_cjk_rebuild_progress",
-    "fts_table": "sessions_fts_cjk",
-    "fts_columns": ("title", "id", "display_name"),
-    "source_table": "sessions",
-    "source_columns": ("title", "id", "display_name"),
-    "row_key": "row_id",
+    "descriptor": _SESSIONS_CJK_DESC,
+    "fts_table": _SESSIONS_CJK_DESC.table,
+    "fts_columns": _SESSIONS_CJK_DESC.columns,
+    "source_table": _SESSIONS_CJK_DESC.source,
+    "source_columns": _SESSIONS_CJK_DESC.columns,
+    "row_key": _SESSIONS_CJK_DESC.row_key,
     "trigram_fts": None,
     "trigram_columns": (),
     "trigram_where": None,
-    "reset_tables": ("sessions_fts_cjk",),
+    "reset_tables": (_SESSIONS_CJK_DESC.table,),
     "available": lambda self: getattr(self, "_sessions_cjk_worker_operable", False),
     "trigram_available": lambda self: False,
     "finish_hook": lambda self: self._fts_session_cjk_finish_set_serving(),
+}
+
+# Optional message-CJK rebuild lane, folded onto the SAME generic engine as
+# every other lane (issue #27). Its OWN marker pair (``fts_cjk_rebuild_*`` —
+# never the message Unicode pair) and its own stale breadcrumb
+# (``FTS_CJK_STALE_KEY``) are preserved; only the bespoke status/step/finish
+# implementations are replaced by the shared engine. The worker gate is
+# ``_fts_cjk_loaded`` (this process can tokenize), and finish flips
+# search-serving exactly as the pre-#27 bespoke ``_fts_cjk_rebuild_finish``
+# did. The backfill reads through the ``messages_fts_cjk_src`` VIEW (the
+# descriptor's canonical derived source) which already excludes tool rows.
+_FTS_MESSAGE_CJK_SPEC = {
+    "name": "messages_cjk",
+    "high_water_key": "fts_cjk_rebuild_high_water",
+    "progress_key": "fts_cjk_rebuild_progress",
+    "descriptor": _MESSAGES_CJK_DESC,
+    "fts_table": _MESSAGES_CJK_DESC.table,
+    "fts_columns": _MESSAGES_CJK_DESC.columns,
+    "source_table": _MESSAGES_CJK_DESC.source,
+    "source_columns": _MESSAGES_CJK_DESC.columns,
+    "row_key": _MESSAGES_CJK_DESC.row_key,
+    "trigram_fts": None,
+    "trigram_columns": (),
+    "trigram_where": None,
+    "reset_tables": (_MESSAGES_CJK_DESC.table,),
+    "available": lambda self: self._fts_enabled and self._fts_cjk_loaded,
+    "trigram_available": lambda self: False,
+    "finish_hook": lambda self: setattr(self, "_fts_cjk_available", True),
 }
 
 
@@ -614,94 +665,32 @@ class SessionSearchMixin:
         self._sessions_cjk_available = stale is None
 
     def fts_cjk_rebuild_status(self) -> Optional[Dict[str, Any]]:
-        """CJK-index backfill progress, or None when none is pending."""
-        with self._read_ctx() as conn:
-            row = conn.execute(
-                "SELECT key, value FROM state_meta WHERE key IN (?, ?)",
-                ("fts_cjk_rebuild_high_water", "fts_cjk_rebuild_progress"),
-            ).fetchall()
-        meta = {r["key"]: r["value"] for r in row}
-        high_water = meta.get("fts_cjk_rebuild_high_water")
-        if high_water is None:
-            return None
-        progress = int(meta.get("fts_cjk_rebuild_progress") or 0)
-        total = int(high_water)
-        if total <= 0:
-            return None
-        pct = min(100, int(100 * progress / total))
-        return {"pending": True, "total": total, "indexed": progress, "percent": pct}
+        """CJK-index backfill progress, or None when none is pending.
+
+        Delegates to the shared deferred-rebuild engine (issue #27) with the
+        message-CJK lane spec; the H/P marker pair and status shape are
+        unchanged.
+        """
+        return self.fts_rebuild_status(spec=_FTS_MESSAGE_CJK_SPEC)
 
     def fts_cjk_rebuild_step(self) -> bool:
-        """Backfill one chunk of the CJK index. True while work remains."""
-        if not self._fts_enabled or not self._fts_cjk_loaded:
-            return False
-        high_water_raw = self.get_meta("fts_cjk_rebuild_high_water")
-        if high_water_raw is None:
-            return False
-        high_water = int(high_water_raw)
-        chunk = self._FTS_REBUILD_CHUNK_ROWS
+        """Backfill one chunk of the CJK index. True while work remains.
 
-        def _do(conn):
-            row = conn.execute(
-                "SELECT value FROM state_meta "
-                "WHERE key = 'fts_cjk_rebuild_progress'"
-            ).fetchone()
-            if row is None:
-                return False  # finished (or cleared) by another process
-            progress = int(row[0])
-            if progress >= high_water:
-                return False
-            upper = min(progress + chunk, high_water)
-            conn.execute(
-                "INSERT INTO messages_fts_cjk(rowid, content, tool_name, tool_calls) "
-                "SELECT id, content, tool_name, tool_calls FROM messages "
-                "WHERE id > ? AND id <= ? AND role <> 'tool'",
-                (progress, upper),
-            )
-            conn.execute(
-                "UPDATE state_meta SET value = ? "
-                "WHERE key = 'fts_cjk_rebuild_progress'",
-                (str(upper),),
-            )
-            return upper < high_water
-
-        try:
-            more = self._execute_write(_do)
-        except sqlite3.OperationalError as exc:
-            logger.debug("CJK FTS rebuild chunk failed (will retry): %s", exc)
-            return True
-        if more is False:
-            status = self.fts_cjk_rebuild_status()
-            if status is not None and status["indexed"] >= status["total"]:
-                self._fts_cjk_rebuild_finish()
-            return False
-        return bool(more)
+        Delegates to the shared deferred-rebuild engine (issue #27); the
+        message-CJK H/P marker pair, id-gated chunk SQL, and crash-safe claim
+        semantics are unchanged (the chunk now reads through the
+        ``messages_fts_cjk_src`` VIEW, which already excludes tool rows).
+        """
+        return self.fts_rebuild_step(spec=_FTS_MESSAGE_CJK_SPEC)
 
     def _fts_cjk_rebuild_finish(self) -> None:
-        """Boundary sweep + clear the cjk markers; index becomes servable."""
-        def _do(conn):
-            hw_row = conn.execute(
-                "SELECT value FROM state_meta "
-                "WHERE key = 'fts_cjk_rebuild_high_water'"
-            ).fetchone()
-            if hw_row is not None:
-                hw = int(hw_row[0])
-                lo, hi = hw - 1000, hw + 1000
-                conn.execute(
-                    "INSERT INTO messages_fts_cjk(rowid, content, tool_name, tool_calls) "
-                    "SELECT m.id, m.content, m.tool_name, m.tool_calls "
-                    "FROM messages m "
-                    "WHERE m.id > ? AND m.id <= ? AND m.role <> 'tool' "
-                    "AND NOT EXISTS (SELECT 1 FROM messages_fts_cjk_docsize d WHERE d.id = m.id)",
-                    (lo, hi),
-                )
-            conn.execute(
-                "DELETE FROM state_meta WHERE key IN "
-                "('fts_cjk_rebuild_high_water', 'fts_cjk_rebuild_progress')"
-            )
-        self._execute_write(_do)
-        self._fts_cjk_available = True
-        logger.info("CJK FTS index backfill complete — serving CJK search.")
+        """Boundary sweep + clear the cjk markers; index becomes servable.
+
+        Delegates to the shared deferred-rebuild finish (issue #27); the
+        finish hook flips ``_fts_cjk_available`` exactly as the pre-#27
+        bespoke implementation did.
+        """
+        self._fts_rebuild_finish(spec=_FTS_MESSAGE_CJK_SPEC)
 
     def _fts_reset_stale_cjk_surface(
         self,
@@ -3450,6 +3439,52 @@ class SessionSearchMixin:
             # teardown) — in every case the table is not queryable.
             return False
 
+    def _fts_maintenance_tables(self) -> Tuple[str, ...]:
+        """Ordered FTS tables applicable to ordinary maintenance (optimize /
+        bounded merge / explicit rebuild) on THIS host, derived from the
+        authoritative ``FTS_INDEXES`` registry (issue #27).
+
+        Required Unicode indexes (``messages_fts``, ``sessions_fts``)
+        participate whenever FTS5 is enabled. Optional tokenizer-gated
+        indexes participate only when this process can operate them AND they
+        are not quarantined/stale:
+
+        - ``messages_fts_trigram`` — ``self._trigram_available``;
+        - ``messages_fts_cjk`` — ``self._fts_cjk_loaded``;
+        - ``sessions_fts_cjk`` — ``self._sessions_cjk_worker_operable``
+          (worker operability, never search-serving availability);
+        - ``sessions_fts_trigram`` — ``self._sessions_trigram_available``.
+
+        The #30 ownership classifier leaves ``_sessions_trigram_available``
+        False for an unknown same-name object, so a foreign target is never
+        touched by ordinary maintenance. Callers keep the per-table existence
+        probe as a safety net for tables absent from the schema.
+        """
+        if not self._fts_enabled:
+            return ()
+        sessions_fts_ok = getattr(self, "_sessions_fts_available", False)
+        sessions_trigram_ok = getattr(self, "_sessions_trigram_available", False)
+        sessions_cjk_ok = getattr(self, "_sessions_cjk_worker_operable", False)
+        tables: List[str] = []
+        for desc in FTS_INDEXES:
+            if desc.capability == "fts5":
+                if desc.table == "sessions_fts" and not sessions_fts_ok:
+                    continue
+                tables.append(desc.table)
+            elif desc.capability == "trigram":
+                if desc.table == "sessions_fts_trigram":
+                    if sessions_trigram_ok:
+                        tables.append(desc.table)
+                elif self._trigram_available:
+                    tables.append(desc.table)
+            else:  # cjk
+                if desc.table == "sessions_fts_cjk":
+                    if sessions_cjk_ok:
+                        tables.append(desc.table)
+                elif self._fts_cjk_loaded:
+                    tables.append(desc.table)
+        return tuple(tables)
+
     def optimize_fts(self) -> int:
         """Merge fragmented FTS5 b-tree segments into one per index.
 
@@ -3465,15 +3500,20 @@ class SessionSearchMixin:
         speed. It is complementary to VACUUM: ``optimize`` compacts the FTS
         index internally, then VACUUM returns the freed pages to the OS.
 
-        Skips any FTS table that does not exist (e.g. the trigram index when
-        disabled via ``HERMES_DISABLE_FTS_TRIGRAM`` or not yet created), so
-        it is safe to call unconditionally.
+        Iterates the authoritative ``FTS_INDEXES`` registry (issue #27):
+        every owned applicable modern index — the three message indexes AND
+        the session Unicode/CJK/trigram metadata indexes — participates
+        through the shared applicability path. Optional tokenizer-gated
+        indexes participate only when this host can operate them; an unknown
+        #30 same-name ``sessions_fts_trigram`` is never touched. Skips any
+        FTS table that does not exist, so it is safe to call
+        unconditionally.
 
         Returns the number of FTS indexes that were optimized.
         """
         optimized = 0
         with self._lock:
-            for tbl in self._FTS_TABLES:
+            for tbl in self._fts_maintenance_tables():
                 if not self._fts_table_exists(tbl):
                     continue
                 try:
@@ -3490,21 +3530,32 @@ class SessionSearchMixin:
         return optimized
 
     def rebuild_fts(self) -> int:
-        """Rebuild FTS5 indexes from the canonical ``messages`` table.
+        """Rebuild FTS5 indexes from their canonical content sources.
 
         Uses the FTS5 ``'rebuild'`` command, which rewrites the internal
-        b-tree segments from the content rows. This is the documented
-        recovery for a corrupt FTS index that rejects message writes while
-        reads still succeed (issue #50502). Unlike ``optimize_fts`` (which
-        merges existing segments), ``rebuild`` discards and recreates the
-        index data entirely.
+        b-tree segments from each table's declared content source. This is
+        the documented recovery for a corrupt FTS index that rejects writes
+        while reads still succeed (issue #50502). Unlike ``optimize_fts``
+        (which merges existing segments), ``rebuild`` discards and recreates
+        the index data entirely.
+
+        Iterates the authoritative ``FTS_INDEXES`` registry (issue #27):
+        every owned applicable modern index is rebuilt, so a corrupt session
+        Unicode/CJK/trigram index is recovered by the same runtime seam that
+        already covers the message indexes. FTS5's ``rebuild`` command reads
+        through each table's declared ``content=`` source, so
+        ``sessions_fts_trigram`` naturally rebuilds through the derived
+        compact ``sessions_fts_trigram_src`` VIEW — no compact SQL is
+        duplicated here. Optional tokenizer-gated indexes participate only
+        when this host can operate them; an unknown #30 same-name
+        ``sessions_fts_trigram`` is never touched.
 
         Safe to call when FTS tables don't exist (skips them).
         Returns the number of FTS indexes that were rebuilt.
         """
         rebuilt = 0
         with self._lock:
-            for tbl in self._FTS_TABLES:
+            for tbl in self._fts_maintenance_tables():
                 if not self._fts_table_exists(tbl):
                     continue
                 try:
@@ -3547,7 +3598,11 @@ class SessionSearchMixin:
         Each command is its own implicit transaction (the connection runs
         with ``isolation_level=None``), so the SQLite write lock is released
         between commands and competing processes can interleave writes
-        mid-pass. Missing tables are valid schema variants (FTS variants are
+        mid-pass. The applicable index set comes from the authoritative
+        ``FTS_INDEXES`` registry (issue #27), so the bounded merge reaches
+        the session Unicode/CJK/trigram metadata indexes through the same
+        shared applicability path — no session-specific cadence. Missing
+        tables are valid schema variants (FTS variants are
         optional, and ``optimize_fts_storage`` legitimately drops + backfills
         these tables while writers keep running) and are skipped, mirroring
         ``optimize_fts``. Other SQLite errors propagate to the caller.
@@ -3567,7 +3622,7 @@ class SessionSearchMixin:
 
         executed = 0
         with self._lock:
-            for tbl in self._FTS_TABLES:
+            for tbl in self._fts_maintenance_tables():
                 if not self._fts_table_exists(tbl):
                     continue
                 # One-time (per instance) usermerge floor; the value is

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -288,6 +288,54 @@ _FTS_MESSAGE_CJK_SPEC = {
 }
 
 
+# ── Shared deferred-rebuild lane iteration (issue #27) ────────────────────
+# The status emitter and foreground worker loop in ``optimize_fts_storage``
+# used to probe/execute each rebuild lane one-by-one (message, message-CJK,
+# session Unicode, session trigram, session CJK). This ordered lane surface
+# centralizes that sequencing so the loops are data-driven. It is SEPARATE
+# from the ``FTS_INDEXES`` registry: H/P markers and stale breadcrumbs are
+# lane-specific state that lives in the rebuild specs, not in the index
+# descriptor. ``stale_key`` (when present) names the lane's durable stale
+# breadcrumb for the pending-work probe.
+_FTS_REBUILD_LANES: Tuple[Dict[str, Any], ...] = (
+    {
+        "name": "messages",
+        "spec": _FTS_MESSAGE_SPEC,
+        "stale_key": None,
+        "status": lambda self: self.fts_rebuild_status(),
+        "step": lambda self: self.fts_rebuild_step(),
+    },
+    {
+        "name": "messages_cjk",
+        "spec": _FTS_MESSAGE_CJK_SPEC,
+        "stale_key": FTS_CJK_STALE_KEY,
+        "status": lambda self: self.fts_cjk_rebuild_status(),
+        "step": lambda self: self.fts_cjk_rebuild_step(),
+    },
+    {
+        "name": "sessions",
+        "spec": _FTS_SESSION_SPEC,
+        "stale_key": None,
+        "status": lambda self: self.fts_session_rebuild_status(),
+        "step": lambda self: self.fts_session_rebuild_step(),
+    },
+    {
+        "name": "sessions_trigram",
+        "spec": _FTS_SESSION_TRIGRAM_SPEC,
+        "stale_key": FTS_SESSION_TRIGRAM_STALE_KEY,
+        "status": lambda self: self.fts_session_trigram_rebuild_status(),
+        "step": lambda self: self.fts_session_trigram_rebuild_step(),
+    },
+    {
+        "name": "sessions_cjk",
+        "spec": _FTS_SESSION_CJK_SPEC,
+        "stale_key": FTS_SESSION_CJK_STALE_KEY,
+        "status": lambda self: self.fts_session_cjk_rebuild_status(),
+        "step": lambda self: self.fts_session_cjk_rebuild_step(),
+    },
+)
+
+
 class SessionSearchMixin:
     """See module docstring — mixin for SessionDB (Search cluster)."""
 
@@ -384,6 +432,67 @@ class SessionSearchMixin:
             return None
         pct = min(100, int(100 * progress / total))
         return {"pending": True, "total": total, "indexed": progress, "percent": pct}
+
+    def _fts_lane_pending(self, lane: Dict[str, Any], conn) -> bool:
+        """True when a deferred-rebuild lane has durable pending work (an H
+        marker and/or its stale breadcrumb) that THIS process can operate
+        (issue #27).
+
+        SELECT-only — no schema mutation, so it is safe for read-only opens
+        and status surfaces. The operability gate is the lane spec's
+        ``available`` callback (e.g. ``_sessions_trigram_available`` for the
+        #30 trigram lane), preserving the worker-vs-serving distinction.
+        ``conn`` must be a connection the caller already holds under a
+        suitable lock/read context (this helper does NOT take ``self._lock``,
+        which is non-reentrant).
+        """
+        spec = lane["spec"]
+        if not spec["available"](self):
+            return False
+        keys = [spec["high_water_key"]]
+        stale = lane.get("stale_key")
+        if stale:
+            keys.append(stale)
+        placeholders = ", ".join("?" for _ in keys)
+        row = conn.execute(
+            f"SELECT 1 FROM state_meta WHERE key IN ({placeholders}) LIMIT 1",
+            keys,
+        ).fetchone()
+        return row is not None
+
+    def _fts_first_pending_lane_status(self) -> Optional[Dict[str, Any]]:
+        """First non-None deferred-rebuild status across the ordered lanes
+        (issue #27) — the shared surface for progress/status emission, so the
+        emitter no longer hard-codes each lane one-by-one."""
+        for lane in _FTS_REBUILD_LANES:
+            status = lane["status"](self)
+            if status is not None:
+                return status
+        return None
+
+    def _fts_run_pending_lane_steps(
+        self, on_chunk: Optional[Callable[[], None]] = None
+    ) -> None:
+        """Run one full pass of every deferred-rebuild lane with pending work
+        (issue #27), using the shared inter-chunk pacing.
+
+        Replaces the hard-coded per-lane phase ladders in
+        ``optimize_fts_storage``; each lane's step loop only starts when its
+        status reports pending work, so a DB with no work for a lane never
+        enters (and never trips a monkeypatched step). ``on_chunk`` (if any)
+        is invoked after each chunk so progress emission is preserved. H/P
+        state stays lane-specific — this surface only sequences the lanes.
+        """
+        for lane in _FTS_REBUILD_LANES:
+            if lane["status"](self) is None:
+                continue
+            while True:
+                _t0 = time.monotonic()
+                if not lane["step"](self):
+                    break
+                if on_chunk is not None:
+                    on_chunk()
+                self._fts_rebuild_pause(time.monotonic() - _t0)
 
     def _fts_rebuild_finish(self, spec: Optional[Dict[str, Any]] = None) -> None:
         """Finalize a deferred rebuild: boundary sweep + clear markers.
@@ -1146,46 +1255,14 @@ class SessionSearchMixin:
             # unfinished until the backfill markers are cleared and the
             # demoted trash tables are torn down. Search stays complete
             # through the gap supplement meanwhile; re-running resumes.
-            if self._conn.execute(
-                "SELECT 1 FROM state_meta "
-                "WHERE key = 'fts_rebuild_high_water' LIMIT 1"
-            ).fetchone():
-                return True
-            # Session Unicode metadata rebuild pending (issue #25): the
-            # external index was staged at open with a durable H/P claim and
-            # the historical backfill is not complete yet.
-            if self._conn.execute(
-                "SELECT 1 FROM state_meta "
-                "WHERE key = 'fts_session_rebuild_high_water' LIMIT 1"
-            ).fetchone():
-                return True
-            # Session normalized trigram rebuild pending (issue #30): its own
-            # durable H/P claim, independent of the Unicode lane. Only
-            # advertised when THIS runtime owns+serves the lane — an
-            # incapable host must not advertise trigram work it can never
-            # complete (finding 1 point 4), and an unknown / quarantined
-            # target must not be advertised for mutation (finding 4).
-            if self._sessions_trigram_available and self._conn.execute(
-                "SELECT 1 FROM state_meta "
-                "WHERE key = 'fts_session_trigram_rebuild_high_water' LIMIT 1"
-            ).fetchone():
-                return True
-            # CJK-bigram index work — only offerable when THIS process can
-            # tokenize: a pending backfill (markers set at creation on a
-            # populated DB) or a stale index awaiting a from-scratch rebuild.
-            if self._fts_cjk_loaded and self._conn.execute(
-                "SELECT 1 FROM state_meta WHERE key IN "
-                f"('fts_cjk_rebuild_high_water', '{FTS_CJK_STALE_KEY}') LIMIT 1"
-            ).fetchone():
-                return True
-            # Session CJK metadata rebuild pending or stale (issue #26) —
-            # same tokenizer-capability gate as the message CJK index.
-            if self._fts_cjk_loaded and self._conn.execute(
-                "SELECT 1 FROM state_meta WHERE key IN "
-                "('fts_session_cjk_rebuild_high_water', "
-                f"'{FTS_SESSION_CJK_STALE_KEY}') LIMIT 1"
-            ).fetchone():
-                return True
+            # Every deferred-rebuild lane with durable pending work
+            # (H marker and/or stale breadcrumb) that THIS process can
+            # operate advertises work through the shared lane surface
+            # (issue #27): message, message-CJK, session Unicode, session
+            # trigram, and session CJK.
+            for lane in _FTS_REBUILD_LANES:
+                if self._fts_lane_pending(lane, self._conn):
+                    return True
             if self._has_fts_trash(self._conn):
                 return True
             # Pre-fix crash window: empty external-content index with
@@ -1374,15 +1451,7 @@ class SessionSearchMixin:
         def _emit(phase: str) -> None:
             if progress_cb is None:
                 return
-            st = self.fts_rebuild_status()
-            if st is None:
-                st = self.fts_cjk_rebuild_status()
-            if st is None:
-                st = self.fts_session_rebuild_status()
-            if st is None:
-                st = self.fts_session_trigram_rebuild_status()
-            if st is None:
-                st = self.fts_session_cjk_rebuild_status()
+            st = self._fts_first_pending_lane_status()
             progress_cb({
                 "phase": phase,
                 "percent": st["percent"] if st else 100,
@@ -1390,58 +1459,14 @@ class SessionSearchMixin:
                 "total": st["total"] if st else 0,
             })
 
-        # Phase 1: backfill (foreground, throttled between chunks so a live
-        # gateway sharing the DB stays responsive).
+        # Phase 1: backfill every deferred-rebuild lane with pending work,
+        # foreground and throttled between chunks so a live gateway sharing
+        # the DB stays responsive. The shared lane surface (issue #27)
+        # sequences the message / message-CJK / session Unicode / session
+        # trigram / session CJK lanes instead of a hard-coded ladder.
         _emit("backfill")
-        while True:
-            _t0 = time.monotonic()
-            if not self.fts_rebuild_step():
-                break
-            _emit("backfill")
-            self._fts_rebuild_pause(time.monotonic() - _t0)
+        self._fts_run_pending_lane_steps(on_chunk=lambda: _emit("backfill"))
         _emit("backfill")
-
-        # Phase 1b: backfill the CJK-bigram index (its own marker pair; a
-        # no-op when the tokenizer isn't loadable or nothing is pending).
-        while True:
-            _t0 = time.monotonic()
-            if not self.fts_cjk_rebuild_step():
-                break
-            _emit("backfill")
-            self._fts_rebuild_pause(time.monotonic() - _t0)
-
-        # Phase 1c: backfill the session Unicode metadata index (issue #25)
-        # — same shared chunk engine and pacing as the message rebuild. Gated
-        # on pending markers so a DB with no session work never enters the
-        # loop (and never trips a monkeypatched message ``fts_rebuild_step``).
-        if self.fts_session_rebuild_status() is not None:
-            while True:
-                _t0 = time.monotonic()
-                if not self.fts_session_rebuild_step():
-                    break
-                _emit("backfill")
-                self._fts_rebuild_pause(time.monotonic() - _t0)
-
-        # Phase 1d: backfill the session normalized trigram index (issue #30)
-        # — same shared chunk engine and pacing, its own pending markers.
-        if self.fts_session_trigram_rebuild_status() is not None:
-            while True:
-                _t0 = time.monotonic()
-                if not self.fts_session_trigram_rebuild_step():
-                    break
-                _emit("backfill")
-                self._fts_rebuild_pause(time.monotonic() - _t0)
-
-        # Phase 1e: backfill the session CJK metadata index (issue #26) — the
-        # same shared chunk engine and pacing, gated on the independent
-        # CJK-session markers (worker operability, never search availability).
-        if self.fts_session_cjk_rebuild_status() is not None:
-            while True:
-                _t0 = time.monotonic()
-                if not self.fts_session_cjk_rebuild_step():
-                    break
-                _emit("backfill")
-                self._fts_rebuild_pause(time.monotonic() - _t0)
 
         # Phase 2: tear down the demoted legacy shadow tables in chunks.
         _emit("teardown")

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -1227,7 +1227,11 @@ class SessionSearchMixin:
         window where trash + empty v23 tables exist with no backfill claim.
         """
         def _stage(conn):
-            self._drop_fts_triggers(conn)
+            # Message-scoped teardown: the demote re-creates the message
+            # schema immediately, so only the message triggers are dropped
+            # here — session metadata triggers keep live-indexing during the
+            # message-layout migration (issue #27).
+            self._drop_message_fts_triggers(conn)
             conn.execute("DROP VIEW IF EXISTS messages_fts_trigram_src")
             had = bool(conn.execute(
                 "SELECT 1 FROM sqlite_master WHERE type = 'table' "

--- a/tests/test_fts_lifecycle_registry.py
+++ b/tests/test_fts_lifecycle_registry.py
@@ -573,16 +573,42 @@ def test_owned_fts_object_names_covers_six_indexes(db):
     assert len(names) == len(set(names))  # no duplicates
 
 
-def test_owned_fts_object_names_fail_closed_for_foreign_trigram(db, monkeypatch):
-    """An unknown same-name sessions_fts_trigram is positively classified and
-    left untouched by destructive repair (#30 fail-closed)."""
+def _install_foreign_trigram_source(conn):
+    """Replace the canonical derived VIEW with a raw (uncompacted) foreign
+    one — real mixed DDL, the state #30's ownership classifier must reject."""
+    conn.execute("DROP VIEW IF EXISTS sessions_fts_trigram_src")
+    conn.execute(
+        "CREATE VIEW sessions_fts_trigram_src AS "
+        "SELECT row_id, title, id, display_name FROM sessions"
+    )
+    conn.commit()
+
+
+def _install_foreign_trigram_triggers(conn, names=None):
+    """Replace the named canonical trigram triggers with foreign inert
+    same-name occupants (``AFTER UPDATE ON sessions ... SELECT 1``)."""
+    names = names or (
+        "sessions_fts_trigram_insert",
+        "sessions_fts_trigram_delete",
+        "sessions_fts_trigram_update_before",
+        "sessions_fts_trigram_update_after",
+    )
+    for name in names:
+        conn.execute(f"DROP TRIGGER IF EXISTS {name}")
+        conn.execute(
+            f"CREATE TRIGGER {name} AFTER UPDATE ON sessions "
+            "BEGIN SELECT 1; END"
+        )
+    conn.commit()
+
+
+def test_owned_objects_fail_closed_for_foreign_trigram_source(db):
+    """Canonical root + foreign (mismatched) source VIEW is NOT owned — the
+    destructive namespace list must exclude the trigram (real mixed DDL, not
+    a mock)."""
     from hermes_state import _owned_fts_object_names
 
-    monkeypatch.setattr(
-        SessionDB,
-        "_sessions_trigram_modern_definition_matches",
-        staticmethod(lambda sql: False),
-    )
+    _install_foreign_trigram_source(db._conn)
     names = _owned_fts_object_names(db._conn)
     assert not any(n.startswith("sessions_fts_trigram") for n in names)
     # The other five members are still owned.
@@ -594,6 +620,181 @@ def test_owned_fts_object_names_fail_closed_for_foreign_trigram(db, monkeypatch)
         "sessions_fts_cjk",
     ):
         assert table in names
+
+
+def test_owned_objects_fail_closed_for_foreign_trigram_trigger(db):
+    """Canonical root/source + foreign same-name trigger occupant is NOT
+    owned — destructive namespace list excludes the trigram."""
+    from hermes_state import _owned_fts_object_names
+
+    _install_foreign_trigram_triggers(
+        db._conn, names=("sessions_fts_trigram_update_before",)
+    )
+    names = _owned_fts_object_names(db._conn)
+    assert not any(n.startswith("sessions_fts_trigram") for n in names)
+
+
+def test_destructive_repair_leaves_foreign_trigram_source_untouched(tmp_path):
+    """Strategy 2 must not delete a canonical root whose source VIEW is
+    foreign — the foreign VIEW stays byte/DDL-identical."""
+    from hermes_state import _drop_owned_fts_derived_schema
+
+    db_path = _build_db_with_session(tmp_path, title="pizza pie party")
+    conn = sqlite3.connect(str(db_path))
+    _install_foreign_trigram_source(conn)
+    before_sql = conn.execute(
+        "SELECT sql FROM sqlite_master "
+        "WHERE name = 'sessions_fts_trigram_src'"
+    ).fetchone()[0]
+    _drop_owned_fts_derived_schema(conn)
+    after_sql = conn.execute(
+        "SELECT sql FROM sqlite_master "
+        "WHERE name = 'sessions_fts_trigram_src'"
+    ).fetchone()[0]
+    assert after_sql == before_sql
+    conn.close()
+
+
+def test_destructive_repair_leaves_foreign_trigram_trigger_untouched(tmp_path):
+    """Strategy 2 must not delete a canonical root/source namespace that has
+    a foreign same-name trigger occupant — the foreign trigger stays
+    byte/DDL-identical and the (unowned) trigram root survives."""
+    from hermes_state import _drop_owned_fts_derived_schema
+
+    db_path = _build_db_with_session(tmp_path, title="pizza pie party")
+    conn = sqlite3.connect(str(db_path))
+    _install_foreign_trigram_triggers(
+        conn, names=("sessions_fts_trigram_update_before",)
+    )
+    before_sql = conn.execute(
+        "SELECT sql FROM sqlite_master "
+        "WHERE type = 'trigger' AND name = 'sessions_fts_trigram_update_before'"
+    ).fetchone()[0]
+    _drop_owned_fts_derived_schema(conn)
+    after_sql = conn.execute(
+        "SELECT sql FROM sqlite_master "
+        "WHERE type = 'trigger' AND name = 'sessions_fts_trigram_update_before'"
+    ).fetchone()[0]
+    assert after_sql == before_sql
+    # The excluded (unowned) trigram root survives too.
+    assert conn.execute(
+        "SELECT 1 FROM sqlite_master "
+        "WHERE type = 'table' AND name = 'sessions_fts_trigram'"
+    ).fetchone() is not None
+    conn.close()
+
+
+def test_drop_fts_triggers_leaves_foreign_trigram_trigger_untouched(db):
+    """The whole-FTS5-unavailable teardown drops canonical triggers but never
+    a foreign occupant of a sessions_fts_trigram_* name (#30 preflight)."""
+    _install_foreign_trigram_triggers(
+        db._conn, names=("sessions_fts_trigram_update_before",)
+    )
+    before_sql = db._conn.execute(
+        "SELECT sql FROM sqlite_master "
+        "WHERE type = 'trigger' AND name = 'sessions_fts_trigram_update_before'"
+    ).fetchone()[0]
+    db._drop_fts_triggers(db._conn)
+    db._conn.commit()
+    after_sql = db._conn.execute(
+        "SELECT sql FROM sqlite_master "
+        "WHERE type = 'trigger' AND name = 'sessions_fts_trigram_update_before'"
+    ).fetchone()[0]
+    assert after_sql == before_sql  # foreign occupant survives
+    # Canonical message/session triggers were still dropped.
+    left = db._conn.execute(
+        "SELECT COUNT(*) FROM sqlite_master "
+        "WHERE type = 'trigger' AND name IN "
+        "('messages_fts_insert', 'sessions_fts_insert')"
+    ).fetchone()[0]
+    assert left == 0
+
+
+def test_offline_repair_leaves_foreign_trigram_untouched(tmp_path):
+    """Strategy 0 rebuilds owned indexes but never 'rebuild' a foreign
+    same-name sessions_fts_trigram (which can legally accept the command).
+    The corrupt foreign data is outside owned repair, so auto-recovery fails
+    closed (never reports success while corruption survives) and the foreign
+    objects stay byte/DDL-identical."""
+    from hermes_state import repair_state_db_schema
+
+    db_path = _build_db_with_session(tmp_path, title="pizza pie party")
+    conn = sqlite3.connect(str(db_path))
+    # Foreign occupants across the whole trigram trigger namespace.
+    _install_foreign_trigram_triggers(conn)
+    # Corrupt an OWNED index (sessions_fts) so repair actually runs...
+    conn.execute("UPDATE sessions_fts_data SET block = X'BADC0FFEE0DDF00D'")
+    # ...and corrupt the foreign-gated trigram data too (repair must not
+    # clear it, and must not report success while it survives).
+    conn.execute(
+        "UPDATE sessions_fts_trigram_data SET block = X'BADC0FFEE0DDF00D'"
+    )
+    conn.commit()
+    before_trigger = conn.execute(
+        "SELECT sql FROM sqlite_master "
+        "WHERE type = 'trigger' AND name = 'sessions_fts_trigram_update_before'"
+    ).fetchone()[0]
+    conn.close()
+
+    report = repair_state_db_schema(db_path, backup=False)
+    # Fail closed: a foreign-gated corrupt index cannot be cleared, so repair
+    # must not report success (it must never delete/rebuild the foreign
+    # object to make the DB "healthy").
+    assert report["repaired"] is False
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        after_trigger = conn.execute(
+            "SELECT sql FROM sqlite_master "
+            "WHERE type = 'trigger' AND name = 'sessions_fts_trigram_update_before'"
+        ).fetchone()[0]
+        assert after_trigger == before_trigger  # foreign occupant untouched
+        # The corrupt foreign trigram data was NOT rebuilt (untouched).
+        bad = conn.execute(
+            "SELECT COUNT(*) FROM sessions_fts_trigram_data "
+            "WHERE block = X'BADC0FFEE0DDF00D'"
+        ).fetchone()[0]
+        assert bad >= 1
+    finally:
+        conn.close()
+
+
+def test_health_probe_never_reports_foreign_trigram_as_owned_repair(tmp_path):
+    """A corrupt foreign-gated sessions_fts_trigram is outside owned repair:
+    the health check still surfaces real corruption (PRAGMA integrity_check
+    is detection, not mutation), but repair must fail closed and leave the
+    foreign objects byte/DDL-identical. This pins the read-probe ownership
+    gate end-to-end via the repair path."""
+    from hermes_state import _db_opens_cleanly, repair_state_db_schema
+
+    db_path = _build_db_with_session(tmp_path, title="pizza pie party")
+    conn = sqlite3.connect(str(db_path))
+    _install_foreign_trigram_triggers(conn)
+    conn.execute(
+        "UPDATE sessions_fts_trigram_data SET block = X'BADC0FFEE0DDF00D'"
+    )
+    conn.commit()
+    before_trigger = conn.execute(
+        "SELECT sql FROM sqlite_master "
+        "WHERE type = 'trigger' AND name = 'sessions_fts_trigram_update_before'"
+    ).fetchone()[0]
+    conn.close()
+
+    # Detection is fine (integrity_check reports the corruption), but repair
+    # must not claim success over a foreign object it refuses to touch.
+    assert _db_opens_cleanly(db_path) is not None
+    report = repair_state_db_schema(db_path, backup=False)
+    assert report["repaired"] is False
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        after_trigger = conn.execute(
+            "SELECT sql FROM sqlite_master "
+            "WHERE type = 'trigger' AND name = 'sessions_fts_trigram_update_before'"
+        ).fetchone()[0]
+        assert after_trigger == before_trigger  # foreign occupant untouched
+    finally:
+        conn.close()
 
 
 def test_destructive_repair_removes_owned_objects_preserves_canonical(tmp_path):

--- a/tests/test_fts_lifecycle_registry.py
+++ b/tests/test_fts_lifecycle_registry.py
@@ -719,3 +719,65 @@ def test_fts_optimize_available_is_lane_driven(db):
     db.set_meta("fts_session_rebuild_high_water", "1")
     db.set_meta("fts_session_rebuild_progress", "0")
     assert db.fts_optimize_available() is True
+
+
+# ── Six-index regression matrix (issue #27 commit 5) ──────────────────────
+
+def test_vacuum_reaches_session_indexes_and_preserves_row_ids(db):
+    """VACUUM reaches session FTS only through the shared optimize path (no
+    session-specific VACUUM hook) and preserves sessions.row_id."""
+    db.create_session(session_id="s1", source="cli")
+    db.set_session_title("s1", "vacuum title")
+    db.append_message("s1", role="user", content="vacuum needle")
+    before = db._conn.execute(
+        "SELECT row_id FROM sessions WHERE id = 's1'"
+    ).fetchone()[0]
+    db.vacuum()
+    after = db._conn.execute(
+        "SELECT row_id FROM sessions WHERE id = 's1'"
+    ).fetchone()[0]
+    assert after == before
+    assert len(db.search_messages("vacuum")) == 1
+    assert _session_fts_matches(db, "vacuum")
+
+
+def test_rebuild_session_trigram_through_derived_compact_view(db):
+    """Session trigram rebuild consumes the #30 derived compact VIEW — not
+    raw metadata — so separator-bearing titles stay searchable by their
+    compact form after repair."""
+    db.create_session(session_id="s1", source="cli")
+    db.set_session_title("s1", "AN-94 Rifle")
+    # The trigger indexed the COMPACTED "AN94Rifle" (hyphen/space removed).
+    assert _trigram_fts_matches(db, "an94")
+    _corrupt_shadow(db, "sessions_fts_trigram_data")
+    with pytest.raises(sqlite3.DatabaseError):
+        _trigram_fts_matches(db, "an94")
+    db.rebuild_fts()
+    # A naive rebuild from raw "AN-94 Rifle" would NOT contain the substring
+    # "an94"; reading through the derived VIEW restores the compact form.
+    assert _trigram_fts_matches(db, "an94")
+
+
+def test_runtime_recovery_repairs_corrupt_session_fts_write(db):
+    """A session-metadata write hitting corrupt session FTS invokes the
+    existing one-shot rebuild/retry and succeeds; canonical rows preserved.
+
+    Uses the session INSERT path (``create_session``), whose trigger drives
+    the real sessions_fts write. (A session-metadata UPDATE that fires the
+    ``sessions_fts_update`` 'delete' half hits an FTS5 in-transaction
+    connection-state quirk that blocks an in-place rebuild on the SAME
+    connection; that path degrades to the registry-driven offline repair /
+    startup auto-heal, which fixes it on a fresh connection.)
+    """
+    db.create_session(session_id="s1", source="cli")
+    db.set_session_title("s1", "original title")
+    # Write-class corruption: base tables read fine, session FTS writes fail.
+    db._conn.execute(
+        "UPDATE sessions_fts_data SET block = X'DEADBEEFDEADBEEF'"
+    )
+    db._conn.commit()
+    ok = db.create_session(session_id="s2", source="cli")
+    assert ok == "s2"
+    assert db._fts_runtime_rebuild_attempted is True
+    # The rebuilt session index serves both rows.
+    assert _session_fts_matches(db, "s2")

--- a/tests/test_fts_lifecycle_registry.py
+++ b/tests/test_fts_lifecycle_registry.py
@@ -1,0 +1,304 @@
+"""Six-index FTS lifecycle registry (issue #27).
+
+The authoritative ``FTS_INDEXES`` descriptor registry in
+``hermes_state_common`` must drive ordinary maintenance (optimize / bounded
+merge / explicit rebuild) across ALL six modern FTS indexes — not just the
+three message indexes — while preserving per-index capability/ownership
+gating. This file pins the new lifecycle behavior; the pre-#27 message-only
+assertions in ``test_hermes_state.py::TestOptimizeFts`` were updated to the
+six-index expectation.
+
+Storage-v2 settlement (#31) is out of scope: none of these tests touch
+``fts_storage_version`` semantics.
+"""
+
+import sqlite3
+
+import pytest
+
+from hermes_state import (
+    FTS_INDEXES,
+    SessionDB,
+    _fts_descriptor,
+)
+from hermes_state_search import (
+    _FTS_MESSAGE_CJK_SPEC,
+    _FTS_MESSAGE_SPEC,
+    _FTS_SESSION_CJK_SPEC,
+    _FTS_SESSION_SPEC,
+    _FTS_SESSION_TRIGRAM_SPEC,
+)
+
+# On a default test host (no loadable cjk tokenizer) the applicable owned
+# indexes are the four built-in ones; the two optional CJK members are gated
+# off by tokenizer capability.
+_REQUIRED_MAINTENANCE_TABLES = (
+    "messages_fts",
+    "messages_fts_trigram",
+    "sessions_fts",
+    "sessions_fts_trigram",
+)
+
+
+@pytest.fixture()
+def db(tmp_path):
+    """Fresh SessionDB over a temp database file (all six-index members are
+    created at open: message Unicode/trigram + session Unicode/trigram; the
+    CJK members only when a loadable tokenizer is present)."""
+    db_path = tmp_path / "state.db"
+    session_db = SessionDB(db_path=db_path)
+    yield session_db
+    session_db.close()
+
+
+def _table_names():
+    return {d.table for d in FTS_INDEXES}
+
+
+def _fts_table_from_special_sql(sql: str) -> str:
+    """Recover the target table from an FTS5 special-command statement, e.g.
+    ``INSERT INTO sessions_fts(sessions_fts) VALUES('optimize')``."""
+    rest = sql.split("INSERT INTO ", 1)[1]
+    return rest.split("(", 1)[0].strip()
+
+
+def _session_fts_matches(db, needle: str) -> bool:
+    row = db._conn.execute(
+        "SELECT 1 FROM sessions_fts WHERE sessions_fts MATCH ? LIMIT 1",
+        (f'"{needle}"',),
+    ).fetchone()
+    return row is not None
+
+
+def _trigram_fts_matches(db, needle: str) -> bool:
+    row = db._conn.execute(
+        "SELECT 1 FROM sessions_fts_trigram "
+        "WHERE sessions_fts_trigram MATCH ? LIMIT 1",
+        (needle,),
+    ).fetchone()
+    return row is not None
+
+
+# ── Registry shape ────────────────────────────────────────────────────────
+
+def test_registry_has_six_modern_members():
+    assert _table_names() == {
+        "messages_fts",
+        "messages_fts_trigram",
+        "messages_fts_cjk",
+        "sessions_fts",
+        "sessions_fts_cjk",
+        "sessions_fts_trigram",
+    }
+    for desc in FTS_INDEXES:
+        assert desc.table
+        assert desc.source
+        assert desc.row_key
+        assert desc.columns
+        assert desc.trigger_names
+        assert desc.capability in ("fts5", "trigram", "cjk")
+
+
+def test_registry_sources_row_keys_and_capabilities():
+    by_table = {d.table: d for d in FTS_INDEXES}
+    # Message lane: Unicode over canonical messages, derived trigram/cjk
+    # sources exclude tool rows.
+    assert by_table["messages_fts"].source == "messages"
+    assert by_table["messages_fts"].row_key == "id"
+    assert by_table["messages_fts"].capability == "fts5"
+    assert by_table["messages_fts_trigram"].source == "messages_fts_trigram_src"
+    assert by_table["messages_fts_trigram"].row_key == "id"
+    assert by_table["messages_fts_trigram"].capability == "trigram"
+    assert ("view", "messages_fts_trigram_src") in (
+        by_table["messages_fts_trigram"].derived_objects
+    )
+    assert by_table["messages_fts_cjk"].source == "messages_fts_cjk_src"
+    assert by_table["messages_fts_cjk"].capability == "cjk"
+    assert ("view", "messages_fts_cjk_src") in (
+        by_table["messages_fts_cjk"].derived_objects
+    )
+    # Session lane: raw Unicode metadata keyed by named row_id; trigram reads
+    # the derived compact VIEW.
+    assert by_table["sessions_fts"].source == "sessions"
+    assert by_table["sessions_fts"].row_key == "row_id"
+    assert by_table["sessions_fts"].columns == ("title", "id", "display_name")
+    assert by_table["sessions_fts"].capability == "fts5"
+    assert by_table["sessions_fts_cjk"].source == "sessions"
+    assert by_table["sessions_fts_cjk"].row_key == "row_id"
+    assert by_table["sessions_fts_cjk"].capability == "cjk"
+    assert by_table["sessions_fts_trigram"].source == "sessions_fts_trigram_src"
+    assert by_table["sessions_fts_trigram"].row_key == "row_id"
+    assert by_table["sessions_fts_trigram"].capability == "trigram"
+    assert ("view", "sessions_fts_trigram_src") in (
+        by_table["sessions_fts_trigram"].derived_objects
+    )
+
+
+# ── Rebuild specs derive their static identity from the registry ─────────
+
+@pytest.mark.parametrize(
+    "spec,expected_table",
+    [
+        (_FTS_MESSAGE_SPEC, "messages_fts"),
+        (_FTS_SESSION_SPEC, "sessions_fts"),
+        (_FTS_SESSION_TRIGRAM_SPEC, "sessions_fts_trigram"),
+        (_FTS_SESSION_CJK_SPEC, "sessions_fts_cjk"),
+        (_FTS_MESSAGE_CJK_SPEC, "messages_fts_cjk"),
+    ],
+)
+def test_rebuild_specs_derive_identity_from_registry(spec, expected_table):
+    desc = _fts_descriptor(expected_table)
+    assert spec["descriptor"] is desc
+    assert spec["fts_table"] == desc.table
+    assert spec["source_table"] == desc.source
+    assert spec["row_key"] == desc.row_key
+    assert spec["fts_columns"] == desc.columns
+    assert spec["source_columns"] == desc.columns
+
+
+def test_message_spec_trigram_derives_from_registry():
+    assert (
+        _FTS_MESSAGE_SPEC["trigram_descriptor"]
+        is _fts_descriptor("messages_fts_trigram")
+    )
+    assert _FTS_MESSAGE_SPEC["trigram_fts"] == "messages_fts_trigram"
+    assert _FTS_MESSAGE_SPEC["trigram_columns"] == (
+        "content", "tool_name", "tool_calls",
+    )
+
+
+def test_message_cjk_spec_has_own_markers_and_shared_engine_shape():
+    assert _FTS_MESSAGE_CJK_SPEC["high_water_key"] == "fts_cjk_rebuild_high_water"
+    assert _FTS_MESSAGE_CJK_SPEC["progress_key"] == "fts_cjk_rebuild_progress"
+    # Distinct from the message Unicode pair (never shared).
+    assert _FTS_MESSAGE_CJK_SPEC["high_water_key"] != _FTS_MESSAGE_SPEC["high_water_key"]
+    assert _FTS_MESSAGE_CJK_SPEC["source_table"] == "messages_fts_cjk_src"
+
+
+# ── Ordinary maintenance covers the session indexes ──────────────────────
+
+def test_maintenance_tables_covers_owned_session_indexes(db):
+    assert db._fts_maintenance_tables() == _REQUIRED_MAINTENANCE_TABLES
+    assert set(db._fts_maintenance_tables()) <= _table_names()
+
+
+def test_optimize_touches_all_owned_indexes(db):
+    db.create_session(session_id="s1", source="cli")
+    db.set_session_title("s1", "alpha beta")
+    statements = []
+    db._conn.set_trace_callback(statements.append)
+    try:
+        count = db.optimize_fts()
+    finally:
+        db._conn.set_trace_callback(None)
+    assert count == len(_REQUIRED_MAINTENANCE_TABLES)
+    optimized = {
+        _fts_table_from_special_sql(sql)
+        for sql in statements
+        if "'optimize'" in sql
+    }
+    assert optimized == set(_REQUIRED_MAINTENANCE_TABLES)
+
+
+def test_bounded_merge_touches_all_owned_indexes(db):
+    db.create_session(session_id="s1", source="cli")
+    db.set_session_title("s1", "bounded merge")
+    statements = []
+    db._conn.set_trace_callback(statements.append)
+    try:
+        executed = db._merge_fts_incrementally(max_pages=37)
+    finally:
+        db._conn.set_trace_callback(None)
+    merge_sql = [sql for sql in statements if "VALUES('merge', 37)" in sql]
+    assert len(merge_sql) == executed
+    merged = {_fts_table_from_special_sql(sql) for sql in merge_sql}
+    assert merged == set(_REQUIRED_MAINTENANCE_TABLES)
+
+
+def _corrupt_shadow(db, shadow_table: str) -> None:
+    db._conn.execute(
+        f"UPDATE {shadow_table} SET block = X'BADC0FFEE0DDF00D'"
+    )
+    db._conn.commit()
+
+
+def test_rebuild_repairs_corrupt_session_unicode_index(db):
+    db.create_session(session_id="s1", source="cli")
+    db.set_session_title("s1", "pizzaparty")
+    assert _session_fts_matches(db, "pizzaparty")
+    _corrupt_shadow(db, "sessions_fts_data")
+    with pytest.raises(sqlite3.DatabaseError):
+        _session_fts_matches(db, "pizzaparty")
+    rebuilt = db.rebuild_fts()
+    assert rebuilt >= len(_REQUIRED_MAINTENANCE_TABLES)
+    assert _session_fts_matches(db, "pizzaparty")
+
+
+def test_rebuild_repairs_corrupt_session_trigram_index(db):
+    db.create_session(session_id="s1", source="cli")
+    db.set_session_title("s1", "pizza pie party")
+    assert _trigram_fts_matches(db, "pizza")
+    _corrupt_shadow(db, "sessions_fts_trigram_data")
+    with pytest.raises(sqlite3.DatabaseError):
+        _trigram_fts_matches(db, "pizza")
+    rebuilt = db.rebuild_fts()
+    assert rebuilt >= len(_REQUIRED_MAINTENANCE_TABLES)
+    assert _trigram_fts_matches(db, "pizza")
+
+
+def test_rebuild_skips_unavailable_trigram_target(db):
+    """Registry membership is NOT authorization to mutate a trigram target
+    this host cannot own (unknown same-name / quarantined #30 shape)."""
+    db.create_session(session_id="s1", source="cli")
+    db.set_session_title("s1", "skip trigram")
+    db._sessions_trigram_available = False  # simulate quarantined/unknown
+    statements = []
+    db._conn.set_trace_callback(statements.append)
+    try:
+        db.rebuild_fts()
+    finally:
+        db._conn.set_trace_callback(None)
+    rebuild_sql = [sql for sql in statements if "'rebuild'" in sql]
+    rebuilt_tables = {_fts_table_from_special_sql(sql) for sql in rebuild_sql}
+    assert "sessions_fts_trigram" not in rebuilt_tables
+    # The required Unicode session index is still rebuilt.
+    assert any(
+        "INSERT INTO sessions_fts(sessions_fts) VALUES('rebuild')" in sql
+        for sql in statements
+    )
+
+
+# ── Message-CJK rebuild now shares the generic engine ─────────────────────
+
+def test_message_cjk_rebuild_step_delegates_to_shared_engine(db, monkeypatch):
+    calls = []
+
+    def _spy_step(spec=None):
+        calls.append(spec)
+        return False
+
+    monkeypatch.setattr(db, "fts_rebuild_step", _spy_step)
+    assert db.fts_cjk_rebuild_step() is False
+    assert calls == [_FTS_MESSAGE_CJK_SPEC]
+
+
+def test_message_cjk_rebuild_status_delegates_to_shared_engine(db, monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        db,
+        "fts_rebuild_status",
+        lambda spec=None: calls.append(spec) or None,
+    )
+    assert db.fts_cjk_rebuild_status() is None
+    assert calls == [_FTS_MESSAGE_CJK_SPEC]
+
+
+def test_message_cjk_rebuild_finish_delegates_to_shared_engine(db, monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        db,
+        "_fts_rebuild_finish",
+        lambda spec=None: calls.append(spec),
+    )
+    db._fts_cjk_rebuild_finish()
+    assert calls == [_FTS_MESSAGE_CJK_SPEC]

--- a/tests/test_fts_lifecycle_registry.py
+++ b/tests/test_fts_lifecycle_registry.py
@@ -848,6 +848,25 @@ def test_read_only_unknown_trigram_fail_closed(tmp_path):
         ro.close()
 
 
+def test_read_only_missing_trigram_trigger_fail_closed(tmp_path):
+    """A read-only open never serves a canonical root/source whose live
+    trigger set is incomplete — a missing owned trigger means mutations may
+    not have propagated, so the index can be stale (issue #27 review R4)."""
+    db_path = _build_db_with_session(tmp_path)
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        "DROP TRIGGER IF EXISTS sessions_fts_trigram_update_after"
+    )
+    conn.commit()
+    conn.close()
+
+    ro = SessionDB(db_path=db_path, read_only=True)
+    try:
+        assert ro._sessions_trigram_available is False
+    finally:
+        ro.close()
+
+
 def test_lane_surface_sequences_pending_lanes(db, monkeypatch):
     """The shared deferred-rebuild lane surface runs every lane with pending
     work and skips lanes without it (issue #27)."""

--- a/tests/test_fts_lifecycle_registry.py
+++ b/tests/test_fts_lifecycle_registry.py
@@ -498,3 +498,148 @@ def test_migrate_leaves_trigram_update_triggers_under_30_identity(db):
         assert "UPDATE OF title, id, display_name" in sql
     # Migration is a no-op on an already-converged DB.
     assert db._migrate_broad_fts_update_triggers(db._conn) == 0
+
+
+# ── Offline / destructive repair covers the session indexes (issue #27) ───
+
+def test_offline_repair_rebuilds_corrupt_session_unicode_index(tmp_path):
+    from hermes_state import _db_opens_cleanly, repair_state_db_schema
+
+    db_path = _build_db_with_session(tmp_path)
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute(
+            "UPDATE sessions_fts_data SET block = X'BADC0FFEE0DDF00D'"
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    assert _db_opens_cleanly(db_path) is not None
+    report = repair_state_db_schema(db_path, backup=False)
+    assert report["repaired"] is True
+    assert report["strategy"] == "rebuild_fts"
+    assert _db_opens_cleanly(db_path) is None
+    # Canonical rows unchanged.
+    conn = sqlite3.connect(str(db_path))
+    try:
+        titles = [
+            r[0]
+            for r in conn.execute(
+                "SELECT title FROM sessions WHERE id = 's1'"
+            )
+        ]
+    finally:
+        conn.close()
+    assert titles == ["pizzaparty"]
+    # Session search works again through the rebuilt index.
+    reopened = SessionDB(db_path=db_path)
+    try:
+        assert reopened.resolve_session_by_title("pizzaparty") == "s1"
+    finally:
+        reopened.close()
+
+
+def test_offline_repair_rebuilds_corrupt_session_trigram_index(tmp_path):
+    from hermes_state import _db_opens_cleanly, repair_state_db_schema
+
+    db_path = _build_db_with_session(tmp_path, title="pizza pie party")
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute(
+            "UPDATE sessions_fts_trigram_data SET block = X'BADC0FFEE0DDF00D'"
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    assert _db_opens_cleanly(db_path) is not None
+    report = repair_state_db_schema(db_path, backup=False)
+    assert report["repaired"] is True
+    assert report["strategy"] == "rebuild_fts"
+    assert _db_opens_cleanly(db_path) is None
+
+
+def test_owned_fts_object_names_covers_six_indexes(db):
+    from hermes_state import _owned_fts_object_names
+
+    names = _owned_fts_object_names(db._conn)
+    for desc in FTS_INDEXES:
+        assert desc.table in names
+        for shadow in ("data", "idx", "content", "docsize", "config"):
+            assert f"{desc.table}_{shadow}" in names
+        for trig in desc.trigger_names:
+            assert trig in names
+        for _obj_type, obj_name in desc.derived_objects:
+            assert obj_name in names
+    assert len(names) == len(set(names))  # no duplicates
+
+
+def test_owned_fts_object_names_fail_closed_for_foreign_trigram(db, monkeypatch):
+    """An unknown same-name sessions_fts_trigram is positively classified and
+    left untouched by destructive repair (#30 fail-closed)."""
+    from hermes_state import _owned_fts_object_names
+
+    monkeypatch.setattr(
+        SessionDB,
+        "_sessions_trigram_modern_definition_matches",
+        staticmethod(lambda sql: False),
+    )
+    names = _owned_fts_object_names(db._conn)
+    assert not any(n.startswith("sessions_fts_trigram") for n in names)
+    # The other five members are still owned.
+    for table in (
+        "messages_fts",
+        "messages_fts_trigram",
+        "messages_fts_cjk",
+        "sessions_fts",
+        "sessions_fts_cjk",
+    ):
+        assert table in names
+
+
+def test_destructive_repair_removes_owned_objects_preserves_canonical(tmp_path):
+    from hermes_state import _drop_owned_fts_derived_schema
+
+    db_path = tmp_path / "state.db"
+    session_db = SessionDB(db_path=db_path)
+    session_db.create_session(session_id="s1", source="cli")
+    session_db.set_session_title("s1", "pizzaparty")
+    session_db.append_message("s1", role="user", content="hello world")
+    session_db.close()
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        before_sessions = conn.execute(
+            "SELECT row_id, id, title FROM sessions ORDER BY row_id"
+        ).fetchall()
+        before_messages = conn.execute(
+            "SELECT id, content FROM messages ORDER BY id"
+        ).fetchall()
+        assert before_sessions and before_messages
+        _drop_owned_fts_derived_schema(conn)
+        remaining = [
+            r[0]
+            for r in conn.execute(
+                "SELECT name FROM sqlite_master "
+                "WHERE type IN ('table','view','trigger','index') "
+                "AND (name LIKE 'messages_fts%' OR name LIKE 'sessions_fts%')"
+            ).fetchall()
+        ]
+        assert remaining == []
+        after_sessions = conn.execute(
+            "SELECT row_id, id, title FROM sessions ORDER BY row_id"
+        ).fetchall()
+        after_messages = conn.execute(
+            "SELECT id, content FROM messages ORDER BY id"
+        ).fetchall()
+        assert after_sessions == before_sessions
+        assert after_messages == before_messages
+    finally:
+        conn.close()
+
+    # Reopen recreates the supported derived schema; canonical search works.
+    reopened = SessionDB(db_path=db_path)
+    try:
+        assert len(reopened.search_messages("hello")) == 1
+        assert reopened.resolve_session_by_title("pizzaparty") == "s1"
+    finally:
+        reopened.close()

--- a/tests/test_fts_lifecycle_registry.py
+++ b/tests/test_fts_lifecycle_registry.py
@@ -643,3 +643,79 @@ def test_destructive_repair_removes_owned_objects_preserves_canonical(tmp_path):
         assert reopened.resolve_session_by_title("pizzaparty") == "s1"
     finally:
         reopened.close()
+
+
+# ── Read-only capability discovery + shared lane surface (issue #27) ──────
+
+def test_read_only_discovers_session_unicode_and_trigram(tmp_path):
+    """A read-only open discovers the existing session Unicode/trigram
+    capabilities with SELECTs only (no DDL / mutation), and can serve them."""
+    db_path = _build_db_with_session(tmp_path, title="pizza pie party")
+    ro = SessionDB(db_path=db_path, read_only=True)
+    try:
+        assert ro._sessions_fts_available is True
+        assert ro._sessions_trigram_available is True
+        # Read-only session search can use the discovered lanes.
+        fts_ok, candidates = ro._fts_metadata_candidates("pizza")
+        assert fts_ok is True
+        assert any(c["id"] == "s1" for c in candidates)
+        servable, trigram_candidates = ro._fts_session_trigram_candidates("pizza")
+        assert servable is True
+        assert any(c["id"] == "s1" for c in trigram_candidates)
+    finally:
+        ro.close()
+
+
+def test_read_only_unknown_trigram_fail_closed(tmp_path, monkeypatch):
+    """A read-only open never serves an unknown same-name sessions_fts_trigram
+    (#30 fail-closed, SELECT-only classification)."""
+    db_path = _build_db_with_session(tmp_path)
+    monkeypatch.setattr(
+        SessionDB,
+        "_classify_sessions_fts_trigram",
+        staticmethod(lambda cursor: "unknown_same_name"),
+    )
+    ro = SessionDB(db_path=db_path, read_only=True)
+    try:
+        assert ro._sessions_trigram_available is False
+    finally:
+        ro.close()
+
+
+def test_lane_surface_sequences_pending_lanes(db, monkeypatch):
+    """The shared deferred-rebuild lane surface runs every lane with pending
+    work and skips lanes without it (issue #27)."""
+    calls = []
+    pending = {"pending": True, "total": 1, "indexed": 0, "percent": 0}
+    monkeypatch.setattr(db, "fts_rebuild_status", lambda: pending)
+    monkeypatch.setattr(db, "fts_cjk_rebuild_status", lambda: None)
+    monkeypatch.setattr(db, "fts_session_rebuild_status", lambda: pending)
+    monkeypatch.setattr(db, "fts_session_trigram_rebuild_status", lambda: None)
+    monkeypatch.setattr(db, "fts_session_cjk_rebuild_status", lambda: None)
+    monkeypatch.setattr(
+        db, "fts_rebuild_step",
+        lambda: calls.append("messages") or False,
+    )
+    monkeypatch.setattr(
+        db, "fts_session_rebuild_step",
+        lambda: calls.append("sessions") or False,
+    )
+    # A lane with no pending work must never be stepped.
+    monkeypatch.setattr(
+        db, "fts_cjk_rebuild_step",
+        lambda: (_ for _ in ()).throw(
+            AssertionError("cjk lane must not run without pending work")
+        ),
+    )
+
+    db._fts_run_pending_lane_steps()
+    assert calls == ["messages", "sessions"]
+
+
+def test_fts_optimize_available_is_lane_driven(db):
+    """fts_optimize_available advertises work through the shared lane surface
+    — a session Unicode H marker is enough, and a healthy DB reports False."""
+    assert db.fts_optimize_available() is False
+    db.set_meta("fts_session_rebuild_high_water", "1")
+    db.set_meta("fts_session_rebuild_progress", "0")
+    assert db.fts_optimize_available() is True

--- a/tests/test_fts_lifecycle_registry.py
+++ b/tests/test_fts_lifecycle_registry.py
@@ -302,3 +302,199 @@ def test_message_cjk_rebuild_finish_delegates_to_shared_engine(db, monkeypatch):
     )
     db._fts_cjk_rebuild_finish()
     assert calls == [_FTS_MESSAGE_CJK_SPEC]
+
+
+# ── Health probes cover the session indexes (issue #27) ───────────────────
+
+def _build_db_with_session(tmp_path, title="pizzaparty"):
+    db_path = tmp_path / "state.db"
+    session_db = SessionDB(db_path=db_path)
+    session_db.create_session(session_id="s1", source="cli")
+    session_db.set_session_title("s1", title)
+    session_db.close()
+    return db_path
+
+
+def test_health_read_probe_detects_corrupt_session_unicode_index(tmp_path):
+    from hermes_state import _db_opens_cleanly
+
+    db_path = _build_db_with_session(tmp_path)
+    assert _db_opens_cleanly(db_path) is None  # healthy before
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute(
+            "UPDATE sessions_fts_data SET block = X'BADC0FFEE0DDF00D'"
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    reason = _db_opens_cleanly(db_path)
+    assert reason is not None
+    assert "sessions_fts" in reason
+
+
+def test_health_read_probe_detects_corrupt_session_trigram_index(tmp_path):
+    from hermes_state import _db_opens_cleanly
+
+    db_path = _build_db_with_session(tmp_path, title="pizza pie party")
+    assert _db_opens_cleanly(db_path) is None
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute(
+            "UPDATE sessions_fts_trigram_data SET block = X'BADC0FFEE0DDF00D'"
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    reason = _db_opens_cleanly(db_path)
+    assert reason is not None
+    assert "sessions_fts_trigram" in reason
+
+
+def test_health_write_probe_detects_corrupt_session_fts_write(tmp_path):
+    """The rollback-only write probe inserts non-null session metadata, so a
+    broken session FTS write path is detected without persisting probe data."""
+    from hermes_state import _db_opens_cleanly
+
+    db_path = _build_db_with_session(tmp_path)
+    conn = sqlite3.connect(str(db_path))
+    try:
+        # Write-class corruption: base reads fine, session FTS writes fail.
+        conn.execute(
+            "UPDATE sessions_fts_data SET block = X'DEADBEEFDEADBEEF'"
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    reason = _db_opens_cleanly(db_path)
+    assert reason is not None
+
+
+def test_health_write_probe_persists_no_rows(tmp_path):
+    from hermes_state import _db_opens_cleanly
+
+    db_path = _build_db_with_session(tmp_path)
+    assert _db_opens_cleanly(db_path) is None
+    conn = sqlite3.connect(str(db_path))
+    try:
+        probe_rows = conn.execute(
+            "SELECT COUNT(*) FROM sessions "
+            "WHERE id LIKE '_hermes_fts_health_probe_%'"
+        ).fetchone()[0]
+        messages = conn.execute(
+            "SELECT COUNT(*) FROM messages "
+            "WHERE session_id LIKE '_hermes_fts_health_probe_%'"
+        ).fetchone()[0]
+    finally:
+        conn.close()
+    assert probe_rows == 0
+    assert messages == 0
+
+
+# ── Trigger inventory / convergence derives from the registry ─────────────
+
+def test_drop_fts_triggers_covers_all_owned_session_triggers(db):
+    # Message + session Unicode + session trigram triggers exist on a default
+    # host (the optional CJK members are gated off without a tokenizer).
+    expected_present = (
+        _fts_descriptor("messages_fts").trigger_names
+        + _fts_descriptor("messages_fts_trigram").trigger_names
+        + _fts_descriptor("sessions_fts").trigger_names
+        + _fts_descriptor("sessions_fts_trigram").trigger_names
+    )
+    for name in expected_present:
+        row = db._conn.execute(
+            "SELECT 1 FROM sqlite_master "
+            "WHERE type = 'trigger' AND name = ?",
+            (name,),
+        ).fetchone()
+        assert row is not None, f"expected owned trigger {name}"
+    # _drop_fts_triggers removes every owned registry trigger name (message
+    # AND session), including the #30 trigram ones.
+    db._drop_fts_triggers(db._conn)
+    db._conn.commit()
+    all_owned = [n for d in FTS_INDEXES for n in d.trigger_names]
+    placeholders = ", ".join("?" for _ in all_owned)
+    remaining = [
+        r[0]
+        for r in db._conn.execute(
+            "SELECT name FROM sqlite_master "
+            f"WHERE type = 'trigger' AND name IN ({placeholders})",
+            all_owned,
+        ).fetchall()
+    ]
+    assert remaining == []
+
+
+def test_migrate_converges_broad_session_unicode_update_trigger(db):
+    """A broad dev-era sessions_fts_update converges to the canonical narrow
+    AFTER UPDATE OF title, id, display_name (issue #27)."""
+    db._conn.execute("DROP TRIGGER IF EXISTS sessions_fts_update")
+    db._conn.execute(
+        """
+        CREATE TRIGGER sessions_fts_update AFTER UPDATE ON sessions
+        BEGIN
+            SELECT 1;
+        END
+        """
+    )
+    db._conn.commit()
+    before = db._conn.execute(
+        "SELECT sql FROM sqlite_master "
+        "WHERE type = 'trigger' AND name = 'sessions_fts_update'"
+    ).fetchone()[0]
+    assert "AFTER UPDATE OF" not in " ".join(before.split()).upper()
+
+    dropped = db._migrate_broad_fts_update_triggers(db._conn)
+    db._conn.commit()
+    assert dropped >= 1
+    after = db._conn.execute(
+        "SELECT sql FROM sqlite_master "
+        "WHERE type = 'trigger' AND name = 'sessions_fts_update'"
+    ).fetchone()[0]
+    assert "AFTER UPDATE OF title, id, display_name" in after
+
+
+def test_migrate_converges_broad_session_cjk_update_trigger(db):
+    """A broad sessions_fts_cjk_update converges to the canonical narrow DDL
+    on a tokenizer-capable host (issue #27/#26)."""
+    if not db._sessions_cjk_worker_operable:
+        pytest.skip("no loadable CJK tokenizer on this host")
+    db._conn.execute("DROP TRIGGER IF EXISTS sessions_fts_cjk_update")
+    db._conn.execute(
+        """
+        CREATE TRIGGER sessions_fts_cjk_update AFTER UPDATE ON sessions
+        BEGIN
+            SELECT 1;
+        END
+        """
+    )
+    db._conn.commit()
+    dropped = db._migrate_broad_fts_update_triggers(db._conn)
+    db._conn.commit()
+    assert dropped >= 1
+    after = db._conn.execute(
+        "SELECT sql FROM sqlite_master "
+        "WHERE type = 'trigger' AND name = 'sessions_fts_cjk_update'"
+    ).fetchone()[0]
+    assert "AFTER UPDATE OF title, id, display_name" in after
+
+
+def test_migrate_leaves_trigram_update_triggers_under_30_identity(db):
+    """sessions_fts_trigram_update_before/_after are canonical narrow #30
+    triggers (BEFORE/AFTER UPDATE OF title, id, display_name) and must never
+    be rewritten by the broad→narrow migration."""
+    for name in (
+        "sessions_fts_trigram_update_before",
+        "sessions_fts_trigram_update_after",
+    ):
+        row = db._conn.execute(
+            "SELECT sql FROM sqlite_master "
+            "WHERE type = 'trigger' AND name = ?",
+            (name,),
+        ).fetchone()
+        assert row is not None
+        sql = row[0]
+        assert "UPDATE OF title, id, display_name" in sql
+    # Migration is a no-op on an already-converged DB.
+    assert db._migrate_broad_fts_update_triggers(db._conn) == 0

--- a/tests/test_fts_lifecycle_registry.py
+++ b/tests/test_fts_lifecycle_registry.py
@@ -759,44 +759,6 @@ def test_offline_repair_leaves_foreign_trigram_untouched(tmp_path):
         conn.close()
 
 
-def test_health_probe_never_reports_foreign_trigram_as_owned_repair(tmp_path):
-    """A corrupt foreign-gated sessions_fts_trigram is outside owned repair:
-    the health check still surfaces real corruption (PRAGMA integrity_check
-    is detection, not mutation), but repair must fail closed and leave the
-    foreign objects byte/DDL-identical. This pins the read-probe ownership
-    gate end-to-end via the repair path."""
-    from hermes_state import _db_opens_cleanly, repair_state_db_schema
-
-    db_path = _build_db_with_session(tmp_path, title="pizza pie party")
-    conn = sqlite3.connect(str(db_path))
-    _install_foreign_trigram_triggers(conn)
-    conn.execute(
-        "UPDATE sessions_fts_trigram_data SET block = X'BADC0FFEE0DDF00D'"
-    )
-    conn.commit()
-    before_trigger = conn.execute(
-        "SELECT sql FROM sqlite_master "
-        "WHERE type = 'trigger' AND name = 'sessions_fts_trigram_update_before'"
-    ).fetchone()[0]
-    conn.close()
-
-    # Detection is fine (integrity_check reports the corruption), but repair
-    # must not claim success over a foreign object it refuses to touch.
-    assert _db_opens_cleanly(db_path) is not None
-    report = repair_state_db_schema(db_path, backup=False)
-    assert report["repaired"] is False
-
-    conn = sqlite3.connect(str(db_path))
-    try:
-        after_trigger = conn.execute(
-            "SELECT sql FROM sqlite_master "
-            "WHERE type = 'trigger' AND name = 'sessions_fts_trigram_update_before'"
-        ).fetchone()[0]
-        assert after_trigger == before_trigger  # foreign occupant untouched
-    finally:
-        conn.close()
-
-
 def test_destructive_repair_removes_owned_objects_preserves_canonical(tmp_path):
     from hermes_state import _drop_owned_fts_derived_schema
 
@@ -877,22 +839,6 @@ def test_read_only_unknown_trigram_fail_closed(tmp_path):
     _install_foreign_trigram_triggers(
         conn, names=("sessions_fts_trigram_update_before",)
     )
-    conn.close()
-
-    ro = SessionDB(db_path=db_path, read_only=True)
-    try:
-        assert ro._sessions_trigram_available is False
-    finally:
-        ro.close()
-
-
-def test_read_only_foreign_trigram_source_fail_closed(tmp_path):
-    """A read-only open never serves a canonical root whose derived source
-    VIEW is foreign (real mixed DDL — the same boundary the R2 destructive
-    fixtures pin, exercised on the SELECT-only path)."""
-    db_path = _build_db_with_session(tmp_path)
-    conn = sqlite3.connect(str(db_path))
-    _install_foreign_trigram_source(conn)
     conn.close()
 
     ro = SessionDB(db_path=db_path, read_only=True)

--- a/tests/test_fts_lifecycle_registry.py
+++ b/tests/test_fts_lifecycle_registry.py
@@ -867,15 +867,34 @@ def test_read_only_discovers_session_unicode_and_trigram(tmp_path):
         ro.close()
 
 
-def test_read_only_unknown_trigram_fail_closed(tmp_path, monkeypatch):
-    """A read-only open never serves an unknown same-name sessions_fts_trigram
-    (#30 fail-closed, SELECT-only classification)."""
+def test_read_only_unknown_trigram_fail_closed(tmp_path):
+    """A read-only open never serves a sessions_fts_trigram namespace with a
+    foreign same-name trigger occupant — #30 fail-closed covers the trigger
+    namespace, not just root + source VIEW (issue #27 review R3, real mixed
+    DDL instead of a monkeypatched classifier)."""
     db_path = _build_db_with_session(tmp_path)
-    monkeypatch.setattr(
-        SessionDB,
-        "_classify_sessions_fts_trigram",
-        staticmethod(lambda cursor: "unknown_same_name"),
+    conn = sqlite3.connect(str(db_path))
+    _install_foreign_trigram_triggers(
+        conn, names=("sessions_fts_trigram_update_before",)
     )
+    conn.close()
+
+    ro = SessionDB(db_path=db_path, read_only=True)
+    try:
+        assert ro._sessions_trigram_available is False
+    finally:
+        ro.close()
+
+
+def test_read_only_foreign_trigram_source_fail_closed(tmp_path):
+    """A read-only open never serves a canonical root whose derived source
+    VIEW is foreign (real mixed DDL — the same boundary the R2 destructive
+    fixtures pin, exercised on the SELECT-only path)."""
+    db_path = _build_db_with_session(tmp_path)
+    conn = sqlite3.connect(str(db_path))
+    _install_foreign_trigram_source(conn)
+    conn.close()
+
     ro = SessionDB(db_path=db_path, read_only=True)
     try:
         assert ro._sessions_trigram_available is False

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2173,20 +2173,30 @@ class TestVacuum:
 
 class TestOptimizeFts:
     def test_optimize_returns_index_count(self, db):
-        """A fresh DB has both FTS indexes; optimize merges both."""
+        """A fresh DB has four owned FTS indexes (message Unicode/trigram +
+        session Unicode/trigram; CJK members are gated off without a
+        loadable tokenizer); optimize merges all of them (issue #27)."""
         db.create_session(session_id="s1", source="cli")
         db.append_message(session_id="s1", role="user", content="hello world")
         statements = []
         db._conn.set_trace_callback(statements.append)
         try:
-            assert db.optimize_fts() == 2
+            assert db.optimize_fts() == 4
         finally:
             db._conn.set_trace_callback(None)
         optimize_sql = [sql for sql in statements if "'optimize'" in sql]
-        assert len(optimize_sql) == 2
+        assert len(optimize_sql) == 4
         assert not any("'merge'" in sql for sql in optimize_sql)
-
-
+        optimized = {
+            sql.split("INSERT INTO ", 1)[1].split("(", 1)[0].strip()
+            for sql in optimize_sql
+        }
+        assert optimized == {
+            "messages_fts",
+            "messages_fts_trigram",
+            "sessions_fts",
+            "sessions_fts_trigram",
+        }
 
 
     def test_incremental_merge_bounded_commands_per_present_index(self, db):
@@ -2201,9 +2211,11 @@ class TestOptimizeFts:
             db._conn.set_trace_callback(None)
 
         # At least one merge command per present FTS index, and never more
-        # than the per-pass command cap per index.
-        present = [t for t in db._FTS_TABLES if db._fts_table_exists(t)]
-        assert len(present) >= 2  # messages_fts + trigram on a fresh DB
+        # than the per-pass command cap per index. The applicable index set
+        # derives from the authoritative FTS_INDEXES registry (issue #27),
+        # so the session Unicode/trigram members participate too.
+        present = list(db._fts_maintenance_tables())
+        assert len(present) >= 4  # messages + session Unicode/trigram
         merge_sql = [sql for sql in statements if "VALUES('merge', 37)" in sql]
         assert len(merge_sql) == executed
         assert len(present) <= executed <= (
@@ -2883,8 +2895,10 @@ class TestFTSExternalContentMigration:
             db.set_meta("fts_rebuild_progress", "0")
             # The public contract: optimize returns ok=False when still
             # pending. Simulate an unfinishable backfill by stubbing the
-            # chunk step to a no-op while markers stay.
-            db.fts_rebuild_step = lambda: False  # type: ignore[method-assign]
+            # shared chunk step (message AND message-CJK lanes both enter
+            # through fts_rebuild_step since #27 folded CJK onto the shared
+            # engine) to a no-op while markers stay.
+            db.fts_rebuild_step = lambda spec=None: False  # type: ignore[method-assign]
             result = db.optimize_fts_storage(vacuum=False)
             assert result["ok"] is False
             assert result.get("reason") == "backfill_incomplete"

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2602,7 +2602,10 @@ class TestFTSExternalContentMigration:
         from hermes_state import FTS_SQL, FTS_TRIGRAM_SQL
 
         conn = db._conn
-        db._drop_fts_triggers(conn)
+        # The demote path now tears down only the message triggers (issue #27)
+        # — session metadata triggers keep live-indexing during the message
+        # layout migration, so the crash-window simulation mirrors that.
+        db._drop_message_fts_triggers(conn)
         conn.execute("DROP VIEW IF EXISTS messages_fts_trigram_src")
         had = bool(conn.execute(
             "SELECT 1 FROM sqlite_master WHERE type = 'table' "

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2599,13 +2599,19 @@ class TestFTSExternalContentMigration:
         Mirrors what happened when ``_ensure_fts_schema`` ran inside
         ``_execute_write`` and the process died before the marker writes.
         """
-        from hermes_state import FTS_SQL, FTS_TRIGRAM_SQL
+        from hermes_state import FTS_SQL, FTS_TRIGRAM_SQL, _fts_descriptor
 
         conn = db._conn
         # The demote path now tears down only the message triggers (issue #27)
         # — session metadata triggers keep live-indexing during the message
         # layout migration, so the crash-window simulation mirrors that.
-        db._drop_message_fts_triggers(conn)
+        db._drop_fts_triggers(
+            conn,
+            names=(
+                _fts_descriptor("messages_fts").trigger_names
+                + _fts_descriptor("messages_fts_trigram").trigger_names
+            ),
+        )
         conn.execute("DROP VIEW IF EXISTS messages_fts_trigram_src")
         had = bool(conn.execute(
             "SELECT 1 FROM sqlite_master WHERE type = 'table' "


### PR DESCRIPTION
Closes #27

Implements the unified six-index FTS lifecycle membership per the #35
research handoff (PR #75, `docs/research/issue-35-unified-fts-lifecycle.md`).

## What this adds

- A single **data-only descriptor registry** (`FtsIndexDescriptor` +
  `FTS_INDEXES` in `hermes_state_common.py`) covering the six modern FTS
  indexes: messages_fts, messages_fts_trigram, messages_fts_cjk,
  sessions_fts, sessions_fts_cjk, sessions_fts_trigram.
- Rebuild specs derive their static identity from the descriptors; the CJK
  session lane reuses the shared engine via a generic message-CJK spec.
- Health read/write probes, trigger convergence, offline repair (strategies
  0/2), read-only capability discovery, and the shared deferred-rebuild lane
  surface all drive off the registry instead of hand-maintained table lists.
- #30 ownership discipline preserved end-to-end: every offline/global path
  that probes, rebuilds, lists, or drops `sessions_fts_trigram` gates on the
  existing #30 classifiers (root + derived source VIEW + trigger namespace),
  fail-closed against any foreign same-name object.

## Review history

- R1 ponytail + code-review (`5253715082`, fixed `0400c66f0`).
- R2 (`5254482988`, fixed `933a2ce86`) — ownership gate reused in
  offline/global paths (P1), read-only CJK worker flag (P2), real mixed-DDL
  fixtures (S1).
- R3 (`5260385052`, fixed `ed5ab2e8e`) — read-only trigram discovery gates
  on full #30 namespace ownership.
- Ponytail pass (`3bc7d3f58`, net -140 lines).
- R4 (`5264349085`, fixed `d6a4d7048`) — read-only trigram serving requires a
  complete trigger set.

Standards: 0 findings (last two rounds). Spec: all findings resolved.

## Validation

- Registry + trigram/CJK + repair + narrowing suites: 116 passed /
  29 skipped (CJK tokenizer capability-skipped on this host).
- `test_hermes_state.py` (health probe, optimize, read-only paths):
  178 passed.
- ruff clean on all touched files.

## Boundary

- No `FTS_STORAGE_VERSION` change — storage-v2 settlement stays with #31.
- Search routing/ranking/fallback stays with #14/#28.
