### PR TITLE
fix(recovery): exclude session-trigram derived markers from recovered DB (#79)

### DIFF
--- a/docs/research/issue-79-session-recovery-trigram-markers.md
+++ b/docs/research/issue-79-session-recovery-trigram-markers.md
@@ -1,0 +1,95 @@
+# #79 session-recovery: session-trigram derived markers
+
+Status: **implemented (2026-08-13)**  
+Code base: **`276d497764feb7d4a71f1424ed44b8958da63b16`** (post-#31 `dev` merge, PR #78)  
+Branch: `feat/79-session-recovery-trigram-markers`  
+Target: **#79 ??Final #12 acceptance / closure audit**
+
+> This closes the last known derived-FTS recovery gap before #12 acceptance:
+> the session-trigram lane was the only session-metadata lane missing from
+> the offline recovery `state_meta` inventory, so a source DB carrying
+> trigram transition state could leak that derived bookkeeping into the
+> recovered database as ordinary `state_meta`.
+
+## Background
+
+Offline session recovery (`hermes_cli/session_recovery.py`) is non-destructive:
+canonical rows are copied into a freshly initialized current-schema database,
+and **derived FTS state is rebuilt by the fresh destination, never copied**.
+That invariant is enforced by two inventories:
+
+- `_GENERATED_META_KEYS` ??the `state_meta` keys excluded during the copy
+  (`NOT IN (...)` filter) and deleted by `_finalize_derived_metadata()` before
+  the storage-version stamp;
+- the `pending_fts_keys` verifier ??the hard-coded tuple checked against the
+  recovered DB's `state_meta` so a leftover derived marker fails verification.
+
+At `dev@276d497` both inventories covered the message lane
+(`fts_rebuild_*`, `fts_cjk_*`), the session Unicode lane
+(`fts_session_rebuild_*`, #25), and the session CJK lane
+(`fts_session_cjk_*`, #26) ??but not the session trigram lane (`#30`):
+
+```
+fts_session_trigram_rebuild_high_water
+fts_session_trigram_rebuild_progress
+fts_session_trigram_stale
+```
+
+This was recorded as a **pre-existing #30 recovery gap** in the #31 final
+merge note.
+
+## What changed
+
+`hermes_cli/session_recovery.py`:
+
+- `_GENERATED_META_KEYS` gained the three `fts_session_trigram_*` keys. This
+  makes the copy filter exclude them (they no longer pass the `NOT IN`
+  filter) **and** makes `_finalize_derived_metadata()` delete any of them the
+  fresh `SessionDB` open happened to re-seed before the final stamp.
+- The `pending_fts_keys` verifier tuple gained the same three keys, so a
+  recovered DB that still carries trigram transition state now fails
+  verification with "derived FTS transition markers remain in the recovered
+  database".
+
+The fresh destination is opened as a real `SessionDB` (which runs the full
+message + session FTS ensure on a capable host), so on a trigram-capable host
+the destination *will* seed its own `fts_session_trigram_rebuild_high_water` /
+`progress` during open; the fix makes `_finalize_derived_metadata()` strip
+those seeds along with every other generated key, leaving only the
+`fts_storage_version` stamp.
+
+## Verification
+
+New tests in `tests/hermes_cli/test_session_recovery.py` (TDD RED ?? GREEN):
+
+- `test_session_trigram_derived_keys_are_generated_meta` ??the three trigram
+  keys are members of `_GENERATED_META_KEYS` (mirrors the existing #26 CJK
+  membership test).
+- `test_recovery_strips_session_trigram_derived_markers` ??behavioral
+  regression: a source DB seeded with all three trigram transition markers
+  (H=999, P=500, stale=1) is recovered; the recovered DB's `state_meta` must
+  not contain any of them, and verification reports no `pending_fts_keys`.
+  **Before the fix this failed** with `fts_session_trigram_rebuild_high_water`
+  present in the recovered `state_meta`.
+
+Results:
+
+```
+tests/hermes_cli/test_session_recovery.py      6 passed, 1 pre-existing env failure
+tests/test_fts_storage_v2_settlement.py        (passes)
+tests/test_session_metadata_trigram_fts.py     (passes)
+tests/test_fts_lifecycle_registry.py           (passes)
+ruff check                                     clean
+```
+
+The one `test_session_recovery.py` failure is
+`test_cli_allow_partial_salvages_rows_across_a_corrupt_leaf`, which fails on
+BASE with a subprocess `UnicodeDecodeError: cp950` on this Windows console
+(pre-existing environment artifact, documented in the #31 record), unrelated
+to this change.
+
+## Out of scope
+
+- Negative-space audit of the full #12 contract against `dev@276d497` (item 2
+  of #79).
+- Updating the stale #30-ownership statement in #13 (item 3 of #79).

--- a/hermes_cli/session_recovery.py
+++ b/hermes_cli/session_recovery.py
@@ -65,6 +65,12 @@ _GENERATED_META_KEYS = frozenset({
     "fts_session_cjk_rebuild_high_water",
     "fts_session_cjk_rebuild_progress",
     "fts_session_cjk_stale",
+    # Session trigram metadata rebuild markers + stale breadcrumb (issue #30) -
+    # trigram derived state, regenerated from the current schema on a fresh
+    # destination, never copied.
+    "fts_session_trigram_rebuild_high_water",
+    "fts_session_trigram_rebuild_progress",
+    "fts_session_trigram_stale",
     "telegram_dm_topic_schema_version",
 })
 
@@ -1119,6 +1125,9 @@ def _verify_recovered_database(
                 "fts_session_cjk_rebuild_high_water",
                 "fts_session_cjk_rebuild_progress",
                 "fts_session_cjk_stale",
+                "fts_session_trigram_rebuild_high_water",
+                "fts_session_trigram_rebuild_progress",
+                "fts_session_trigram_stale",
             )
             if key in meta
         )

--- a/tests/hermes_cli/test_session_recovery.py
+++ b/tests/hermes_cli/test_session_recovery.py
@@ -606,6 +606,72 @@ def test_session_cjk_derived_keys_are_generated_meta():
         assert key in session_recovery._GENERATED_META_KEYS, key
 
 
+def test_session_trigram_derived_keys_are_generated_meta():
+    """#79: the session-trigram derived markers (H/P/stale) are regenerated
+    from the fresh destination's own schema on recovery — never copied from
+    the source — mirroring the #25 session Unicode and #26 session CJK
+    lanes."""
+    for key in (
+        "fts_session_trigram_rebuild_high_water",
+        "fts_session_trigram_rebuild_progress",
+        "fts_session_trigram_stale",
+    ):
+        assert key in session_recovery._GENERATED_META_KEYS, key
+
+
+def test_recovery_strips_session_trigram_derived_markers(
+    tmp_path: Path,
+) -> None:
+    """Session-trigram transition markers must not reach the recovered DB.
+
+    #31's final merge note recorded this as a pre-existing #30 recovery gap:
+    the session-trigram lane was missing from both _GENERATED_META_KEYS and
+    the pending_fts_keys verifier, so a source DB carrying trigram transition
+    state had that derived bookkeeping copied into the new DB as ordinary
+    state_meta, and verification never flagged it.
+    """
+    source = tmp_path / "trigram-markers.db"
+    output = tmp_path / "trigram-markers-recovered.db"
+    _make_source(source)
+
+    db = SessionDB(db_path=source)
+    try:
+        # The source carries trigram transition state: a partially-done
+        # rebuild plus a stale breadcrumb, exactly the shape the #30 lane
+        # can leave behind before recovery.
+        db.set_meta("fts_session_trigram_rebuild_high_water", "999")
+        db.set_meta("fts_session_trigram_rebuild_progress", "500")
+        db.set_meta("fts_session_trigram_stale", "1")
+    finally:
+        db.close()
+
+    report = recover_session_database(
+        source,
+        output,
+        work_dir=tmp_path,
+        chunk_size=16,
+    )
+
+    assert report["verified"] is True
+    assert report["complete"] is True
+    assert report["verification"]["healthy"] is True
+    assert report["verification"]["pending_fts_keys"] == []
+
+    conn = sqlite3.connect(str(output))
+    try:
+        recovered_keys = {
+            str(row[0]) for row in conn.execute("SELECT key FROM state_meta")
+        }
+    finally:
+        conn.close()
+    for key in (
+        "fts_session_trigram_rebuild_high_water",
+        "fts_session_trigram_rebuild_progress",
+        "fts_session_trigram_stale",
+    ):
+        assert key not in recovered_keys, key
+
+
 def test_partial_recovery_clears_only_unreadable_system_prompt_refs(
     tmp_path: Path,
 ) -> None:

--- a/tests/hermes_cli/test_session_recovery.py
+++ b/tests/hermes_cli/test_session_recovery.py
@@ -672,6 +672,65 @@ def test_recovery_strips_session_trigram_derived_markers(
         assert key not in recovered_keys, key
 
 
+@pytest.mark.parametrize(
+    "marker_key",
+    (
+        "fts_session_trigram_rebuild_high_water",
+        "fts_session_trigram_rebuild_progress",
+        "fts_session_trigram_stale",
+    ),
+)
+def test_verify_flags_leftover_session_trigram_markers(
+    tmp_path: Path,
+    marker_key: str,
+) -> None:
+    """The recovered-DB verifier must detect a trigram transition marker that
+    survives recovery.
+
+    The behavioral recovery test above proves the copy path strips the
+    markers, but if someone later removes the trigram keys from the verifier's
+    pending_fts_keys inventory, a leftover marker would go un-noticed. This
+    guards the detection side of the two-layer fix (#79 item 1): build a
+    healthy recovered DB, seed one leftover marker, and require verification
+    to flag it.
+    """
+    source = tmp_path / "trigram-marker-source.db"
+    output = tmp_path / "trigram-marker-output.db"
+    _make_source(source)
+
+    report = recover_session_database(
+        source,
+        output,
+        work_dir=tmp_path,
+        chunk_size=16,
+    )
+    assert report["verified"] is True
+    assert report["complete"] is True
+
+    # Simulate a marker that survived the copy (e.g. the inventory drifts
+    # again and a future lane is omitted from _GENERATED_META_KEYS).
+    conn = sqlite3.connect(str(output), isolation_level=None)
+    try:
+        conn.execute(
+            "INSERT OR REPLACE INTO state_meta(key, value) VALUES (?, ?)",
+            (marker_key, "1"),
+        )
+    finally:
+        conn.close()
+
+    verification = session_recovery._verify_recovered_database(
+        output,
+        expected_counts={},
+        copy_report={},
+    )
+    assert marker_key in verification["pending_fts_keys"]
+    assert verification["healthy"] is False
+    assert any(
+        "derived FTS transition markers remain" in error
+        for error in verification["errors"]
+    )
+
+
 def test_partial_recovery_clears_only_unreadable_system_prompt_refs(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
Closes #79 (item 1: session-recovery trigram markers)

## What

`hermes_cli/session_recovery.py`: the session-trigram lane was the only session-metadata lane missing from the offline-recovery derived-state inventory. A source DB carrying trigram transition state could leak `fts_session_trigram_rebuild_high_water` / `fts_session_trigram_rebuild_progress` / `fts_session_trigram_stale` into the recovered DB as ordinary `state_meta`, and the verifier never flagged it. Recorded as a pre-existing #30 recovery gap in the #31 final merge note.

- `_GENERATED_META_KEYS` now includes the three `fts_session_trigram_*` keys, so the copy filter excludes them and `_finalize_derived_metadata()` strips any the fresh `SessionDB` open re-seeded before the storage-version stamp.
- The `pending_fts_keys` verifier now includes the same three keys, so leftover trigram transition state fails verification.

## Tests

TDD RED -> GREEN, two new tests in `tests/hermes_cli/test_session_recovery.py`:

- `test_session_trigram_derived_keys_are_generated_meta` (membership).
- `test_recovery_strips_session_trigram_derived_markers` (behavioral: source seeded with trigram H/P/stale -> recovered DB must not contain them). Failed before the fix with `fts_session_trigram_rebuild_high_water` present in the recovered `state_meta`.

`test_session_recovery.py` 6 passed + 1 pre-existing cp950 env failure (`test_cli_allow_partial_salvages_rows_across_a_corrupt_leaf`, fails on BASE, unrelated). Related suites green: `test_fts_storage_v2_settlement.py`, `test_session_metadata_trigram_fts.py`, `test_fts_lifecycle_registry.py` (130 passed, 1 skipped). ruff clean.

Research doc: `docs/research/issue-79-session-recovery-trigram-markers.md`.
