### PR TITLE
feat(fts): storage-v2 settlement state machine (#31)

### DIFF
--- a/docs/research/issue-31-storage-v2-settlement.md
+++ b/docs/research/issue-31-storage-v2-settlement.md
@@ -1,0 +1,101 @@
+# #31 implementation — storage-v2 settlement state machine
+
+Status: **implemented (2026-08-12)**  
+Code base: **`9d140c8594c67ed37729b190fd3733508d0d770c`** (post-#27 `dev` merge, per the #36 research handoff)  
+Branch: `feat/31-storage-v2-settlement`  
+Research artifact: `docs/research/issue-36-storage-v2-settlement.md` (PR #77)  
+Target: **#31 — Session metadata FTS: settle storage v2 after all required indexes complete**
+
+> This is the implementation record for #36's handoff. #31 owns **only the
+> storage-layout settlement / completion state machine**: when the DB is
+> allowed to claim `fts_storage_version = 2`, and how that claim recovers
+> across interruption/reopen. It is NOT a rebuild engine, scheduler,
+> registry, or migration framework; #25/#26/#27/#30 keep owning every
+> per-lane worker/repair/stale-transition path, and search routing/ranking
+> stays with #14/#28.
+
+## What changed
+
+`FTS_STORAGE_VERSION` moved `1 -> 2` in the same stack as one **shared
+SELECT-only, durable/schema-aware completion evaluator**,
+`SessionDB._fts_storage_v2_blocker(conn)`:
+
+- returns `None` when the DB is acceptance-complete for v2, or
+- returns `(reason, actionable_here)` for the first blocker found.
+
+The SAME evaluator now drives every place that can claim or advertise
+completion, so the four pre-#31 completion decisions can never diverge again:
+
+| Consumer | Before #31 | After #31 |
+|---|---|---|
+| writable startup | message-only subset, **before** session ensure | runs **after** every message/session ensure path, same evaluator |
+| `fts_optimize_available()` | independent inventory + operability-gated `_fts_lane_pending()` | evaluator result, `actionable_here` only |
+| foreground pre-VACUUM refusal | hard-coded partial session list | same evaluator |
+| final transactional `_settle()` | message high-water/trash/message-empty only | same evaluator, re-checked inside the write transaction |
+
+### Refusal semantics (durable, not serving-boolean)
+
+- Any required message/session **H, P, or stale breadcrumb** blocks v2 — even
+  on a host that cannot operate the lane. Missing capability is never
+  evidence of completion.
+- `unknown_same_name` trigram (incl. the historical fork `tokenize='simple'`
+  root), foreign trigger occupants, source collisions, and an incomplete
+  exact modern trigger set fail closed — v2 is refused and the object is
+  left byte-identical (no destructive legacy-simple convergence resurrected).
+- Optional capability rule preserved: *optional + never established + no
+  durable work* = valid degraded completion; *optional + H/P/stale/quarantine
+  or incomplete existing target* = unfinished.
+
+### Claim withdrawal (crash-safety)
+
+A stale v2 claim is withdrawn wherever the evaluator reports a blocker —
+startup reopen, the pre-VACUUM refusal, and the final transactional re-check
+— so no completion is advertised while work remains (e.g. a DB settled at v2
+that later stages a new optional CJK/trigram index).
+
+### Reuse, not reimplementation
+
+- `_FTS_REBUILD_LANES` is the marker/stale membership source for the
+  per-lane H/P/stale loop (one tiny reason-label map added).
+- `_FTS_INDEXES` / #30 ownership classifiers / #76832 claim-before-empty +
+  transactional re-check seams are all consumed unchanged.
+- `_fts_lane_pending()` was removed — its only consumer was
+  `fts_optimize_available()`, and its combined operability gate is wrong for
+  settlement (the evaluator splits "blocked" from "actionable here").
+
+## Files
+
+- `hermes_state_common.py` — `FTS_STORAGE_VERSION = 2`.
+- `hermes_state_search.py` — `_fts_storage_v2_blocker`, lane helpers
+  (`_fts_lane_durable_keys` / `_fts_meta_has_any` / `_fts_lane_actionable`),
+  `_fts_session_trigram_settlement_blocker`, and the three consumers
+  (`fts_optimize_available`, pre-VACUUM refusal, `_settle`).
+- `hermes_state_schema.py` — startup stamp moved after all FTS/session
+  ensure paths; withdraws a stale claim when blocked.
+- `tests/test_fts_storage_v2_settlement.py` — refusal matrix, startup +
+  interruption/reopen, six-index acceptance matrix (24 tests).
+
+## Validation
+
+```bash
+uv run pytest -q tests/test_fts_storage_v2_settlement.py \
+  tests/test_hermes_state.py tests/test_session_metadata_fts.py \
+  tests/test_session_metadata_cjk_fts.py tests/test_session_metadata_trigram_fts.py \
+  tests/test_fts_cjk_bigram.py tests/test_fts_lifecycle_registry.py \
+  tests/test_session_db_read_path_split.py tests/state/test_fts_runtime_rebuild.py \
+  tests/test_state_db_malformed_repair.py tests/test_fts_update_of_narrowing.py
+
+uvx ruff check hermes_state_common.py hermes_state_schema.py \
+  hermes_state_search.py tests/test_fts_storage_v2_settlement.py
+```
+
+Focused suite: 375 passed / 43 skipped (CJK-tokenizer capability skips) on
+this host. ruff clean.
+
+## Boundary / non-goals
+
+- No per-index search-routing changes (#14/#28).
+- No ordinary optimize/merge/health/repair membership changes (#27).
+- No message FTS storage-semantics changes (v23 path).
+- `schema_version` stays independent of storage-v2 settlement (decoupled).
+- `unknown_same_name` trigram objects are never deleted or demoted here.

--- a/docs/research/issue-31-storage-v2-settlement.md
+++ b/docs/research/issue-31-storage-v2-settlement.md
@@ -55,25 +55,43 @@ that later stages a new optional CJK/trigram index).
 
 ### Reuse, not reimplementation
 
-- `_FTS_REBUILD_LANES` is the marker/stale membership source for the
-  per-lane H/P/stale loop (one tiny reason-label map added).
+- `_FTS_REBUILD_LANES` is the marker/stale membership source; each lane also
+  carries its own `settlement_reason` label (no parallel reason map to drift
+  or KeyError on a future lane).
 - `_FTS_INDEXES` / #30 ownership classifiers / #76832 claim-before-empty +
   transactional re-check seams are all consumed unchanged.
 - `_fts_lane_pending()` was removed — its only consumer was
   `fts_optimize_available()`, and its combined operability gate is wrong for
   settlement (the evaluator splits "blocked" from "actionable here").
 
+### Review round (2026-08-12)
+
+Findings addressed from the first `/code-review`:
+- All nine structural refusal branches (`*_legacy`, `*_orphan_empty`, trigram
+  `namespace_foreign` / `source_collision` / `trigger_incomplete`) are now
+  directly pinned in `tests/test_fts_storage_v2_settlement.py`.
+- Stale-claim withdrawal extracted into one `_fts_storage_v2_withdraw_claim`
+  helper (three call sites, no scattered `DELETE` literals).
+- Startup settlement now runs unconditionally (outside the `if fts5_available:`
+  gate), so an FTS5-unavailable reopen also withdraws a stale v2 claim via the
+  evaluator's own `fts5_unavailable` guard.
+- Message-lane marker keys derive from `_FTS_MESSAGE_SPEC`; optional
+  capability attrs are read directly (they are always initialized in
+  `SessionDB.__init__`).
+
 ## Files
 
 - `hermes_state_common.py` — `FTS_STORAGE_VERSION = 2`.
 - `hermes_state_search.py` — `_fts_storage_v2_blocker`, lane helpers
   (`_fts_lane_durable_keys` / `_fts_meta_has_any` / `_fts_lane_actionable`),
-  `_fts_session_trigram_settlement_blocker`, and the three consumers
+  `_fts_session_trigram_settlement_blocker`,
+  `_fts_storage_v2_withdraw_claim`, and the three consumers
   (`fts_optimize_available`, pre-VACUUM refusal, `_settle`).
 - `hermes_state_schema.py` — startup stamp moved after all FTS/session
   ensure paths; withdraws a stale claim when blocked.
 - `tests/test_fts_storage_v2_settlement.py` — refusal matrix, startup +
-  interruption/reopen, six-index acceptance matrix (24 tests).
+  interruption/reopen, six-index acceptance matrix, structural-branch pins
+  (33 tests).
 
 ## Validation
 
@@ -89,8 +107,8 @@ uvx ruff check hermes_state_common.py hermes_state_schema.py \
   hermes_state_search.py tests/test_fts_storage_v2_settlement.py
 ```
 
-Focused suite: 375 passed / 43 skipped (CJK-tokenizer capability skips) on
-this host. ruff clean.
+Focused suite: 369 passed / 43 skipped (CJK-tokenizer capability skips) on
+this host (incl. the 33-test settlement file). ruff clean.
 
 ## Boundary / non-goals
 

--- a/docs/research/issue-31-storage-v2-settlement.md
+++ b/docs/research/issue-31-storage-v2-settlement.md
@@ -125,7 +125,7 @@ uvx ruff check hermes_state_common.py hermes_state_schema.py \
 ```
 
 Focused suite: 371 passed / 43 skipped (CJK-tokenizer capability skips) on
-this host (incl. the 33-test settlement file). ruff clean.
+this host (incl. the 35-test settlement file). ruff clean.
 
 ## Boundary / non-goals
 

--- a/docs/research/issue-31-storage-v2-settlement.md
+++ b/docs/research/issue-31-storage-v2-settlement.md
@@ -79,10 +79,27 @@ Findings addressed from the first `/code-review`:
   capability attrs are read directly (they are always initialized in
   `SessionDB.__init__`).
 
+### Review round 3 (2026-08-12) — P2: actionability over the whole blocker set
+
+`fts_optimize_available()` must answer "is ANY blocker actionable on this
+host", not "is the FIRST blocker actionable": the shared worker skips lanes
+it cannot operate and keeps going, so an earlier incapable blocker (e.g.
+message-CJK on a cjk-less host) used to hide a later runnable lane. The
+evaluator is now a generator, `_fts_storage_v2_blockers(conn)`, that yields
+EVERY blocker in order; `_fts_storage_v2_blocker()` keeps its first-blocker
+contract for settlement/refusal, while `fts_optimize_available()` computes
+`ANY(actionable)` across the whole set. The refusal inventory stays
+single-source — no second hard-coded list was reintroduced. Two tests pin
+it: a mixed-capability case (non-actionable message-CJK first, actionable
+session-Unicode after -> `fts_optimize_available()` True, and optimize
+progresses the session lane while message-CJK stays) and an
+only-non-actionable case (-> False).
+
 ## Files
 
 - `hermes_state_common.py` — `FTS_STORAGE_VERSION = 2`.
-- `hermes_state_search.py` — `_fts_storage_v2_blocker`, lane helpers
+- `hermes_state_search.py` — `_fts_storage_v2_blockers` (all blockers),
+  `_fts_storage_v2_blocker` (first blocker), lane helpers
   (`_fts_lane_durable_keys` / `_fts_meta_has_any` / `_fts_lane_actionable`),
   `_fts_session_trigram_settlement_blocker`,
   `_fts_storage_v2_withdraw_claim`, and the three consumers
@@ -90,8 +107,8 @@ Findings addressed from the first `/code-review`:
 - `hermes_state_schema.py` — startup stamp moved after all FTS/session
   ensure paths; withdraws a stale claim when blocked.
 - `tests/test_fts_storage_v2_settlement.py` — refusal matrix, startup +
-  interruption/reopen, six-index acceptance matrix, structural-branch pins
-  (33 tests).
+  interruption/reopen, six-index acceptance matrix, structural-branch pins,
+  mixed-capability actionability (35 tests).
 
 ## Validation
 
@@ -107,7 +124,7 @@ uvx ruff check hermes_state_common.py hermes_state_schema.py \
   hermes_state_search.py tests/test_fts_storage_v2_settlement.py
 ```
 
-Focused suite: 369 passed / 43 skipped (CJK-tokenizer capability skips) on
+Focused suite: 371 passed / 43 skipped (CJK-tokenizer capability skips) on
 this host (incl. the 33-test settlement file). ruff clean.
 
 ## Boundary / non-goals

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -164,7 +164,11 @@ SCHEMA_VERSION = 25
 # layout 0 (marker absent) with a working inline index until the user opts in.
 #   1 = v23 external-content layout (content/tool_name/tool_calls,
 #       tool-row-excluded trigram)
-FTS_STORAGE_VERSION = 1
+#   2 = #31 six-index settlement: the same layout claim additionally
+#       requires EVERY session-metadata index (Unicode/CJK/trigram) to be
+#       acceptance-complete through the shared storage-v2 evaluator — it is
+#       never stamped from a message-only subset of state.
+FTS_STORAGE_VERSION = 2
 
 
 # Cap on user-controlled FTS5 query input before regex/sanitizer processing.

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -1101,31 +1101,6 @@ class SessionSchemaMixin:
                 # one large prompt copy per session.
                 self._dedupe_legacy_system_prompts(cursor)
 
-            # The FTS storage layout is versioned independently of the main
-            # schema (see the v23 note above). Stamp the current layout so the
-            # main version can always advance: a fresh/optimized DB is at
-            # FTS_STORAGE_VERSION; a legacy DB is left at whatever it had
-            # (absent/0) until `optimize-storage` runs. An INTERRUPTED
-            # optimize (legacy vtables already demoted, but rebuild markers
-            # or demoted trash tables still present, or an empty external
-            # index against non-empty messages) is NOT stamped either —
-            # the marker is the source of truth for "fully optimized", and
-            # `fts_optimize_available()` keeps offering the resume until the
-            # transition actually completes.
-            if (
-                fts5_available
-                and not self._db_has_legacy_inline_fts(cursor)
-                and cursor.execute(
-                    "SELECT 1 FROM state_meta "
-                    "WHERE key = 'fts_rebuild_high_water' LIMIT 1"
-                ).fetchone() is None
-                and not self._has_fts_trash(cursor)
-                and not self._fts_external_index_empty_with_messages(cursor)
-            ):
-                self.set_meta(
-                    "fts_storage_version", str(FTS_STORAGE_VERSION), cursor=cursor
-                )
-
             # Advance schema_version to current for ALL non-FTS-layout
             # migrations. This is deliberately NOT gated on the FTS opt-in —
             # holding the whole version back would block every future schema
@@ -1275,6 +1250,32 @@ class SessionSchemaMixin:
             # AFTER UPDATE OF variants. IF NOT EXISTS cannot rewrite them.
             if getattr(self, "_fts_enabled", False):
                 self._migrate_broad_fts_update_triggers(cursor)
+
+            # ── Storage-v2 auto-settlement (issue #31) ─────────────
+            # Runs AFTER every message/session FTS ensure path so the shared
+            # SELECT-only completion evaluator sees the full staged state. A
+            # populated DB's first open therefore does NOT stamp v2 (session
+            # Unicode/CJK/trigram ensure stages durable H/P claims that
+            # remain pending); a fresh/empty or already-settled DB may claim
+            # the current storage layout. The SAME evaluator drives
+            # fts_optimize_available(), the foreground pre-VACUUM refusal,
+            # and the final transactional stamp, so no completion decision
+            # can diverge. schema_version stays independent (decoupled), as
+            # in v23.
+            blocker = self._fts_storage_v2_blocker(cursor)
+            if blocker is None:
+                self.set_meta(
+                    "fts_storage_version", str(FTS_STORAGE_VERSION), cursor=cursor
+                )
+            else:
+                # A previously stamped layout claim is now stale (new
+                # incomplete work appeared — e.g. an optional CJK/trigram
+                # index staged on a previously-settled DB). Withdraw it so
+                # no completion can be advertised while work remains
+                # (issue #31).
+                cursor.execute(
+                    "DELETE FROM state_meta WHERE key = 'fts_storage_version'"
+                )
 
         self._conn.commit()
 

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -1251,31 +1251,33 @@ class SessionSchemaMixin:
             if getattr(self, "_fts_enabled", False):
                 self._migrate_broad_fts_update_triggers(cursor)
 
-            # ── Storage-v2 auto-settlement (issue #31) ─────────────
-            # Runs AFTER every message/session FTS ensure path so the shared
-            # SELECT-only completion evaluator sees the full staged state. A
-            # populated DB's first open therefore does NOT stamp v2 (session
-            # Unicode/CJK/trigram ensure stages durable H/P claims that
-            # remain pending); a fresh/empty or already-settled DB may claim
-            # the current storage layout. The SAME evaluator drives
-            # fts_optimize_available(), the foreground pre-VACUUM refusal,
-            # and the final transactional stamp, so no completion decision
-            # can diverge. schema_version stays independent (decoupled), as
-            # in v23.
-            blocker = self._fts_storage_v2_blocker(cursor)
-            if blocker is None:
-                self.set_meta(
-                    "fts_storage_version", str(FTS_STORAGE_VERSION), cursor=cursor
-                )
-            else:
-                # A previously stamped layout claim is now stale (new
-                # incomplete work appeared — e.g. an optional CJK/trigram
-                # index staged on a previously-settled DB). Withdraw it so
-                # no completion can be advertised while work remains
-                # (issue #31).
-                cursor.execute(
-                    "DELETE FROM state_meta WHERE key = 'fts_storage_version'"
-                )
+        # ── Storage-v2 auto-settlement (issue #31) ─────────────────
+        # Runs AFTER every message/session FTS ensure path so the shared
+        # SELECT-only completion evaluator sees the full staged state. A
+        # populated DB's first open therefore does NOT stamp v2 (session
+        # Unicode/CJK/trigram ensure stages durable H/P claims that remain
+        # pending); a fresh/empty or already-settled DB may claim the current
+        # storage layout. The SAME evaluator drives fts_optimize_available(),
+        # the foreground pre-VACUUM refusal, and the final transactional
+        # stamp, so no completion decision can diverge. schema_version stays
+        # independent (decoupled), as in v23.
+        #
+        # Runs unconditionally (not only when FTS5 is available): the
+        # evaluator's own ``_fts_enabled`` guard refuses (and withdraws) a
+        # stale v2 claim on an FTS5-unavailable reopen too, so no layout
+        # claim survives on a host that cannot even run FTS.
+        blocker = self._fts_storage_v2_blocker(cursor)
+        if blocker is None:
+            self.set_meta(
+                "fts_storage_version", str(FTS_STORAGE_VERSION), cursor=cursor
+            )
+        else:
+            # A previously stamped layout claim is now stale (new incomplete
+            # work appeared — e.g. an optional CJK/trigram index staged on a
+            # previously-settled DB, or FTS5 unavailable on reopen). Withdraw
+            # it so no completion can be advertised while work remains
+            # (issue #31).
+            self._fts_storage_v2_withdraw_claim(cursor)
 
         self._conn.commit()
 

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -296,7 +296,8 @@ _FTS_MESSAGE_CJK_SPEC = {
 # from the ``FTS_INDEXES`` registry: H/P markers and stale breadcrumbs are
 # lane-specific state that lives in the rebuild specs, not in the index
 # descriptor. ``stale_key`` (when present) names the lane's durable stale
-# breadcrumb for the pending-work probe.
+# breadcrumb for the pending-work probe; ``settlement_reason`` is the
+# storage-v2 refusal label for the lane (issue #31).
 _FTS_REBUILD_LANES: Tuple[Dict[str, Any], ...] = (
     {
         "spec": _FTS_MESSAGE_SPEC,
@@ -307,40 +308,32 @@ _FTS_REBUILD_LANES: Tuple[Dict[str, Any], ...] = (
     {
         "spec": _FTS_MESSAGE_CJK_SPEC,
         "stale_key": FTS_CJK_STALE_KEY,
+        "settlement_reason": "message_cjk_incomplete",
         "status": lambda self: self.fts_cjk_rebuild_status(),
         "step": lambda self: self.fts_cjk_rebuild_step(),
     },
     {
         "spec": _FTS_SESSION_SPEC,
         "stale_key": None,
+        "settlement_reason": "session_unicode_incomplete",
         "status": lambda self: self.fts_session_rebuild_status(),
         "step": lambda self: self.fts_session_rebuild_step(),
     },
     {
         "spec": _FTS_SESSION_TRIGRAM_SPEC,
         "stale_key": FTS_SESSION_TRIGRAM_STALE_KEY,
+        "settlement_reason": "session_trigram_incomplete",
         "status": lambda self: self.fts_session_trigram_rebuild_status(),
         "step": lambda self: self.fts_session_trigram_rebuild_step(),
     },
     {
         "spec": _FTS_SESSION_CJK_SPEC,
         "stale_key": FTS_SESSION_CJK_STALE_KEY,
+        "settlement_reason": "session_cjk_incomplete",
         "status": lambda self: self.fts_session_cjk_rebuild_status(),
         "step": lambda self: self.fts_session_cjk_rebuild_step(),
     },
 )
-
-
-# Storage-v2 settlement reason per deferred rebuild lane (issue #31). Lane
-# membership still comes from ``_FTS_REBUILD_LANES``; this only maps the
-# spec's internal name to the human/CLI reason label (the required message
-# lane is handled separately as ``backfill_incomplete``).
-_FTS_STORAGE_V2_LANE_REASONS = {
-    "messages_cjk": "message_cjk_incomplete",
-    "sessions": "session_unicode_incomplete",
-    "sessions_trigram": "session_trigram_incomplete",
-    "sessions_cjk": "session_cjk_incomplete",
-}
 
 
 class SessionSearchMixin:
@@ -499,7 +492,8 @@ class SessionSearchMixin:
         if self._fts_external_index_empty_with_messages(conn):
             return ("backfill_incomplete", True)
         if self._fts_meta_has_any(
-            conn, ("fts_rebuild_high_water", "fts_rebuild_progress")
+            conn,
+            (_FTS_MESSAGE_SPEC["high_water_key"], _FTS_MESSAGE_SPEC["progress_key"]),
         ):
             return ("backfill_incomplete", True)
 
@@ -508,12 +502,8 @@ class SessionSearchMixin:
         # on a host that cannot operate the lane (missing capability is never
         # evidence of completion). Membership is ``_FTS_REBUILD_LANES``.
         for lane in _FTS_REBUILD_LANES[1:]:
-            spec = lane["spec"]
             if self._fts_meta_has_any(conn, self._fts_lane_durable_keys(lane)):
-                return (
-                    _FTS_STORAGE_V2_LANE_REASONS[spec["name"]],
-                    self._fts_lane_actionable(lane),
-                )
+                return (lane["settlement_reason"], self._fts_lane_actionable(lane))
 
         # ── Optional / session structural (schema-identity) states ──
         # message CJK orphan-empty (optional; an absent table is valid
@@ -521,7 +511,7 @@ class SessionSearchMixin:
         if self._fts_external_index_empty_with_source(
             conn, "messages_fts_cjk_src", "messages_fts_cjk"
         ):
-            return ("message_cjk_orphan_empty", getattr(self, "_fts_cjk_loaded", False))
+            return ("message_cjk_orphan_empty", self._fts_cjk_loaded)
         # session Unicode legacy/internal shape or orphan-empty.
         if self._db_has_internal_content_sessions_fts(conn):
             return ("session_unicode_legacy", True)
@@ -531,17 +521,11 @@ class SessionSearchMixin:
             return ("session_unicode_orphan_empty", True)
         # session CJK legacy/internal shape or orphan-empty (optional).
         if self._db_has_internal_content_sessions_fts_cjk(conn):
-            return (
-                "session_cjk_legacy",
-                getattr(self, "_sessions_cjk_worker_operable", False),
-            )
+            return ("session_cjk_legacy", self._sessions_cjk_worker_operable)
         if self._fts_external_index_empty_with_source(
             conn, "sessions", "sessions_fts_cjk"
         ):
-            return (
-                "session_cjk_orphan_empty",
-                getattr(self, "_sessions_cjk_worker_operable", False),
-            )
+            return ("session_cjk_orphan_empty", self._sessions_cjk_worker_operable)
         return self._fts_session_trigram_settlement_blocker(conn)
 
     def _fts_session_trigram_settlement_blocker(
@@ -571,11 +555,16 @@ class SessionSearchMixin:
         if self._fts_external_index_empty_with_source(
             conn, "sessions_fts_trigram_src", "sessions_fts_trigram"
         ):
-            return (
-                "session_trigram_orphan_empty",
-                getattr(self, "_sessions_trigram_available", False),
-            )
+            return ("session_trigram_orphan_empty", self._sessions_trigram_available)
         return None
+
+    def _fts_storage_v2_withdraw_claim(self, conn) -> None:
+        """Withdraw any stale storage-layout claim (issue #31): a blocker
+        found by the settlement evaluator means the DB is not
+        acceptance-complete, so an existing ``fts_storage_version`` must not
+        keep advertising completion. DML on the caller's connection (a cursor
+        works too)."""
+        conn.execute("DELETE FROM state_meta WHERE key = 'fts_storage_version'")
 
     def _fts_first_pending_lane_status(self) -> Optional[Dict[str, Any]]:
         """First non-None deferred-rebuild status across the ordered lanes
@@ -1579,11 +1568,7 @@ class SessionSearchMixin:
         if blocker is not None:
             # Withdraw any stale layout claim — the DB is not
             # acceptance-complete (issue #31).
-            def _withdraw(conn):
-                conn.execute(
-                    "DELETE FROM state_meta WHERE key = 'fts_storage_version'"
-                )
-            self._execute_write(_withdraw)
+            self._execute_write(self._fts_storage_v2_withdraw_claim)
             logger.warning(
                 "FTS storage optimization did not settle (%s, actionable=%s)",
                 blocker[0], blocker[1],
@@ -1636,9 +1621,7 @@ class SessionSearchMixin:
             if blocker is not None:
                 # Withdraw any stale claim in the same transaction that would
                 # have stamped it (issue #31).
-                conn.execute(
-                    "DELETE FROM state_meta WHERE key = 'fts_storage_version'"
-                )
+                self._fts_storage_v2_withdraw_claim(conn)
                 return blocker[0]
             conn.execute(
                 "INSERT INTO state_meta (key, value) VALUES ('fts_storage_version', ?) "

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -331,6 +331,18 @@ _FTS_REBUILD_LANES: Tuple[Dict[str, Any], ...] = (
 )
 
 
+# Storage-v2 settlement reason per deferred rebuild lane (issue #31). Lane
+# membership still comes from ``_FTS_REBUILD_LANES``; this only maps the
+# spec's internal name to the human/CLI reason label (the required message
+# lane is handled separately as ``backfill_incomplete``).
+_FTS_STORAGE_V2_LANE_REASONS = {
+    "messages_cjk": "message_cjk_incomplete",
+    "sessions": "session_unicode_incomplete",
+    "sessions_trigram": "session_trigram_incomplete",
+    "sessions_cjk": "session_cjk_incomplete",
+}
+
+
 class SessionSearchMixin:
     """See module docstring — mixin for SessionDB (Search cluster)."""
 
@@ -428,32 +440,142 @@ class SessionSearchMixin:
         pct = min(100, int(100 * progress / total))
         return {"pending": True, "total": total, "indexed": progress, "percent": pct}
 
-    def _fts_lane_pending(self, lane: Dict[str, Any], conn) -> bool:
-        """True when a deferred-rebuild lane has durable pending work (an H
-        marker and/or its stale breadcrumb) that THIS process can operate
-        (issue #27).
+    def _fts_lane_durable_keys(self, lane: Dict[str, Any]) -> Tuple[str, ...]:
+        """All durable settlement-relevant ``state_meta`` keys for one
+        deferred rebuild lane: the H/P marker pair plus the lane's stale
+        breadcrumb when it has one. Membership comes from
+        ``_FTS_REBUILD_LANES`` (issue #31) — never a hand-maintained ladder.
+        """
+        spec = lane["spec"]
+        keys = [spec["high_water_key"], spec["progress_key"]]
+        stale = lane.get("stale_key")
+        if stale:
+            keys.append(stale)
+        return tuple(keys)
 
-        SELECT-only — no schema mutation, so it is safe for read-only opens
-        and status surfaces. The operability gate is the lane spec's
-        ``available`` callback (e.g. ``_sessions_trigram_available`` for the
-        #30 trigram lane), preserving the worker-vs-serving distinction.
+    def _fts_meta_has_any(self, conn, keys: Collection[str]) -> bool:
+        """True when any of *keys* is present in ``state_meta`` (SELECT-only)."""
+        placeholders = ", ".join("?" for _ in keys)
+        row = conn.execute(
+            f"SELECT 1 FROM state_meta WHERE key IN ({placeholders}) LIMIT 1",
+            tuple(keys),
+        ).fetchone()
+        return row is not None
+
+    def _fts_lane_actionable(self, lane: Dict[str, Any]) -> bool:
+        """True when THIS process can operate the lane's ordinary optimize /
+        repair work — the lane's own worker gate, used ONLY for the
+        storage-v2 "actionable here" flag, never as proof of DB acceptance
+        completeness (issue #31)."""
+        return bool(lane["spec"]["available"](self))
+
+    def _fts_storage_v2_blocker(self, conn) -> Optional[Tuple[str, bool]]:
+        """Return the first storage-v2 settlement blocker ``(reason,
+        actionable_here)``, or None when the database is acceptance-complete
+        for ``fts_storage_version = 2`` (issue #31).
+
+        SELECT-only and durable/schema-aware: every check reads
+        ``sqlite_master`` or ``state_meta`` — never process-local serving
+        booleans as evidence of DB completeness. None is the single proof
+        that v2 may be claimed; the ``actionable_here`` flag only
+        distinguishes "work this process can finish via optimize-storage"
+        from "blocked until a capable/external resolution exists". The SAME
+        evaluator drives startup auto-settlement, ``fts_optimize_available()``,
+        the foreground pre-VACUUM refusal, and the final transactional
+        stamp, so no completion decision can diverge.
+
         ``conn`` must be a connection the caller already holds under a
         suitable lock/read context (this helper does NOT take ``self._lock``,
         which is non-reentrant).
         """
-        spec = lane["spec"]
-        if not spec["available"](self):
-            return False
-        keys = [spec["high_water_key"]]
-        stale = lane.get("stale_key")
-        if stale:
-            keys.append(stale)
-        placeholders = ", ".join("?" for _ in keys)
-        row = conn.execute(
-            f"SELECT 1 FROM state_meta WHERE key IN ({placeholders}) LIMIT 1",
-            keys,
-        ).fetchone()
-        return row is not None
+        if not getattr(self, "_fts_enabled", False):
+            return ("fts5_unavailable", False)
+
+        # ── Required message base ──
+        if self._db_has_legacy_inline_fts(conn):
+            return ("legacy_inline", True)
+        if self._has_fts_trash(conn):
+            return ("teardown_incomplete", True)
+        if self._fts_external_index_empty_with_messages(conn):
+            return ("backfill_incomplete", True)
+        if self._fts_meta_has_any(
+            conn, ("fts_rebuild_high_water", "fts_rebuild_progress")
+        ):
+            return ("backfill_incomplete", True)
+
+        # ── Optional / session deferred lanes: durable H/P/stale state ──
+        # Any H, P, or stale breadcrumb is non-settled durable state — even
+        # on a host that cannot operate the lane (missing capability is never
+        # evidence of completion). Membership is ``_FTS_REBUILD_LANES``.
+        for lane in _FTS_REBUILD_LANES[1:]:
+            spec = lane["spec"]
+            if self._fts_meta_has_any(conn, self._fts_lane_durable_keys(lane)):
+                return (
+                    _FTS_STORAGE_V2_LANE_REASONS[spec["name"]],
+                    self._fts_lane_actionable(lane),
+                )
+
+        # ── Optional / session structural (schema-identity) states ──
+        # message CJK orphan-empty (optional; an absent table is valid
+        # absence, and an empty source is nothing to index).
+        if self._fts_external_index_empty_with_source(
+            conn, "messages_fts_cjk_src", "messages_fts_cjk"
+        ):
+            return ("message_cjk_orphan_empty", getattr(self, "_fts_cjk_loaded", False))
+        # session Unicode legacy/internal shape or orphan-empty.
+        if self._db_has_internal_content_sessions_fts(conn):
+            return ("session_unicode_legacy", True)
+        if self._fts_external_index_empty_with_source(
+            conn, "sessions", "sessions_fts"
+        ):
+            return ("session_unicode_orphan_empty", True)
+        # session CJK legacy/internal shape or orphan-empty (optional).
+        if self._db_has_internal_content_sessions_fts_cjk(conn):
+            return (
+                "session_cjk_legacy",
+                getattr(self, "_sessions_cjk_worker_operable", False),
+            )
+        if self._fts_external_index_empty_with_source(
+            conn, "sessions", "sessions_fts_cjk"
+        ):
+            return (
+                "session_cjk_orphan_empty",
+                getattr(self, "_sessions_cjk_worker_operable", False),
+            )
+        return self._fts_session_trigram_settlement_blocker(conn)
+
+    def _fts_session_trigram_settlement_blocker(
+        self, conn
+    ) -> Optional[Tuple[str, bool]]:
+        """Storage-v2 structural refusal for the #30 normalized session
+        trigram lane (issue #31): an ``unknown_same_name`` object or any
+        noncanonical root/source/trigger ownership fails closed — v2 is
+        refused and the object is left untouched (never deleted or demoted
+        inside #31)."""
+        classification = self._classify_sessions_fts_trigram(conn)
+        if classification == "unknown_same_name":
+            return ("session_trigram_unknown_same_name", False)
+        _owned, foreign, missing = self._sessions_trigram_namespace_owned(
+            conn, classification
+        )
+        if foreign:
+            return ("session_trigram_namespace_foreign", False)
+        if classification == "absent":
+            if not self._sessions_trigram_src_compatible(conn):
+                return ("session_trigram_source_collision", False)
+            return None
+        # modern_trigram: an incomplete exact trigger set is a fail-closed
+        # state the #30 lifecycle cannot create — refuse without repair.
+        if missing:
+            return ("session_trigram_trigger_incomplete", False)
+        if self._fts_external_index_empty_with_source(
+            conn, "sessions_fts_trigram_src", "sessions_fts_trigram"
+        ):
+            return (
+                "session_trigram_orphan_empty",
+                getattr(self, "_sessions_trigram_available", False),
+            )
+        return None
 
     def _fts_first_pending_lane_status(self) -> Optional[Dict[str, Any]]:
         """First non-None deferred-rebuild status across the ordered lanes
@@ -1230,60 +1352,26 @@ class SessionSearchMixin:
         self._repair_session_spec_bookkeeping(_FTS_SESSION_CJK_SPEC)
 
     def fts_optimize_available(self) -> bool:
-        """True when `optimize_fts_storage()` has work to do: either this DB
-        is a legacy inline-FTS install that can be optimized to the v23
-        external-content schema, or a previous optimize run was interrupted
-        (legacy vtables already demoted, but backfill markers and/or trash
-        tables remain) and re-running would resume it, or the CJK-bigram
-        index needs a backfill/rebuild on this tokenizer-capable host, or
-        a prior demote left an empty external-content index without markers
-        (healable on re-run).
-        False for fresh and fully-optimized installs (and when FTS5 is
-        unavailable)."""
+        """True when `optimize_fts_storage()` has work THIS process can
+        finish: the DB is not yet acceptance-complete for the current storage
+        layout AND at least one remaining blocker is actionable on this host
+        (legacy inline layout to demote, deferred rebuild lanes to backfill,
+        trash to tear down, orphan/empty indexes to heal).
+
+        Derived from the SAME shared storage-v2 evaluator as startup
+        auto-settlement and the final stamp (issue #31), so "is there work"
+        and "may v2 be claimed" can never diverge. A blocker that requires an
+        optional tokenizer / external resolution this process lacks is NOT
+        advertised here (the stamp is still refused; status surfaces report
+        why). False for fresh/fully-settled installs, when FTS5 is
+        unavailable, and on read-only opens."""
         if not self._fts_enabled or self.read_only:
             return False
         with self._lock:
-            if self._db_has_legacy_inline_fts(self._conn):
-                return True
-            # Interrupted optimize: demotion already removed the legacy
-            # vtables (so the check above is False), but the transition is
-            # unfinished until the backfill markers are cleared and the
-            # demoted trash tables are torn down. Search stays complete
-            # through the gap supplement meanwhile; re-running resumes.
-            # Every deferred-rebuild lane with durable pending work
-            # (H marker and/or stale breadcrumb) that THIS process can
-            # operate advertises work through the shared lane surface
-            # (issue #27): message, message-CJK, session Unicode, session
-            # trigram, and session CJK.
-            for lane in _FTS_REBUILD_LANES:
-                if self._fts_lane_pending(lane, self._conn):
-                    return True
-            if self._has_fts_trash(self._conn):
-                return True
-            # Pre-fix crash window: empty external-content index with
-            # messages still present, no markers, no trash (teardown already
-            # finished or never needed). Re-run seeds markers and backfills.
-            if self._fts_external_index_empty_with_messages(self._conn):
-                return True
-            # Session orphan: external sessions_fts empty with sessions
-            # present and no claim (crash window) — healable on re-run.
-            if self._fts_external_index_empty_with_source(
-                self._conn, "sessions", "sessions_fts"
-            ):
-                return True
-            # Trigram orphan: empty sessions_fts_trigram with the derived
-            # source populated and no trigram claim (crash window / lost
-            # markers) — healable on re-run. The trigram source is a VIEW so
-            # this probe also covers the not-yet-created table (absent → the
-            # ensure that follows creates it fresh over the claim). Only
-            # advertised when THIS runtime owns+serves the lane (finding 4:
-            # an unknown/quarantined target must never trigger a delete-all /
-            # re-seed).
-            if not self._sessions_trigram_available:
+            blocker = self._fts_storage_v2_blocker(self._conn)
+            if blocker is None:
                 return False
-            return self._fts_external_index_empty_with_source(
-                self._conn, "sessions_fts_trigram_src", "sessions_fts_trigram"
-            )
+            return blocker[1]
 
     def _demote_legacy_fts_to_trash(self) -> int:
         """Demote the legacy inline FTS vtables and stage their shadow tables
@@ -1478,54 +1566,29 @@ class SessionSearchMixin:
             _emit("teardown")
             self._fts_rebuild_pause(time.monotonic() - _t0)
 
-        # Refuse to stamp "optimized" while work remains or the base index is
-        # still empty against a non-empty messages table. Pre-fix code could
-        # tear down trash and settle after a no-op backfill when markers were
-        # missing — permanent search-index loss for historical rows. Session
-        # markers / empty session index (issue #25) count as remaining work,
-        # as do the trigram lane's own markers / empty index (issue #30).
+        # Refuse to stamp "optimized" while the shared storage-v2 evaluator
+        # reports ANY incomplete durable state — message/session Unicode/CJK/
+        # trigram H/P or stale breadcrumbs, demoted trash, orphan-empty or
+        # legacy shapes, and #30 fail-closed trigram ownership. This is the
+        # SAME predicate startup and the final transactional re-check use
+        # (issue #31), so a DB cannot be stamped here and refused there (or
+        # vice versa), and pre-fix code can never settle past a no-op
+        # backfill into permanent search-index loss again.
         with self._lock:
-            # The trigram lane's marker / empty-index only counts as remaining
-            # work when THIS runtime owns+serves it (finding 1 point 4): an
-            # incapable host must not report permanent backfill_incomplete for
-            # a lane it can never recover — the stale evidence stays, but the
-            # settle check ignores it here.
-            trigram_pending = self._conn.execute(
-                "SELECT 1 FROM state_meta "
-                "WHERE key = 'fts_session_trigram_rebuild_high_water' LIMIT 1"
-            ).fetchone() is not None
-            still_pending = (
-                self._conn.execute(
-                    "SELECT 1 FROM state_meta "
-                    "WHERE key IN ('fts_rebuild_high_water', "
-                    "'fts_session_rebuild_high_water') LIMIT 1"
-                ).fetchone() is not None
-                or (self._sessions_trigram_available and trigram_pending)
-            )
-            still_trash = self._has_fts_trash(self._conn)
-            trigram_empty = self._fts_external_index_empty_with_source(
-                self._conn,
-                "sessions_fts_trigram_src",
-                "sessions_fts_trigram",
-            )
-            empty_index = (
-                self._fts_external_index_empty_with_messages(self._conn)
-                or self._fts_external_index_empty_with_source(
-                    self._conn, "sessions", "sessions_fts"
+            blocker = self._fts_storage_v2_blocker(self._conn)
+        if blocker is not None:
+            # Withdraw any stale layout claim — the DB is not
+            # acceptance-complete (issue #31).
+            def _withdraw(conn):
+                conn.execute(
+                    "DELETE FROM state_meta WHERE key = 'fts_storage_version'"
                 )
-                or (self._sessions_trigram_available and trigram_empty)
-            )
-        if still_pending or still_trash or empty_index:
-            reason = (
-                "backfill_incomplete" if still_pending or empty_index
-                else "teardown_incomplete"
-            )
+            self._execute_write(_withdraw)
             logger.warning(
-                "FTS storage optimization did not settle (%s): "
-                "pending=%s trash=%s empty_index=%s",
-                reason, still_pending, still_trash, empty_index,
+                "FTS storage optimization did not settle (%s, actionable=%s)",
+                blocker[0], blocker[1],
             )
-            return {"ok": False, "reason": reason, "vacuumed": None}
+            return {"ok": False, "reason": blocker[0], "vacuumed": None}
 
         # Phase 3: reclaim freed pages to the OS.
         vacuum_ok = None
@@ -1563,18 +1626,20 @@ class SessionSearchMixin:
         # DB opened only by pre-decoupling code still settles). The FTS-layout
         # marker is the source of truth for "is this DB optimized".
         def _settle(conn):
-            # Re-check inside the write transaction so a concurrent writer
-            # cannot race a stamp past incomplete work. Returns a refusal
-            # reason (stamping nothing) or None once the stamp is written.
-            if conn.execute(
-                "SELECT 1 FROM state_meta "
-                "WHERE key = 'fts_rebuild_high_water' LIMIT 1"
-            ).fetchone() is not None:
-                return "backfill_incomplete"
-            if self._has_fts_trash(conn):
-                return "teardown_incomplete"
-            if self._fts_external_index_empty_with_messages(conn):
-                return "backfill_incomplete"
+            # Re-check inside the write transaction that performs the claim
+            # so a concurrent writer cannot race a stamp past incomplete work
+            # (the #76832 rule). Uses the SAME shared storage-v2 evaluator as
+            # startup / availability / the pre-VACUUM refusal (issue #31).
+            # Returns a refusal reason (stamping nothing) or None once the
+            # stamp is written.
+            blocker = self._fts_storage_v2_blocker(conn)
+            if blocker is not None:
+                # Withdraw any stale claim in the same transaction that would
+                # have stamped it (issue #31).
+                conn.execute(
+                    "DELETE FROM state_meta WHERE key = 'fts_storage_version'"
+                )
+                return blocker[0]
             conn.execute(
                 "INSERT INTO state_meta (key, value) VALUES ('fts_storage_version', ?) "
                 "ON CONFLICT(key) DO UPDATE SET value = excluded.value",

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -14,7 +14,7 @@ import os
 import re
 import sqlite3
 import time
-from typing import Any, Callable, Collection, Dict, List, Optional, Tuple
+from typing import Any, Callable, Collection, Dict, Iterator, List, Optional, Tuple
 
 from agent.skill_commands import describe_skill_invocation
 from hermes_state_common import (
@@ -462,40 +462,43 @@ class SessionSearchMixin:
         completeness (issue #31)."""
         return bool(lane["spec"]["available"](self))
 
-    def _fts_storage_v2_blocker(self, conn) -> Optional[Tuple[str, bool]]:
-        """Return the first storage-v2 settlement blocker ``(reason,
-        actionable_here)``, or None when the database is acceptance-complete
-        for ``fts_storage_version = 2`` (issue #31).
+    def _fts_storage_v2_blockers(self, conn) -> Iterator[Tuple[str, bool]]:
+        """Yield EVERY storage-v2 settlement blocker ``(reason,
+        actionable_here)`` in evaluation order (issue #31).
 
         SELECT-only and durable/schema-aware: every check reads
         ``sqlite_master`` or ``state_meta`` — never process-local serving
-        booleans as evidence of DB completeness. None is the single proof
-        that v2 may be claimed; the ``actionable_here`` flag only
-        distinguishes "work this process can finish via optimize-storage"
-        from "blocked until a capable/external resolution exists". The SAME
-        evaluator drives startup auto-settlement, ``fts_optimize_available()``,
-        the foreground pre-VACUUM refusal, and the final transactional
-        stamp, so no completion decision can diverge.
+        booleans as evidence of DB completeness. ``actionable_here`` says
+        whether THIS process can resolve that one blocker via
+        optimize-storage; because the shared worker skips lanes it cannot
+        operate and keeps going, the global "is there runnable work" question
+        is ANY(actionable) across the whole set — never the first blocker's
+        flag alone.
 
         ``conn`` must be a connection the caller already holds under a
         suitable lock/read context (this helper does NOT take ``self._lock``,
         which is non-reentrant).
         """
         if not getattr(self, "_fts_enabled", False):
-            return ("fts5_unavailable", False)
+            yield ("fts5_unavailable", False)
+            return
 
         # ── Required message base ──
         if self._db_has_legacy_inline_fts(conn):
-            return ("legacy_inline", True)
+            yield ("legacy_inline", True)
+            return
         if self._has_fts_trash(conn):
-            return ("teardown_incomplete", True)
+            yield ("teardown_incomplete", True)
+            return
         if self._fts_external_index_empty_with_messages(conn):
-            return ("backfill_incomplete", True)
+            yield ("backfill_incomplete", True)
+            return
         if self._fts_meta_has_any(
             conn,
             (_FTS_MESSAGE_SPEC["high_water_key"], _FTS_MESSAGE_SPEC["progress_key"]),
         ):
-            return ("backfill_incomplete", True)
+            yield ("backfill_incomplete", True)
+            return
 
         # ── Optional / session deferred lanes: durable H/P/stale state ──
         # Any H, P, or stale breadcrumb is non-settled durable state — even
@@ -503,7 +506,7 @@ class SessionSearchMixin:
         # evidence of completion). Membership is ``_FTS_REBUILD_LANES``.
         for lane in _FTS_REBUILD_LANES[1:]:
             if self._fts_meta_has_any(conn, self._fts_lane_durable_keys(lane)):
-                return (lane["settlement_reason"], self._fts_lane_actionable(lane))
+                yield (lane["settlement_reason"], self._fts_lane_actionable(lane))
 
         # ── Optional / session structural (schema-identity) states ──
         # message CJK orphan-empty (optional; an absent table is valid
@@ -511,22 +514,46 @@ class SessionSearchMixin:
         if self._fts_external_index_empty_with_source(
             conn, "messages_fts_cjk_src", "messages_fts_cjk"
         ):
-            return ("message_cjk_orphan_empty", self._fts_cjk_loaded)
+            yield ("message_cjk_orphan_empty", self._fts_cjk_loaded)
         # session Unicode legacy/internal shape or orphan-empty.
         if self._db_has_internal_content_sessions_fts(conn):
-            return ("session_unicode_legacy", True)
+            yield ("session_unicode_legacy", True)
         if self._fts_external_index_empty_with_source(
             conn, "sessions", "sessions_fts"
         ):
-            return ("session_unicode_orphan_empty", True)
+            yield ("session_unicode_orphan_empty", True)
         # session CJK legacy/internal shape or orphan-empty (optional).
         if self._db_has_internal_content_sessions_fts_cjk(conn):
-            return ("session_cjk_legacy", self._sessions_cjk_worker_operable)
+            yield ("session_cjk_legacy", self._sessions_cjk_worker_operable)
         if self._fts_external_index_empty_with_source(
             conn, "sessions", "sessions_fts_cjk"
         ):
-            return ("session_cjk_orphan_empty", self._sessions_cjk_worker_operable)
-        return self._fts_session_trigram_settlement_blocker(conn)
+            yield ("session_cjk_orphan_empty", self._sessions_cjk_worker_operable)
+        # session trigram structural (#30 fail-closed).
+        trigram = self._fts_session_trigram_settlement_blocker(conn)
+        if trigram is not None:
+            yield trigram
+
+    def _fts_storage_v2_blocker(self, conn) -> Optional[Tuple[str, bool]]:
+        """Return the FIRST storage-v2 settlement blocker ``(reason,
+        actionable_here)``, or None when the database is acceptance-complete
+        for ``fts_storage_version = 2`` (issue #31).
+
+        None is the single proof that v2 may be claimed. The returned
+        ``actionable_here`` describes ONLY this first blocker; callers that
+        need "is any work runnable on this host" must scan the whole blocker
+        set via ``_fts_storage_v2_blockers`` (e.g. ``fts_optimize_available``),
+        because an earlier incapable blocker can shadow a later actionable one
+        while the shared worker still makes progress. The SAME evaluator
+        drives startup auto-settlement, the foreground pre-VACUUM refusal,
+        and the final transactional stamp, so no completion decision can
+        diverge.
+
+        ``conn`` must be a connection the caller already holds under a
+        suitable lock/read context (this helper does NOT take ``self._lock``,
+        which is non-reentrant).
+        """
+        return next(self._fts_storage_v2_blockers(conn), None)
 
     def _fts_session_trigram_settlement_blocker(
         self, conn
@@ -1357,10 +1384,10 @@ class SessionSearchMixin:
         if not self._fts_enabled or self.read_only:
             return False
         with self._lock:
-            blocker = self._fts_storage_v2_blocker(self._conn)
-            if blocker is None:
-                return False
-            return blocker[1]
+            return any(
+                actionable
+                for _reason, actionable in self._fts_storage_v2_blockers(self._conn)
+            )
 
     def _demote_legacy_fts_to_trash(self) -> int:
         """Demote the legacy inline FTS vtables and stage their shadow tables

--- a/tests/test_fts_storage_v2_settlement.py
+++ b/tests/test_fts_storage_v2_settlement.py
@@ -746,3 +746,52 @@ def test_session_trigram_orphan_empty_blocks(tmp_path):
     finally:
         d.close()
 
+
+# ── Mixed-capability actionability (review round 3 / P2) ──────────────────
+# ``fts_optimize_available()`` must answer "is ANY blocker actionable on this
+# host", not "is the FIRST blocker actionable": the shared worker skips lanes
+# it cannot operate and keeps going, so an earlier incapable blocker (e.g.
+# message-CJK on a cjk-less host) must not hide a later runnable lane.
+
+def test_mixed_blocker_optimize_available_sees_any_actionable(
+    tmp_path, monkeypatch
+):
+    """#31 P2 regression: a non-actionable message-CJK blocker first + an
+    actionable session-Unicode blocker after. Storage v2 stays blocked, but
+    ``fts_optimize_available()`` must report True because the worker can
+    progress the session lane."""
+    db_path = tmp_path / "s.db"
+    _build_populated_sessions_db(db_path, n=4)
+    monkeypatch.setenv("HERMES_FTS5_CJK_SO", str(tmp_path / "absent-cjk.so"))
+    d = SessionDB(db_path=db_path)
+    try:
+        assert not d._fts_cjk_loaded
+        # Plant a non-actionable message-CJK claim ahead of the actionable
+        # session-Unicode claim that open already staged.
+        _plant(d, fts_cjk_rebuild_high_water=4, fts_cjk_rebuild_progress=0)
+        assert _blocker(d) == ("message_cjk_incomplete", False)
+        # v2 is still blocked, but SOME work is runnable on this host.
+        assert d.fts_optimize_available() is True
+        # The worker progresses the actionable session lane while the
+        # message-CJK lane stays pending on this incapable host.
+        result = d.optimize_fts_storage(vacuum=False)
+        assert result["ok"] is False
+        assert result.get("reason") == "message_cjk_incomplete"
+        assert d.get_meta("fts_session_rebuild_high_water") is None
+        assert d.get_meta("fts_cjk_rebuild_high_water") is not None
+    finally:
+        d.close()
+
+
+def test_only_non_actionable_blocker_reports_no_work(tmp_path, monkeypatch):
+    """With ONLY a non-actionable blocker (message-CJK on an incapable host),
+    ``fts_optimize_available()`` stays False — no runnable work exists."""
+    d = _cjk_incapable_db(tmp_path, monkeypatch)
+    try:
+        assert not d._fts_cjk_loaded
+        _plant(d, fts_cjk_rebuild_high_water=5, fts_cjk_rebuild_progress=0)
+        assert _blocker(d) == ("message_cjk_incomplete", False)
+        assert d.fts_optimize_available() is False
+    finally:
+        d.close()
+

--- a/tests/test_fts_storage_v2_settlement.py
+++ b/tests/test_fts_storage_v2_settlement.py
@@ -233,8 +233,289 @@ def test_trigram_unknown_same_name_blocks_and_survives_untouched(tmp_path):
     d = SessionDB(db_path=db_path)
     try:
         assert _blocker(d) == ("session_trigram_unknown_same_name", False)
+        assert d.get_meta("fts_storage_version") is None
         assert d.fts_optimize_available() is False
         # Byte/schema-identical: no destructive convergence.
         assert "tokenize='unicode61'" in _trigram_ddl(d)
     finally:
         d.close()
+
+
+# ── Startup auto-settlement + interruption / reopen (commit 3) ────────────
+
+def _build_claim_before_schema_db(db_path, n=3):
+    """DB with ``n`` sessions and a durable session-Unicode H/P claim but NO
+    external FTS table yet (the #76832 claim-before-schema crash window)."""
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA foreign_keys=OFF")
+    conn.executescript(SCHEMA_SQL)
+    t0 = time.time()
+    conn.executemany(
+        "INSERT INTO sessions (row_id, id, source, started_at) "
+        "VALUES (?, ?, 'cli', ?)",
+        [(i, f"s{i}", t0 + i) for i in range(1, n + 1)],
+    )
+    conn.execute(
+        "INSERT INTO state_meta (key, value) VALUES (?, ?), (?, ?)",
+        ("fts_session_rebuild_high_water", str(n),
+         "fts_session_rebuild_progress", "0"),
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_populated_first_open_does_not_stamp_v2(tmp_path):
+    """The core #31 startup rule: a populated DB's first open stages session
+    H/P claims and therefore does NOT stamp v2 (work remains)."""
+    db_path = tmp_path / "s.db"
+    _build_populated_sessions_db(db_path, n=12)
+    d = SessionDB(db_path=db_path)
+    try:
+        assert d.get_meta("fts_session_rebuild_high_water") == "12"
+        assert d.get_meta("fts_storage_version") is None
+        assert d.fts_optimize_available() is True
+    finally:
+        d.close()
+
+
+def test_claim_before_schema_reopen_preserves_claim_and_refuses_v2(tmp_path):
+    """#76832 claim-before-schema: a durable claim committed before the
+    external table existed survives reopen — the claim is preserved, the
+    schema is re-ensured, and v2 stays absent (work remains)."""
+    db_path = tmp_path / "s.db"
+    _build_claim_before_schema_db(db_path, n=3)
+    d = SessionDB(db_path=db_path)
+    try:
+        assert d.get_meta("fts_session_rebuild_high_water") == "3"
+        assert d.get_meta("fts_session_rebuild_progress") == "0"
+        assert d.get_meta("fts_storage_version") is None
+        assert d.fts_optimize_available() is True
+    finally:
+        d.close()
+
+
+def test_reopen_after_partial_backfill_resumes_and_does_not_stamp(tmp_path):
+    """A crash mid-backfill (H/P staged, backfill unfinished): reopen
+    preserves the claim, stays incomplete (no v2), and a re-run settles v2."""
+    db_path = tmp_path / "s.db"
+    _build_populated_sessions_db(db_path, n=12)
+    d1 = SessionDB(db_path=db_path)
+    try:
+        # Markers staged at open; the process "crashes" before any completion.
+        assert d1.get_meta("fts_session_rebuild_high_water") == "12"
+        assert d1.get_meta("fts_session_rebuild_progress") == "0"
+        assert d1.get_meta("fts_storage_version") is None
+    finally:
+        d1.close()
+
+    d2 = SessionDB(db_path=db_path)
+    try:
+        assert d2.get_meta("fts_session_rebuild_high_water") == "12"
+        assert d2.get_meta("fts_storage_version") is None
+        assert d2.fts_optimize_available() is True
+        result = d2.optimize_fts_storage(vacuum=False)
+        assert result["ok"] is True, result
+        assert d2.get_meta("fts_storage_version") == str(FTS_STORAGE_VERSION)
+    finally:
+        d2.close()
+
+
+def test_h_without_p_repair_keeps_v2_absent_until_rebuild(tmp_path):
+    """H-without-P is non-settled durable state: the shared repair restores
+    P only after a known-empty reset, and v2 stays absent until the rebuild
+    completes."""
+    db_path = tmp_path / "s.db"
+    _build_populated_sessions_db(db_path, n=5)
+    d = SessionDB(db_path=db_path)
+    try:
+        d.set_meta("fts_rebuild_high_water", "5")
+        assert d.get_meta("fts_rebuild_progress") is None
+        assert d.get_meta("fts_storage_version") is None
+        d._repair_optimize_bookkeeping()
+        assert d.get_meta("fts_rebuild_progress") == "0"
+        assert d.get_meta("fts_storage_version") is None
+        assert _blocker(d)[0] == "backfill_incomplete"
+        assert d.fts_optimize_available() is True
+    finally:
+        d.close()
+
+
+def test_stale_after_healthy_optional_target_blocks_reopen_v2(tmp_path):
+    """A formerly healthy modern trigram target quarantined (stale written,
+    owned triggers dropped) can never be served as complete: reopen refuses
+    v2 until a capable recovery re-establishes and backfills the lane."""
+    db_path = tmp_path / "p1.db"
+    _build_populated_sessions_db(db_path, n=2)
+    d1 = SessionDB(db_path=db_path)
+    try:
+        assert d1.get_meta("fts_session_trigram_rebuild_high_water") == "2"
+    finally:
+        d1.close()
+    # Simulate the tokenizer-less peer's quarantine side effects.
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        "INSERT INTO state_meta (key, value) VALUES (?, '1') "
+        "ON CONFLICT(key) DO UPDATE SET value = '1'",
+        (FTS_SESSION_TRIGRAM_STALE_KEY,),
+    )
+    for name in (
+        "sessions_fts_trigram_insert",
+        "sessions_fts_trigram_delete",
+        "sessions_fts_trigram_update_before",
+        "sessions_fts_trigram_update_after",
+    ):
+        conn.execute(f"DROP TRIGGER IF EXISTS {name}")
+    conn.commit()
+    conn.close()
+    # Capable reopen recovers the stale target from canonical rows — but the
+    # lane is still pending, so v2 must remain absent.
+    d2 = SessionDB(db_path=db_path)
+    try:
+        assert d2.get_meta("fts_storage_version") is None
+        assert d2.get_meta("fts_session_trigram_rebuild_high_water") == "2"
+        assert d2.fts_optimize_available() is True
+    finally:
+        d2.close()
+
+
+def test_final_transactional_recheck_refuses_race_before_stamp(
+    tmp_path, monkeypatch
+):
+    """#76832 race rule: a blocker that appears after the pre-VACUUM
+    preflight (a concurrent writer) must still refuse the stamp inside the
+    final write transaction that would have written it."""
+    db_path = tmp_path / "s.db"
+    _build_populated_sessions_db(db_path, n=3)
+    d = SessionDB(db_path=db_path)
+    # Keep a real durable blocker alive through the backfill pass (an
+    # unfinishable session lane — the same shape as the existing
+    # settle-refusal test), while the pre-VACUUM preflight pretends complete.
+    d.fts_session_rebuild_step = lambda: False  # type: ignore[method-assign]
+    calls = {"n": 0}
+    real = d._fts_storage_v2_blocker
+
+    def _race(conn):
+        calls["n"] += 1
+        # First call is the pre-VACUUM preflight — pretend it saw complete (a
+        # concurrent writer seeds work just afterwards). The final
+        # transactional re-check must still see the real durable state.
+        if calls["n"] == 1:
+            return None
+        return real(conn)
+
+    monkeypatch.setattr(d, "_fts_storage_v2_blocker", _race)
+    try:
+        result = d.optimize_fts_storage(vacuum=False)
+        assert result["ok"] is False
+        assert result.get("reason") == "session_unicode_incomplete"
+        assert d.get_meta("fts_storage_version") is None
+    finally:
+        d.close()
+
+
+def test_completed_v2_reopen_creates_no_new_work(tmp_path):
+    """A settled v2 DB reopened stays settled: no new H/P/stale markers, no
+    rebuild work advertised, and the claim persists."""
+    db_path = tmp_path / "s.db"
+    _build_populated_sessions_db(db_path, n=12)
+    d1 = SessionDB(db_path=db_path)
+    try:
+        result = d1.optimize_fts_storage(vacuum=False)
+        assert result["ok"] is True, result
+        assert d1.get_meta("fts_storage_version") == str(FTS_STORAGE_VERSION)
+    finally:
+        d1.close()
+
+    d2 = SessionDB(db_path=db_path)
+    try:
+        assert d2.get_meta("fts_storage_version") == str(FTS_STORAGE_VERSION)
+        assert d2.fts_optimize_available() is False
+        assert _blocker(d2) is None
+        # No durable markers were recreated on reopen.
+        for key in (
+            "fts_rebuild_high_water", "fts_rebuild_progress",
+            "fts_cjk_rebuild_high_water", "fts_cjk_rebuild_progress",
+            FTS_CJK_STALE_KEY,
+            "fts_session_rebuild_high_water", "fts_session_rebuild_progress",
+            "fts_session_trigram_rebuild_high_water",
+            "fts_session_trigram_rebuild_progress",
+            FTS_SESSION_TRIGRAM_STALE_KEY,
+            "fts_session_cjk_rebuild_high_water",
+            "fts_session_cjk_rebuild_progress",
+            FTS_SESSION_CJK_STALE_KEY,
+        ):
+            assert d2.get_meta(key) is None, key
+    finally:
+        d2.close()
+
+
+# ── Six-index acceptance matrix (commit 4) ────────────────────────────────
+
+def test_complete_six_index_settlement_stamps_v2(tmp_path):
+    """Full acceptance: with every required + applicable lane complete,
+    optimize stamps v2, no work remains, and search behavior is unchanged."""
+    db_path = tmp_path / "s.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA foreign_keys=OFF")
+    conn.executescript(SCHEMA_SQL)
+    t0 = time.time()
+    conn.execute(
+        "INSERT INTO sessions (row_id, id, source, started_at) "
+        "VALUES (1, 's1', 'cli', ?)",
+        (t0,),
+    )
+    conn.execute(
+        "INSERT INTO messages (session_id, timestamp, role, content) "
+        "VALUES ('s1', ?, 'user', 'needle message')",
+        (t0 + 1,),
+    )
+    conn.commit()
+    conn.close()
+
+    d = SessionDB(db_path=db_path)
+    try:
+        # Populated first open: not stamped, work advertised.
+        assert d.get_meta("fts_storage_version") is None
+        assert d.fts_optimize_available() is True
+        result = d.optimize_fts_storage(vacuum=False)
+        assert result["ok"] is True, result
+        assert d.get_meta("fts_storage_version") == str(FTS_STORAGE_VERSION)
+        assert d.fts_optimize_available() is False
+        assert _blocker(d) is None
+        # No search behavior change.
+        assert len(d.search_messages("needle")) == 1
+    finally:
+        d.close()
+
+
+def test_reintroduced_blocker_withdraws_stale_v2_claim(tmp_path):
+    """#31 invariant: a v2 claim is never left stale — reintroducing a
+    blocker (a fresh session-lane claim on a settled DB) withdraws v2 on the
+    next settlement evaluation, and re-completing the lane re-earns it."""
+    db_path = tmp_path / "s.db"
+    _build_populated_sessions_db(db_path, n=4)
+    d1 = SessionDB(db_path=db_path)
+    try:
+        result = d1.optimize_fts_storage(vacuum=False)
+        assert result["ok"] is True, result
+        assert d1.get_meta("fts_storage_version") == str(FTS_STORAGE_VERSION)
+        # A concurrent writer seeds fresh trigram work on the settled DB.
+        d1.set_meta("fts_session_trigram_rebuild_high_water", "999")
+        d1.set_meta("fts_session_trigram_rebuild_progress", "0")
+        assert _blocker(d1) == ("session_trigram_incomplete", True)
+    finally:
+        d1.close()
+
+    d2 = SessionDB(db_path=db_path)
+    try:
+        # Reopen startup settlement withdrew the now-stale v2 claim.
+        assert d2.get_meta("fts_storage_version") is None
+        assert d2.fts_optimize_available() is True
+        # Re-completing the lane re-earns v2.
+        result = d2.optimize_fts_storage(vacuum=False)
+        assert result["ok"] is True, result
+        assert d2.get_meta("fts_storage_version") == str(FTS_STORAGE_VERSION)
+        assert d2.fts_optimize_available() is False
+    finally:
+        d2.close()
+

--- a/tests/test_fts_storage_v2_settlement.py
+++ b/tests/test_fts_storage_v2_settlement.py
@@ -24,6 +24,7 @@ from hermes_state_common import (
     FTS_CJK_STALE_KEY,
     FTS_SESSION_CJK_STALE_KEY,
     FTS_SESSION_TRIGRAM_STALE_KEY,
+    SESSIONS_FTS_TRIGRAM_SQL,
 )
 
 
@@ -84,6 +85,17 @@ def _build_unknown_same_name_trigram_db(db_path):
         "CREATE VIRTUAL TABLE sessions_fts_trigram USING fts5(x, "
         "tokenize='unicode61')"
     )
+    conn.commit()
+    conn.close()
+
+
+def _build_legacy_internal_db(db_path, table_ddl):
+    """DB with an internal-content (no ``content=``) FTS virtual table over
+    an EMPTY canonical ``sessions`` table (so no lane stages markers)."""
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA foreign_keys=OFF")
+    conn.executescript(SCHEMA_SQL)
+    conn.execute(table_ddl)
     conn.commit()
     conn.close()
 
@@ -518,4 +530,219 @@ def test_reintroduced_blocker_withdraws_stale_v2_claim(tmp_path):
         assert d2.fts_optimize_available() is False
     finally:
         d2.close()
+
+
+# ── Structural refusal branches (review-round pin) ────────────────────────
+# The refusal table's schema-identity branches — legacy/internal shapes,
+# orphan-empty targets, and #30 fail-closed trigram ownership — were
+# implemented but not directly pinned. Each test below constructs the
+# minimal durable/schema state and asserts the evaluator's exact blocker.
+
+def _clear_session_metadata_markers(d):
+    """Drop the Unicode + trigram session H/P markers so earlier marker-loop
+    blockers cannot shadow a structural branch under test."""
+    d._conn.execute(
+        "DELETE FROM state_meta WHERE key IN "
+        "('fts_session_rebuild_high_water', 'fts_session_rebuild_progress', "
+        " 'fts_session_trigram_rebuild_high_water', "
+        " 'fts_session_trigram_rebuild_progress')"
+    )
+    d._conn.commit()
+
+
+def test_session_unicode_legacy_blocks(tmp_path, monkeypatch):
+    """Pre-#25 internal-content ``sessions_fts`` fails closed: v2 refused."""
+    db_path = tmp_path / "legacy.db"
+    _build_legacy_internal_db(
+        db_path, "CREATE VIRTUAL TABLE sessions_fts USING fts5(title)"
+    )
+    # Preserve the legacy shape: the normal ensure path would convert it.
+    monkeypatch.setattr(
+        SessionDB, "_ensure_sessions_fts_schema", lambda self, cursor: False
+    )
+    d = SessionDB(db_path=db_path)
+    try:
+        assert _blocker(d) == ("session_unicode_legacy", True)
+        assert d.get_meta("fts_storage_version") is None
+    finally:
+        d.close()
+
+
+def test_session_unicode_orphan_empty_blocks(tmp_path):
+    """External ``sessions_fts`` empty over populated sessions with no claim
+    (crash window) blocks v2."""
+    db_path = tmp_path / "s.db"
+    _build_populated_sessions_db(db_path, n=4)
+    d = SessionDB(db_path=db_path)
+    try:
+        _clear_session_metadata_markers(d)
+        assert _blocker(d) == ("session_unicode_orphan_empty", True)
+    finally:
+        d.close()
+
+
+def test_session_cjk_legacy_blocks(tmp_path, monkeypatch):
+    """Pre-#26 internal-content ``sessions_fts_cjk`` fails closed even when
+    this host cannot load the cjk tokenizer."""
+    db_path = tmp_path / "legacy-cjk.db"
+    _build_legacy_internal_db(
+        db_path, "CREATE VIRTUAL TABLE sessions_fts_cjk USING fts5(title)"
+    )
+    monkeypatch.setenv("HERMES_FTS5_CJK_SO", str(tmp_path / "absent-cjk.so"))
+    d = SessionDB(db_path=db_path)
+    try:
+        assert not d._fts_cjk_loaded
+        assert _blocker(d) == ("session_cjk_legacy", False)
+    finally:
+        d.close()
+
+
+def test_session_cjk_orphan_empty_blocks(tmp_path, monkeypatch):
+    """External ``sessions_fts_cjk`` empty over populated sessions, no claim
+    — blocks even on a cjk-incapable host."""
+    db_path = tmp_path / "s.db"
+    _build_populated_sessions_db(db_path, n=4)
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        "CREATE VIRTUAL TABLE sessions_fts_cjk USING fts5("
+        "title, id, display_name, content='sessions', content_rowid='row_id')"
+    )
+    conn.commit()
+    conn.close()
+    monkeypatch.setenv("HERMES_FTS5_CJK_SO", str(tmp_path / "absent-cjk.so"))
+    d = SessionDB(db_path=db_path)
+    try:
+        # Backfill the Unicode lane so it cannot orphan-block first, then
+        # drop the trigram markers so the marker loop cannot block first.
+        while d.fts_session_rebuild_step():
+            pass
+        _clear_session_metadata_markers(d)
+        assert _blocker(d) == ("session_cjk_orphan_empty", False)
+    finally:
+        d.close()
+
+
+def test_message_cjk_orphan_empty_blocks(tmp_path, monkeypatch):
+    """External ``messages_fts_cjk`` empty over populated non-tool messages
+    with no claim blocks v2 even on a cjk-incapable host."""
+    db_path = tmp_path / "s.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA foreign_keys=OFF")
+    conn.executescript(SCHEMA_SQL)
+    t0 = time.time()
+    conn.execute(
+        "INSERT INTO sessions (row_id, id, source, started_at) "
+        "VALUES (1, 's1', 'cli', ?)",
+        (t0,),
+    )
+    conn.execute(
+        "INSERT INTO messages (session_id, timestamp, role, content) "
+        "VALUES ('s1', ?, 'user', 'hello')",
+        (t0 + 1,),
+    )
+    conn.executescript("""
+        CREATE VIEW messages_fts_cjk_src AS
+        SELECT id, role, content, tool_name, tool_calls FROM messages
+        WHERE role <> 'tool';
+        CREATE VIRTUAL TABLE messages_fts_cjk USING fts5(
+            content, tool_name, tool_calls,
+            content='messages_fts_cjk_src', content_rowid='id'
+        );
+    """)
+    conn.commit()
+    conn.close()
+    monkeypatch.setenv("HERMES_FTS5_CJK_SO", str(tmp_path / "absent-cjk.so"))
+    d = SessionDB(db_path=db_path)
+    try:
+        # The 1 session staged Unicode/trigram markers — clear them so the
+        # message-CJK structural branch is the first blocker.
+        _clear_session_metadata_markers(d)
+        assert _blocker(d) == ("message_cjk_orphan_empty", False)
+    finally:
+        d.close()
+
+
+def test_session_trigram_namespace_foreign_blocks(tmp_path):
+    """A foreign same-name trigger occupant fails closed (v2 refused, no
+    mutation)."""
+    db_path = tmp_path / "f.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA foreign_keys=OFF")
+    conn.executescript(SCHEMA_SQL)
+    conn.executescript(SESSIONS_FTS_TRIGRAM_SQL)
+    for name in (
+        "sessions_fts_trigram_insert",
+        "sessions_fts_trigram_delete",
+        "sessions_fts_trigram_update_before",
+        "sessions_fts_trigram_update_after",
+    ):
+        conn.execute(f"DROP TRIGGER IF EXISTS {name}")
+    conn.execute(
+        "CREATE TRIGGER sessions_fts_trigram_insert AFTER INSERT ON messages "
+        "BEGIN SELECT 1; END"
+    )
+    conn.commit()
+    conn.close()
+    d = SessionDB(db_path=db_path)
+    try:
+        assert _blocker(d) == ("session_trigram_namespace_foreign", False)
+        assert d.get_meta("fts_storage_version") is None
+    finally:
+        d.close()
+
+
+def test_session_trigram_source_collision_blocks(tmp_path):
+    """The derived source name occupied by a non-canonical object (a plain
+    table) with no root fails closed."""
+    db_path = tmp_path / "sc.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA foreign_keys=OFF")
+    conn.executescript(SCHEMA_SQL)
+    conn.execute("CREATE TABLE sessions_fts_trigram_src (x)")
+    conn.commit()
+    conn.close()
+    d = SessionDB(db_path=db_path)
+    try:
+        assert _blocker(d) == ("session_trigram_source_collision", False)
+    finally:
+        d.close()
+
+
+def test_session_trigram_trigger_incomplete_blocks(tmp_path):
+    """A modern root with an incomplete exact trigger set (no stale breadcrumb)
+    fails closed — v2 refused, not silently repaired."""
+    db_path = tmp_path / "t.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA foreign_keys=OFF")
+    conn.executescript(SCHEMA_SQL)
+    conn.executescript(SESSIONS_FTS_TRIGRAM_SQL)
+    for name in (
+        "sessions_fts_trigram_update_before",
+        "sessions_fts_trigram_update_after",
+    ):
+        conn.execute(f"DROP TRIGGER IF EXISTS {name}")
+    conn.commit()
+    conn.close()
+    d = SessionDB(db_path=db_path)
+    try:
+        assert _blocker(d) == ("session_trigram_trigger_incomplete", False)
+    finally:
+        d.close()
+
+
+def test_session_trigram_orphan_empty_blocks(tmp_path):
+    """Modern session trigram target empty over populated derived source with
+    no claim (claim-loss crash window) blocks v2."""
+    db_path = tmp_path / "o.db"
+    _build_populated_sessions_db(db_path, n=6)
+    d = SessionDB(db_path=db_path)
+    try:
+        # Backfill the Unicode lane so it cannot orphan-block first, then
+        # drop the trigram claim over the empty trigram index (claim-loss).
+        while d.fts_session_rebuild_step():
+            pass
+        _clear_session_metadata_markers(d)
+        assert _blocker(d) == ("session_trigram_orphan_empty", True)
+    finally:
+        d.close()
 

--- a/tests/test_fts_storage_v2_settlement.py
+++ b/tests/test_fts_storage_v2_settlement.py
@@ -1,0 +1,240 @@
+"""Storage-v2 settlement state machine for the session-metadata FTS
+architecture (#31).
+
+The whole ticket is the question: **when may ``fts_storage_version = 2`` be
+claimed, and does that claim survive/recover across interruption and
+reopen?** These tests exercise the ONE shared completion predicate
+(``SessionDB._fts_storage_v2_blocker``) and the single evaluator-driven
+surface that startup auto-settlement, ``fts_optimize_available()``, the
+foreground pre-VACUUM refusal, and the final transactional stamp all
+consume — so no completion decision can ever diverge.
+
+Scoped per #31: settlement/completion ONLY. Per-lane worker/repair/rebuild
+engines belong to #25/#26/#27/#30; search routing/ranking to #14/#28;
+message-layout demote/teardown to the v23 path.
+"""
+
+import sqlite3
+import time
+
+import pytest
+
+from hermes_state import FTS_STORAGE_VERSION, SCHEMA_SQL, SessionDB
+from hermes_state_common import (
+    FTS_CJK_STALE_KEY,
+    FTS_SESSION_CJK_STALE_KEY,
+    FTS_SESSION_TRIGRAM_STALE_KEY,
+)
+
+
+@pytest.fixture()
+def db(tmp_path):
+    """Fresh writable SessionDB over a temp file (v23 message layout)."""
+    db_path = tmp_path / "state.db"
+    session_db = SessionDB(db_path=db_path)
+    yield session_db
+    session_db.close()
+
+
+def _cjk_incapable_db(tmp_path, monkeypatch):
+    """Fresh SessionDB on a host that cannot load the optional cjk tokenizer
+    (the durable-state cases must not depend on local CJK capability)."""
+    monkeypatch.setenv("HERMES_FTS5_CJK_SO", str(tmp_path / "absent-cjk.so"))
+    return SessionDB(db_path=tmp_path / "state.db")
+
+
+def _plant(db, **markers):
+    """Write durable ``state_meta`` markers (H/P/stale) directly."""
+    for key, value in markers.items():
+        db.set_meta(key, str(value))
+
+
+def _blocker(db):
+    """Run the shared SELECT-only storage-v2 evaluator on the live conn."""
+    return db._fts_storage_v2_blocker(db._conn)
+
+
+def _build_populated_sessions_db(db_path, n=12):
+    """DB with ``n`` canonical sessions and NO FTS objects yet — the shape
+    every startup ensure path migrates/claims over (same builder shape as
+    the #30 suite)."""
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA foreign_keys=OFF")
+    conn.executescript(SCHEMA_SQL)
+    t0 = time.time()
+    conn.executemany(
+        "INSERT INTO sessions (row_id, id, source, started_at, title) "
+        "VALUES (?, ?, 'cli', ?, ?)",
+        [(i, f"s{i}", t0 + i, f"Title {i}") for i in range(1, n + 1)],
+    )
+    conn.commit()
+    conn.close()
+
+
+def _build_unknown_same_name_trigram_db(db_path):
+    """DB whose ``sessions_fts_trigram`` is an UNRECOGNIZED same-name object
+    (a unicode61 vtable, not the modern #30 shape) and whose canonical
+    ``sessions`` table is EMPTY (so no session lane stages H/P markers and
+    the trigram state is the only blocker). #31 must refuse v2 and leave it
+    byte/schema-identical — no destructive convergence."""
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA foreign_keys=OFF")
+    conn.executescript(SCHEMA_SQL)
+    conn.execute(
+        "CREATE VIRTUAL TABLE sessions_fts_trigram USING fts5(x, "
+        "tokenize='unicode61')"
+    )
+    conn.commit()
+    conn.close()
+
+
+def _trigram_ddl(db):
+    with db._read_ctx() as conn:
+        row = conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type = 'table' "
+            "AND name = 'sessions_fts_trigram'"
+        ).fetchone()
+    return (row[0] if isinstance(row, sqlite3.Row) else row[0]) if row else ""
+
+
+def _message_docsize(db):
+    with db._read_ctx() as conn:
+        return conn.execute(
+            "SELECT COUNT(*) FROM messages_fts_docsize"
+        ).fetchone()[0]
+
+
+# ── The single evaluator: refusal-state matrix (commit 1) ────────────────
+
+def test_fresh_db_is_acceptance_complete(db):
+    """No durable work anywhere → no blocker; v2 may settle; optimize not
+    advertised."""
+    assert _blocker(db) is None
+    assert db.get_meta("fts_storage_version") == str(FTS_STORAGE_VERSION)
+    assert db.fts_optimize_available() is False
+
+
+def test_fts5_unavailable_refuses_and_is_not_actionable(db, monkeypatch):
+    monkeypatch.setattr(db, "_fts_enabled", False)
+    assert _blocker(db) == ("fts5_unavailable", False)
+    assert db.fts_optimize_available() is False
+
+
+def test_message_hp_blocks_and_is_actionable(db):
+    _plant(db, fts_rebuild_high_water=5, fts_rebuild_progress=0)
+    assert _blocker(db) == ("backfill_incomplete", True)
+    assert db.fts_optimize_available() is True
+
+
+def test_message_p_only_fails_closed(db):
+    """A stray P-only leftover is never evidence of completion."""
+    _plant(db, fts_rebuild_progress=3)
+    assert _blocker(db) == ("backfill_incomplete", True)
+
+
+def test_message_trash_blocks(db):
+    db._conn.execute("CREATE TABLE fts_v22_trash_messages_fts_data (x)")
+    db._conn.commit()
+    assert _blocker(db) == ("teardown_incomplete", True)
+    assert db.fts_optimize_available() is True
+
+
+def test_session_unicode_hp_blocks_while_messages_settled(db):
+    """Session Unicode pending blocks v2 even when the message base is fully
+    settled (the pre-#31 startup stamp missed exactly this)."""
+    db.create_session(session_id="s1", source="cli")
+    _plant(db, fts_session_rebuild_high_water=1, fts_session_rebuild_progress=0)
+    assert _blocker(db) == ("session_unicode_incomplete", True)
+    assert db.fts_optimize_available() is True
+
+
+def test_session_unicode_p_only_fails_closed(db):
+    db.create_session(session_id="s1", source="cli")
+    _plant(db, fts_session_rebuild_progress=1)
+    assert _blocker(db)[0] == "session_unicode_incomplete"
+
+
+def test_message_cjk_hp_blocks_even_on_incapable_host(tmp_path, monkeypatch):
+    d = _cjk_incapable_db(tmp_path, monkeypatch)
+    try:
+        assert not d._fts_cjk_loaded
+        _plant(d, fts_cjk_rebuild_high_water=5, fts_cjk_rebuild_progress=0)
+        assert _blocker(d) == ("message_cjk_incomplete", False)
+        # Blocked + not actionable here → not advertised as optimizable.
+        assert d.fts_optimize_available() is False
+    finally:
+        d.close()
+
+
+def test_message_cjk_stale_only_blocks(tmp_path, monkeypatch):
+    d = _cjk_incapable_db(tmp_path, monkeypatch)
+    try:
+        _plant(d, **{FTS_CJK_STALE_KEY: 1})
+        assert _blocker(d)[0] == "message_cjk_incomplete"
+    finally:
+        d.close()
+
+
+def test_session_cjk_hp_blocks_even_on_incapable_host(tmp_path, monkeypatch):
+    d = _cjk_incapable_db(tmp_path, monkeypatch)
+    try:
+        _plant(d, fts_session_cjk_rebuild_high_water=5,
+               fts_session_cjk_rebuild_progress=0)
+        assert _blocker(d) == ("session_cjk_incomplete", False)
+        assert d.fts_optimize_available() is False
+    finally:
+        d.close()
+
+
+def test_session_cjk_stale_blocks_even_on_incapable_host(tmp_path, monkeypatch):
+    d = _cjk_incapable_db(tmp_path, monkeypatch)
+    try:
+        _plant(d, **{FTS_SESSION_CJK_STALE_KEY: 1})
+        assert _blocker(d)[0] == "session_cjk_incomplete"
+    finally:
+        d.close()
+
+
+def test_optional_cjk_absence_on_incapable_host_does_not_block(
+    tmp_path, monkeypatch
+):
+    """Never-established optional CJK with no durable state is valid
+    degraded absence — it must not deadlock the required settlement."""
+    d = _cjk_incapable_db(tmp_path, monkeypatch)
+    try:
+        assert _blocker(d) is None
+        assert d.fts_optimize_available() is False
+    finally:
+        d.close()
+
+
+def test_session_trigram_hp_blocks_when_local_serving_false(db, monkeypatch):
+    """The block decision is durable-state based: even with the local serving
+    flag forced False, trigram H/P still blocks v2 (capability is never
+    evidence of completion). Only the 'actionable here' flag drops."""
+    _plant(db, fts_session_trigram_rebuild_high_water=1,
+           fts_session_trigram_rebuild_progress=0)
+    monkeypatch.setattr(db, "_sessions_trigram_available", False)
+    assert _blocker(db) == ("session_trigram_incomplete", False)
+    assert db.fts_optimize_available() is False
+
+
+def test_session_trigram_stale_blocks(db):
+    _plant(db, **{FTS_SESSION_TRIGRAM_STALE_KEY: 1})
+    assert _blocker(db)[0] == "session_trigram_incomplete"
+
+
+def test_trigram_unknown_same_name_blocks_and_survives_untouched(tmp_path):
+    """The historical fork-only ``tokenize='simple'`` same-name root is an
+    ``unknown_same_name`` shape: #31 refuses v2, fail-closed, and must NOT
+    delete or demote it."""
+    db_path = tmp_path / "u.db"
+    _build_unknown_same_name_trigram_db(db_path)
+    d = SessionDB(db_path=db_path)
+    try:
+        assert _blocker(d) == ("session_trigram_unknown_same_name", False)
+        assert d.fts_optimize_available() is False
+        # Byte/schema-identical: no destructive convergence.
+        assert "tokenize='unicode61'" in _trigram_ddl(d)
+    finally:
+        d.close()


### PR DESCRIPTION
Closes #31

Implements the storage-v2 settlement state machine per the #36 research handoff (PR #77, `docs/research/issue-36-storage-v2-settlement.md`).

## What this adds

- One **shared SELECT-only, durable/schema-aware evaluator** — `_fts_storage_v2_blockers(conn)` (generator, every blocker) + `_fts_storage_v2_blocker(conn)` (first blocker) — that is the single storage-v2 completion proof. `FTS_STORAGE_VERSION` bumped `1 -> 2`.
- The SAME evaluator drives all four completion decisions (they used to diverge): writable startup (now after every message/session ensure path), `fts_optimize_available()` (now `ANY(actionable)` across the whole blocker set), the foreground pre-VACUUM refusal, and the final transactional `_settle()` re-check.
- Durable/not-serving-boolean refusal semantics: any H/P/stale breadcrumb blocks v2 even on a host that cannot operate the lane; optional absent-with-no-durable-state stays valid degraded completion; #30 trigram ownership failures (`unknown_same_name` / foreign triggers / source collision / incomplete exact trigger set) fail closed untouched.
- A stale v2 claim is withdrawn wherever a blocker is found (startup reopen, pre-VACUUM refusal, final transactional re-check) — no completion is advertised while work remains.

## Review history

- R1 code-review (`5267513065`): structural refusal branches pinned, claim-withdrawal helper, lane reason labels moved onto `_FTS_REBUILD_LANES`, startup settlement moved outside the fts5 gate, direct attribute access.
- R2 ponytail+ (`5268299296`): **P2** — `fts_optimize_available()` only read the first blocker's actionability, hiding later runnable lanes on incapable hosts; fixed by computing `ANY(actionable)` over the full blocker set (single-source generator).
- R3 ponytail re-review (`5268486989`): **merge-ready, 0 P1 / 0 P2.**

## Validation (this host)

Settlement file: 35 passed. Main FTS regression (test_hermes_state + lifecycle registry + session metadata FTS/trigram/CJK + fts_cjk_bigram + read-path + update-of-narrowing): 336 passed / 43 skipped (CJK-tokenizer capability skips only). Repair/runtime suites: 15 passed. ruff clean.

Note: `tests/hermes_cli/test_session_recovery.py::test_cli_allow_partial_salvages_rows_across_a_corrupt_leaf` fails on this Windows cp950 console (subprocess `UnicodeDecodeError`) — confirmed identical on the unmodified base, an environment artifact unrelated to this change. GitHub exposes no status / workflow runs for this branch, so approval is code-review evidence only, not a CI-green claim.
