### PR TITLE
repair(compression): preserve plugin no-op session boundaries

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -3160,6 +3160,31 @@ def compress_context(
             finally:
                 _release_lock()
 
+        # Plugin no-op: engine reports it made no structural change.
+        # Check this BEFORE the semantic equality test so a plugin that
+        # returns a freshly-built equal list (not the input object) is
+        # still recognized as a no-op via its status flag.
+        if (
+            getattr(
+                agent.context_compressor,
+                "last_compression_status",
+                getattr(agent.context_compressor, "_last_compression_status", ""),
+            )
+            == "noop"
+        ):
+            try:
+                logger.info(
+                    "context compression no-op: session=%s messages=%d unchanged; skipping session boundary",
+                    agent.session_id or "none",
+                    _pre_msg_count,
+                )
+                _existing_sp = getattr(agent, "_cached_system_prompt", None)
+                if not _existing_sp:
+                    _existing_sp = agent._build_system_prompt(system_message)
+                return compressed, _existing_sp
+            finally:
+                _release_lock()
+
         # Compare against the pre-dispatch semantic state, not object identity:
         # legacy/plugin engines may return an equal copy for a no-op, or mutate
         # the live list while returning an unchanged snapshot. Neither case may

--- a/tests/run_agent/test_compression_noop_status.py
+++ b/tests/run_agent/test_compression_noop_status.py
@@ -1,0 +1,87 @@
+"""Regression tests for plugin-reported compression no-op boundaries.
+
+These cases intentionally use output that differs from the input. Equal-copy
+results are already covered by the semantic no-progress guard merged upstream
+in NousResearch/hermes-agent#67938; this file protects the residual contract
+where an external context engine reports ``noop`` after cleanup-only active
+context changes that must be adopted without minting a compression boundary.
+"""
+
+import sqlite3
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from tests.run_agent.test_compression_boundary_hook import (
+    TestCompressionBoundaryHook as _BoundaryHarness,
+)
+
+
+def _noop_compressor(cleaned_messages):
+    compressor = MagicMock()
+
+    def _compress(_messages, **_kwargs):
+        compressor.last_compression_status = "noop"
+        return list(cleaned_messages)
+
+    compressor.compress.side_effect = _compress
+    compressor.compression_count = 0
+    compressor.last_prompt_tokens = 0
+    compressor.last_completion_tokens = 0
+    compressor._last_summary_error = None
+    compressor._last_compress_aborted = False
+    compressor._last_compression_made_progress = False
+    compressor._last_summary_fallback_used = False
+    compressor._last_compression_feasibility_reason = None
+    compressor.last_compression_status = ""
+    return compressor
+
+
+def test_plugin_noop_adopts_cleanup_without_session_boundary():
+    """A reported no-op may change active context without being a split."""
+    from hermes_state import SessionDB
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "test.db"
+        db = SessionDB(db_path=db_path)
+        agent = _BoundaryHarness()._make_agent(db)
+
+        messages = [
+            {"role": "user", "content": "replayed scaffold"},
+            {"role": "assistant", "content": "fresh tail"},
+        ]
+        cleaned = [{"role": "assistant", "content": "fresh tail"}]
+        compressor = _noop_compressor(cleaned)
+        agent.context_compressor = compressor
+        agent._cached_system_prompt = "cached-system-prompt"
+
+        original_sid = agent.session_id
+        compressed, prompt = agent._compress_context(
+            messages,
+            "sys",
+            approx_tokens=10_000,
+        )
+
+        # This must exercise the explicit status seam, not #67938's equality
+        # guard: cleanup changed the active context.
+        assert compressed == cleaned
+        assert compressed != messages
+        assert prompt == "cached-system-prompt"
+        assert agent.session_id == original_sid
+
+        compression_boundary_calls = [
+            call
+            for call in compressor.on_session_start.call_args_list
+            if call.kwargs.get("boundary_reason") == "compression"
+        ]
+        assert not compression_boundary_calls
+
+        conn = sqlite3.connect(str(db_path))
+        try:
+            child_count = conn.execute(
+                "SELECT COUNT(*) FROM sessions WHERE parent_session_id = ?",
+                (original_sid,),
+            ).fetchone()[0]
+        finally:
+            conn.close()
+        assert child_count == 0


### PR DESCRIPTION
## Summary

Repairs the Phase-2 `repair:compression-lifecycle` unit from #112 on top of refreshed upstream `main` (`3b9a963b8e5cdb804a422755bed9a60fcd778273`).

This ports the reviewed host-side status contract from upstream PR NousResearch/hermes-agent#58495 onto the current compression lifecycle seam rather than replaying the historical fork telemetry commit shape.

### Current-upstream / prior-art classification

- **Merged/current:** NousResearch/hermes-agent#67938 added semantic no-progress detection (`compressed == messages_before_compression`), including equal newly allocated output and restoration of in-place mutations. That owns the equal-copy half of the historical fork behavior.
- **Closed/unmerged:** NousResearch/hermes-agent#58495 implemented the explicit `last_compression_status == "noop"` boundary skip (plus legacy `_last_compression_status` fallback), but was later closed as “absorbed” by the semantic-equality guard.
- **Residual still real today:** current `stephenschoettler/hermes-lcm` can report `last_compression_status == "noop"` after cleanup-only active-context changes. In those paths the returned context can differ from the input even though no compaction/session boundary occurred, so #67938’s equality guard is not sufficient by itself. The host must adopt the returned active context while skipping session rotation/rewrite.
- **Related but not required:** `stephenschoettler/hermes-lcm#432` is open/unmerged and only adds a setter for an earlier host-side status-reset experiment. #58495 removed that reset after it crashed LCM's read-only property, so this repair does not depend on #432.
- **Out of scope:** Session Search / compression lineage; #112 remains an independent compression transition repair.

## Behavior

- A context engine reporting `noop` returns the engine output through the existing prompt/lock-safe no-boundary path before session rotation/rewrite.
- Public `last_compression_status` is preferred; legacy `_last_compression_status` remains a compatibility fallback.
- Existing abort handling and semantic-equality no-progress handling stay adjacent in the current upstream lifecycle seam.
- Successful compression transitions are unchanged.

## Regression coverage

The regression deliberately does **not** use an equal newly allocated copy, because #67938 already makes that case pass without this repair. Instead it models the current residual contract:

1. the plugin reports `last_compression_status = "noop"` during `compress()`;
2. it returns cleanup-changed active context (`compressed != messages`);
3. the host adopts that returned context;
4. the cached system prompt is retained;
5. the physical session id does not rotate;
6. no compression-boundary hook fires and no child session is persisted.

## Provenance / reconstruction shape

- Historical fork overlay: `176646d2cd6c95fa49b9414f21ed9e781b0aaa84`.
- Reviewed upstream prior art: NousResearch/hermes-agent#58495.
- Current upstream-owned equal-copy behavior: NousResearch/hermes-agent#67938.
- Final feature branch is intentionally squashed to **one current-main-based repair commit** (`c64408947215d3af31e40dc22745e7ebe2921dec`) so the Phase-2 line does not inherit stale #58495 branch topology or unrelated attribution churn. Prior-art credit is preserved here instead.

Closes #112
