### PR TITLE
repair(browser): restore config-gated timeout cleanup

### DIFF
--- a/docs/research/browser-runtime-issue-115.md
+++ b/docs/research/browser-runtime-issue-115.md
@@ -1,0 +1,71 @@
+# Browser Runtime reconstruction preflight — issue #115
+
+Date: 2026-08-19
+
+## Authority / pinned refs
+
+- Phase-2 ticket: #115 (`repair:browser-runtime`).
+- Composition authority: PR #108 at `5aa4f4e27ccf2169beb4fc1f1d1eeb655d13b548` — `line:browser-timeout-cleanup` is an independent vertical feature.
+- Phase-1 accounting: PR #104 manifest head `f81cd921a89516d855b5b69906ce99e6351bc741`.
+- Fork evidence: historical `dev` capability line, including commits `a2450695`, `b42bc25e`, and `cfb2636a`.
+- Final reconstruction substrate: current fork `main` / upstream-aligned base `243352e7b8bddc9f33eba1b6506810f8dd88beaa`.
+- PR #108 originally pinned upstream `56526bc0d36522ab7a87ee0056f70e3847d2f0e6`; `tools/browser_tool.py` remains unchanged through the final refreshed base (blob `544a06d51277098472436ce4e049e293078b52f3`).
+
+## Upstream prior art / current authority
+
+| Upstream work | State at reconstruction | Use here |
+|---|---|---|
+| #86755 — resource-leak salvage, including periodic browser orphan reaping from #82145 | **merged** | Current authority. Preserve the periodic orphan sweep, idle-age escape hatch, and `_verify_reapable_browser_daemon()` identity/session binding checks. |
+| #82145 — periodic browser orphan reaper / live-owner idle escape hatch | closed, unmerged | Its relevant browser behavior was salvaged into merged #86755. Use #86755/current main as authority, not this branch shape. |
+| #68152 — reap daemon directly on command timeout | closed, unmerged | Superseded explicitly by #68220. Provenance/design evidence only. |
+| #68220 — verified daemon tree kill on command timeout | open, unmerged | Strong prior art for the same leak family. Evidence only; it is not current-main policy. |
+| #50667 — verify PID identity before normal browser session cleanup kill | open, unmerged | Adjacent hardening only. Do not silently change normal-cleanup policy in #115. |
+| #64383 — broader ownership/PID-reuse-safe orphan recovery | open, unmerged | Broader hardening evidence only; do not pull its unmerged architecture into this bounded repair. |
+
+## Fork residual contract
+
+Phase-1 provenance identifies one fork-owned capability, `capability:browser-timeout-cleanup`:
+
+1. Timeout-triggered daemon/session teardown is opt-in through `browser.terminate_daemon_on_timeout`; the default is `false`.
+2. When disabled, timeout keeps current-upstream behavior: fail the command but leave the browser session for normal inactivity/orphan lifecycle cleanup.
+3. When enabled for a local session, timeout cleanup covers the owning session and any `::local` sidecar, but destructive cleanup requires verified daemon/session ownership.
+4. Missing, malformed, unverified, or unsuccessfully terminated PIDs preserve the socket directory and in-memory session tracking as recovery evidence for normal lifecycle cleanup and the merged orphan reaper.
+5. Cleanup/termination failures are best-effort and cannot mask the original timeout result.
+6. Cloud/CDP timeout behavior and ordinary non-timeout browser lifecycle remain unchanged.
+
+The merged periodic orphan reaper does **not** supersede this contract. It is delayed recovery for orphaned/untracked daemons; the fork option is an explicit immediate-on-timeout policy for deployments that choose it. Current upstream still has no `terminate_daemon_on_timeout` configuration seam.
+
+## Reconstruction decision
+
+Port the accepted behavior onto the unchanged current-upstream `tools/browser_tool.py` seam rather than replaying historical merge topology.
+
+- Keep current upstream orphan-reaper, owner PID, idle timeout, and normal cleanup behavior intact.
+- Preserve `browser.terminate_daemon_on_timeout=false` as the default and strict no-immediate-teardown path.
+- Preserve local-only scope; do not change cloud/CDP timeout ownership.
+- Preserve sidecar ownership handling.
+- **Do not** replay historical finally-clean-all behavior when daemon ownership is ambiguous. Merged #86755 makes the socket directory — including entry mtimes — recovery evidence.
+- Share PID/socket teardown, session-state removal, and last-active-binding pruning primitives with normal browser cleanup so ownership-sensitive logic has one implementation instead of parallel sources of truth.
+- Do not import #68220/#50667/#64383 wholesale: they remain unmerged and would expand this ticket into a different lifecycle/security policy.
+
+## Acceptance mapping
+
+Tests for this merge unit must prove:
+
+- default/config-false timeout returns the timeout failure without daemon/session teardown;
+- config-true local timeout terminates and removes runtime state only after ownership is verified;
+- `::local` sidecars follow current ownership semantics;
+- missing/malformed/unverified PID and termination failures preserve socket + session recovery metadata;
+- verified ownership plus successful termination removes runtime state;
+- cloud/CDP timeout does not take the local daemon-kill path;
+- the original timeout error remains observable even if cleanup fails;
+- ordinary successful/non-timeout browser behavior remains unchanged.
+
+## Review correction — 2026-08-19
+
+The first reconstruction incorrectly treated ambiguous ownership as cleanup success: it refused to signal an unverified PID but still removed the socket directory and in-memory session metadata. That erased evidence used by the merged #86755 orphan-recovery path, including socket-entry mtimes.
+
+Corrected invariant:
+
+> verified ownership + successful termination → destructive cleanup; ambiguous ownership or failed termination → preserve recovery metadata.
+
+The correction also factors PID/socket teardown and session-state/binding cleanup into shared helpers used by timeout and normal cleanup. Timeout supplies the stricter `require_verified_ownership=True` policy; normal cleanup retains its established best-effort behavior. This removes the duplicated security-sensitive ownership implementation without importing unmerged upstream policy.

--- a/docs/research/browser-runtime-issue-115.md
+++ b/docs/research/browser-runtime-issue-115.md
@@ -105,3 +105,21 @@ handoff (both 2026-08-19). This section records how the branch satisfies them.
 
 Verification on `1cab18e4a`: browser acceptance + hybrid-routing + orphan-reaper +
 timeout/open regressions pass (58 local tests); CI on PR #121 is fully green.
+
+## Review round 2 — 2026-08-19 (late)
+
+`/code-review` on PR #121 returned 2 spec blockers + 3 standards findings
+(addressed on `6f7312464`):
+
+| Finding | Fix |
+|---|---|
+| Spec: `_terminate_host_pid` treated "no exception" as success (Windows `taskkill` return code unchecked; POSIX `AccessDenied`/`OSError` swallowed); destructive cleanup deleted evidence for a still-alive daemon | `_terminate_host_pid` now returns confirmed-dead evidence (taskkill return code + bounded `_pid_gone_within` liveness poll on Windows; whole-tree confirmation after SIGTERM/SIGKILL on POSIX). The timeout teardown path only removes socket dir + session metadata when termination is confirmed; `False` preserves recovery evidence. |
+| Spec: process-global `_cached_terminate_daemon` leaked the opt-in policy across multiplexed profiles | `_should_terminate_daemon_on_timeout` resolves context-local config per call when `get_hermes_home_override()` is set (mirrors `_allow_private_urls`); single-profile path still caches. Dual `true→false→true` regression test added. |
+| Standards: new `browser.terminate_daemon_on_timeout` missing from `DEFAULT_CONFIG` | Added to `hermes_cli/config_defaults.py` browser section (deep-merge picks it up; no version bump needed). |
+| Standards: broad `except Exception` logs lacked tracebacks | `exc_info=True` added on both timeout-cleanup log sites. |
+| Standards: acceptance tests mocked the termination helper, hiding the real Windows/POSIX failure mode | Added contract tests that exercise `_terminate_host_pid`'s real Windows taskkill-failure and POSIX confirmed/survivor paths (stubbed `psutil` module so the hermetic venv needs no psutil), plus unconfirmed-termination-preserves / confirmed-termination-cleans teardown tests. |
+
+Verification on `6f7312464`: 23 acceptance tests (hermetic wrapper) + browser
+lifecycle set green; ruff clean on all changed files; the only failing
+`test_process_registry.py` cases are pre-existing environment/live-system-guard
+failures, identical before and after this change.

--- a/docs/research/browser-runtime-issue-115.md
+++ b/docs/research/browser-runtime-issue-115.md
@@ -69,3 +69,39 @@ Corrected invariant:
 > verified ownership + successful termination → destructive cleanup; ambiguous ownership or failed termination → preserve recovery metadata.
 
 The correction also factors PID/socket teardown and session-state/binding cleanup into shared helpers used by timeout and normal cleanup. Timeout supplies the stricter `require_verified_ownership=True` policy; normal cleanup retains its established best-effort behavior. This removes the duplicated security-sensitive ownership implementation without importing unmerged upstream policy.
+
+## Wayfinder gate resolution — 2026-08-19 (late)
+
+Issue #115 received a Wayfinder intent-topology gate and an implementation
+handoff (both 2026-08-19). This section records how the branch satisfies them.
+
+### Upstream refresh (preflight)
+
+- Current fork `main` / branch base: `243352e7b8bddc9f33eba1b6506810f8dd88beaa`.
+- Current upstream `main` refreshed: `f82f2dbabd9e66b714f2b4f8a40447fe0c13e732`
+  (Wayfinder observed `a6bada232c4889fec1a2b50664f859d5335bc542`; upstream has since advanced).
+- Upstream changes since the base touch `tools/process_registry.py`,
+  `hermes_cli/config.py`, and `tests/conftest.py`, but **not**
+  `tools/browser_tool.py` (the branch's only production seam). No conflict and no
+  rebase requirement for the browser feature.
+- No `base/browser-runtime-115` branch exists; PR #121 targets fork `main`
+  directly, which matches the ticket's branch boundary.
+
+### Handoff directives → status
+
+| Directive | Status |
+|---|---|
+| Fix the #121 browser regressions around session / last-active pruning under the cleanup seam | Resolved on `1cab18e4a` — `cleanup_browser` restores the established bare-task (unconditional drop) vs `::local` (owner-only drop) last-active binding contract. |
+| Do not weaken the recovery-safe ownership contract | Preserved — timeout cleanup still requires `require_verified_ownership=True`; ambiguity/failure keeps socket dir + session metadata + last-active binding for orphan recovery. |
+| Unrelated `relay_shared_metrics` lock flakes are not part of this feature | Not addressed here; no longer present on the final head (all 12 CI slices green). |
+| Preserve shared teardown mechanics only where policy stays explicit | Timeout uses the strict policy; normal cleanup keeps best-effort semantics. |
+| Do not create a child `line:` PR for the regression | No new child line. |
+| Classify commits by behavior intents; tests belong with the behavior | `8a0da17e5` (research/evidence), `97457847a` (recovery-safe ownership + tests), `1cab18e4a` (shared-teardown last-active correctness + tests). |
+
+### Final invariant (unchanged)
+
+> verified ownership + successful termination → destructive cleanup; ambiguity or
+> termination failure → preserve recovery evidence.
+
+Verification on `1cab18e4a`: browser acceptance + hybrid-routing + orphan-reaper +
+timeout/open regressions pass (58 local tests); CI on PR #121 is fully green.

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -470,6 +470,7 @@ DEFAULT_CONFIG = {
         "backend": "",
         "inactivity_timeout": 120,
         "command_timeout": 30,  # Timeout for browser commands in seconds (screenshot, navigate, etc.)
+        "terminate_daemon_on_timeout": False,  # Opt-in: immediately tear down a local browser daemon whose command timed out (recovery-safe — requires verified ownership + confirmed termination)
         "record_sessions": False,  # Auto-record browser sessions as WebM videos
         "headed": False,  # Local mode: launch Chromium with a visible window (also skips per-turn cleanup so the window persists between turns; idle reaper still applies)
         "allow_private_urls": False,  # Allow navigating to private/internal IPs (localhost, 192.168.x.x, etc.)

--- a/tests/tools/test_browser_timeout_cleanup_policy.py
+++ b/tests/tools/test_browser_timeout_cleanup_policy.py
@@ -1,0 +1,361 @@
+"""Acceptance tests for issue #115 browser timeout cleanup policy."""
+
+import subprocess
+from unittest.mock import MagicMock
+
+import pytest
+
+import tools.browser_tool as bt
+
+
+@pytest.fixture(autouse=True)
+def clean_browser_state():
+    bt._active_sessions.clear()
+    bt._recording_sessions.clear()
+    bt._session_last_activity.clear()
+    bt._last_active_session_key.clear()
+    bt._cached_terminate_daemon = None
+    bt._terminate_daemon_resolved = False
+    yield
+    bt._active_sessions.clear()
+    bt._recording_sessions.clear()
+    bt._session_last_activity.clear()
+    bt._last_active_session_key.clear()
+    bt._cached_terminate_daemon = None
+    bt._terminate_daemon_resolved = False
+
+
+def _session(task_id: str, session_name: str) -> None:
+    bt._active_sessions[task_id] = {
+        "session_name": session_name,
+        "cdp_url": None,
+        "session_key": task_id,
+        "owner_task_id": bt._bare_task_id_for_session_key(task_id),
+    }
+    bt._recording_sessions.add(task_id)
+    bt._session_last_activity[task_id] = 1.0
+
+
+def _pid_file(tmp_path, session_name: str, pid: int) -> None:
+    socket_dir = tmp_path / f"agent-browser-{session_name}"
+    socket_dir.mkdir(parents=True, exist_ok=True)
+    (socket_dir / f"{session_name}.pid").write_text(str(pid), encoding="utf-8")
+
+
+def test_timeout_policy_defaults_false_and_parses_false_string(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.config.read_raw_config",
+        lambda: {"browser": {"terminate_daemon_on_timeout": "false"}},
+    )
+
+    assert bt._should_terminate_daemon_on_timeout() is False
+
+
+def test_timeout_policy_true_is_cached(monkeypatch):
+    calls = 0
+
+    def read_config():
+        nonlocal calls
+        calls += 1
+        return {"browser": {"terminate_daemon_on_timeout": True}}
+
+    monkeypatch.setattr("hermes_cli.config.read_raw_config", read_config)
+
+    assert bt._should_terminate_daemon_on_timeout() is True
+    assert bt._should_terminate_daemon_on_timeout() is True
+    assert calls == 1
+
+
+def test_cleanup_bare_task_includes_local_sidecar(tmp_path, monkeypatch):
+    _session("task", "primary")
+    _session("task::local", "sidecar")
+    bt._last_active_session_key["task"] = "task::local"
+    _pid_file(tmp_path, "primary", 101)
+    _pid_file(tmp_path, "sidecar", 202)
+
+    killed = []
+    monkeypatch.setattr(bt, "_socket_safe_tmpdir", lambda: str(tmp_path))
+    monkeypatch.setattr(bt, "_stop_cdp_supervisor", lambda _key: None)
+    monkeypatch.setattr(
+        bt, "_verify_reapable_browser_daemon", lambda *_args: True
+    )
+    monkeypatch.setattr(
+        "tools.process_registry.ProcessRegistry._terminate_host_pid",
+        lambda pid: killed.append(pid),
+    )
+
+    bt._cleanup_local_browser_after_timeout("task", "snapshot")
+
+    assert killed == [101, 202]
+    assert "task" not in bt._active_sessions
+    assert "task::local" not in bt._active_sessions
+    assert not bt._recording_sessions
+    assert not bt._session_last_activity
+    assert "task" not in bt._last_active_session_key
+    assert not (tmp_path / "agent-browser-primary").exists()
+    assert not (tmp_path / "agent-browser-sidecar").exists()
+
+
+def test_sidecar_timeout_does_not_destroy_live_primary_binding(tmp_path, monkeypatch):
+    _session("task", "primary")
+    _session("task::local", "sidecar")
+    bt._last_active_session_key["task"] = "task"
+    _pid_file(tmp_path, "sidecar", 303)
+
+    monkeypatch.setattr(bt, "_socket_safe_tmpdir", lambda: str(tmp_path))
+    monkeypatch.setattr(bt, "_stop_cdp_supervisor", lambda _key: None)
+    monkeypatch.setattr(
+        bt, "_verify_reapable_browser_daemon", lambda *_args: True
+    )
+    monkeypatch.setattr(
+        "tools.process_registry.ProcessRegistry._terminate_host_pid",
+        lambda _pid: None,
+    )
+
+    bt._cleanup_local_browser_after_timeout("task::local", "click")
+
+    assert "task" in bt._active_sessions
+    assert "task::local" not in bt._active_sessions
+    assert bt._last_active_session_key["task"] == "task"
+
+
+def test_sidecar_timeout_drops_binding_when_sidecar_owned_it(tmp_path, monkeypatch):
+    _session("task", "primary")
+    _session("task::local", "sidecar")
+    bt._last_active_session_key["task"] = "task::local"
+    _pid_file(tmp_path, "sidecar", 404)
+
+    monkeypatch.setattr(bt, "_socket_safe_tmpdir", lambda: str(tmp_path))
+    monkeypatch.setattr(bt, "_stop_cdp_supervisor", lambda _key: None)
+    monkeypatch.setattr(
+        bt, "_verify_reapable_browser_daemon", lambda *_args: True
+    )
+    monkeypatch.setattr(
+        "tools.process_registry.ProcessRegistry._terminate_host_pid",
+        lambda _pid: None,
+    )
+
+    bt._cleanup_local_browser_after_timeout("task::local", "click")
+
+    assert "task" in bt._active_sessions
+    assert "task" not in bt._last_active_session_key
+
+
+def test_termination_failure_preserves_recovery_metadata(tmp_path, monkeypatch):
+    _session("task", "primary")
+    bt._last_active_session_key["task"] = "task"
+    _pid_file(tmp_path, "primary", 505)
+
+    monkeypatch.setattr(bt, "_socket_safe_tmpdir", lambda: str(tmp_path))
+    monkeypatch.setattr(bt, "_stop_cdp_supervisor", lambda _key: None)
+    monkeypatch.setattr(
+        bt, "_verify_reapable_browser_daemon", lambda *_args: True
+    )
+    monkeypatch.setattr(
+        "tools.process_registry.ProcessRegistry._terminate_host_pid",
+        MagicMock(side_effect=RuntimeError("kill exploded")),
+    )
+
+    bt._cleanup_local_browser_after_timeout("task", "open")
+
+    assert "task" in bt._active_sessions
+    assert "task" in bt._recording_sessions
+    assert "task" in bt._session_last_activity
+    assert bt._last_active_session_key["task"] == "task"
+    assert (tmp_path / "agent-browser-primary").exists()
+
+
+def test_unverified_pid_preserves_recovery_metadata(tmp_path, monkeypatch):
+    _session("task", "primary")
+    bt._last_active_session_key["task"] = "task"
+    _pid_file(tmp_path, "primary", 707)
+    terminate = MagicMock()
+
+    monkeypatch.setattr(bt, "_socket_safe_tmpdir", lambda: str(tmp_path))
+    monkeypatch.setattr(bt, "_stop_cdp_supervisor", lambda _key: None)
+    monkeypatch.setattr(
+        bt, "_verify_reapable_browser_daemon", lambda *_args: False
+    )
+    monkeypatch.setattr(
+        "tools.process_registry.ProcessRegistry._terminate_host_pid", terminate
+    )
+
+    bt._cleanup_local_browser_after_timeout("task", "snapshot")
+
+    terminate.assert_not_called()
+    assert "task" in bt._active_sessions
+    assert "task" in bt._recording_sessions
+    assert "task" in bt._session_last_activity
+    assert bt._last_active_session_key["task"] == "task"
+    assert (tmp_path / "agent-browser-primary").exists()
+
+
+def test_malformed_pid_preserves_recovery_metadata(tmp_path, monkeypatch):
+    _session("task", "primary")
+    socket_dir = tmp_path / "agent-browser-primary"
+    socket_dir.mkdir(parents=True, exist_ok=True)
+    (socket_dir / "primary.pid").write_text("not-a-pid", encoding="utf-8")
+    verify = MagicMock()
+    terminate = MagicMock()
+
+    monkeypatch.setattr(bt, "_socket_safe_tmpdir", lambda: str(tmp_path))
+    monkeypatch.setattr(bt, "_stop_cdp_supervisor", lambda _key: None)
+    monkeypatch.setattr(bt, "_verify_reapable_browser_daemon", verify)
+    monkeypatch.setattr(
+        "tools.process_registry.ProcessRegistry._terminate_host_pid", terminate
+    )
+
+    bt._cleanup_local_browser_after_timeout("task", "open")
+
+    verify.assert_not_called()
+    terminate.assert_not_called()
+    assert "task" in bt._active_sessions
+    assert "task" in bt._recording_sessions
+    assert "task" in bt._session_last_activity
+    assert socket_dir.exists()
+
+
+
+def test_missing_pid_preserves_recovery_metadata(tmp_path, monkeypatch):
+    _session("task", "primary")
+    socket_dir = tmp_path / "agent-browser-primary"
+    socket_dir.mkdir(parents=True, exist_ok=True)
+    terminate = MagicMock()
+
+    monkeypatch.setattr(bt, "_socket_safe_tmpdir", lambda: str(tmp_path))
+    monkeypatch.setattr(
+        "tools.process_registry.ProcessRegistry._terminate_host_pid", terminate
+    )
+
+    bt._cleanup_local_browser_after_timeout("task", "snapshot")
+
+    terminate.assert_not_called()
+    assert "task" in bt._active_sessions
+    assert "task" in bt._recording_sessions
+    assert "task" in bt._session_last_activity
+    assert socket_dir.exists()
+
+def test_cleanup_all_resets_timeout_policy_cache(monkeypatch):
+    bt._cached_terminate_daemon = True
+    bt._terminate_daemon_resolved = True
+    monkeypatch.setattr(
+        "tools.browser_supervisor.SUPERVISOR_REGISTRY.stop_all", lambda: None
+    )
+
+    bt.cleanup_all_browsers()
+
+    assert bt._cached_terminate_daemon is None
+    assert bt._terminate_daemon_resolved is False
+
+
+def _timeout_result(tmp_path, monkeypatch, *, terminate: bool, cloud: bool = False):
+    session_info = {
+        "session_name": "timeout-session",
+        "cdp_url": "wss://example.invalid/devtools/browser/x" if cloud else None,
+    }
+    proc = MagicMock()
+    waits = 0
+
+    def wait(timeout=None):
+        nonlocal waits
+        waits += 1
+        if waits == 1:
+            raise subprocess.TimeoutExpired(cmd="agent-browser", timeout=5)
+        return 0
+
+    proc.wait.side_effect = wait
+    proc.returncode = None
+    cleanup = MagicMock()
+
+    monkeypatch.setattr(bt, "_find_agent_browser", lambda: "/usr/bin/agent-browser")
+    monkeypatch.setattr(bt, "_requires_real_termux_browser_install", lambda _cmd: False)
+    monkeypatch.setattr(bt, "_is_local_mode", lambda: False)
+    monkeypatch.setattr(bt, "_get_session_info", lambda _task: session_info)
+    monkeypatch.setattr(bt, "_is_headed_mode", lambda: False)
+    monkeypatch.setattr(bt, "_get_browser_engine", lambda: "auto")
+    monkeypatch.setattr(bt, "_is_camofox_mode", lambda: False)
+    monkeypatch.setattr(bt, "_socket_safe_tmpdir", lambda: str(tmp_path))
+    monkeypatch.setattr(bt, "_write_owner_pid", lambda *_args: None)
+    monkeypatch.setattr(bt, "_build_browser_env", lambda: {"PATH": ""})
+    monkeypatch.setattr(bt, "_merge_browser_path", lambda _path: "")
+    monkeypatch.setattr(bt, "_needs_chromium_sandbox_bypass", lambda: False)
+    monkeypatch.setattr(bt, "_lightpanda_fallback_reason", lambda *_args: None)
+    monkeypatch.setattr(bt, "_should_terminate_daemon_on_timeout", lambda: terminate)
+    monkeypatch.setattr(bt, "_cleanup_local_browser_after_timeout", cleanup)
+    monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False)
+    monkeypatch.setattr(bt.subprocess, "Popen", MagicMock(return_value=proc))
+
+    result = bt._run_browser_command("task", "snapshot", [], timeout=5)
+    return result, cleanup
+
+
+def test_default_timeout_keeps_session_and_skips_immediate_teardown(tmp_path, monkeypatch):
+    result, cleanup = _timeout_result(tmp_path, monkeypatch, terminate=False)
+
+    assert result["success"] is False
+    assert "timed out" in result["error"].lower()
+    cleanup.assert_not_called()
+
+
+def test_opt_in_local_timeout_runs_immediate_teardown(tmp_path, monkeypatch):
+    result, cleanup = _timeout_result(tmp_path, monkeypatch, terminate=True)
+
+    assert result["success"] is False
+    cleanup.assert_called_once_with("task", "snapshot")
+
+
+def test_opt_in_does_not_apply_local_daemon_teardown_to_cloud(tmp_path, monkeypatch):
+    result, cleanup = _timeout_result(
+        tmp_path, monkeypatch, terminate=True, cloud=True
+    )
+
+    assert result["success"] is False
+    cleanup.assert_not_called()
+
+
+def test_timeout_diagnostic_is_built_before_cleanup(tmp_path, monkeypatch):
+    events = []
+    session_info = {"session_name": "timeout-session", "cdp_url": None}
+    proc = MagicMock()
+    waits = 0
+
+    def wait(timeout=None):
+        nonlocal waits
+        waits += 1
+        if waits == 1:
+            raise subprocess.TimeoutExpired(cmd="agent-browser", timeout=5)
+        return 0
+
+    proc.wait.side_effect = wait
+
+    monkeypatch.setattr(bt, "_find_agent_browser", lambda: "/usr/bin/agent-browser")
+    monkeypatch.setattr(bt, "_requires_real_termux_browser_install", lambda _cmd: False)
+    monkeypatch.setattr(bt, "_is_local_mode", lambda: False)
+    monkeypatch.setattr(bt, "_get_session_info", lambda _task: session_info)
+    monkeypatch.setattr(bt, "_is_headed_mode", lambda: False)
+    monkeypatch.setattr(bt, "_get_browser_engine", lambda: "auto")
+    monkeypatch.setattr(bt, "_is_camofox_mode", lambda: False)
+    monkeypatch.setattr(bt, "_socket_safe_tmpdir", lambda: str(tmp_path))
+    monkeypatch.setattr(bt, "_write_owner_pid", lambda *_args: None)
+    monkeypatch.setattr(bt, "_build_browser_env", lambda: {"PATH": ""})
+    monkeypatch.setattr(bt, "_merge_browser_path", lambda _path: "")
+    monkeypatch.setattr(bt, "_needs_chromium_sandbox_bypass", lambda: False)
+    monkeypatch.setattr(bt, "_lightpanda_fallback_reason", lambda *_args: None)
+    monkeypatch.setattr(bt, "_should_terminate_daemon_on_timeout", lambda: True)
+    monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False)
+    monkeypatch.setattr(bt.subprocess, "Popen", MagicMock(return_value=proc))
+
+    def read_outputs(*_args):
+        events.append("read")
+        return "", "daemon diagnostic"
+
+    def cleanup(*_args):
+        events.append("cleanup")
+
+    monkeypatch.setattr(bt, "_read_command_output_files", read_outputs)
+    monkeypatch.setattr(bt, "_cleanup_local_browser_after_timeout", cleanup)
+
+    result = bt._run_browser_command("task", "snapshot", [], timeout=5)
+
+    assert events == ["read", "cleanup"]
+    assert "daemon diagnostic" in result["error"]

--- a/tests/tools/test_browser_timeout_cleanup_policy.py
+++ b/tests/tools/test_browser_timeout_cleanup_policy.py
@@ -1,6 +1,8 @@
 """Acceptance tests for issue #115 browser timeout cleanup policy."""
 
 import subprocess
+import sys
+import types
 from unittest.mock import MagicMock
 
 import pytest
@@ -42,6 +44,21 @@ def _pid_file(tmp_path, session_name: str, pid: int) -> None:
     (socket_dir / f"{session_name}.pid").write_text(str(pid), encoding="utf-8")
 
 
+def _fake_psutil_module(monkeypatch, **attrs):
+    """Inject a stub ``psutil`` module so lazy ``import psutil`` resolves.
+
+    ``tools.process_registry`` imports ``psutil`` lazily inside
+    ``_terminate_host_pid``.  The hermetic test venv may not ship psutil, so
+    we stub the module in ``sys.modules`` rather than monkeypatching an
+    attribute on a module that may not be importable.
+    """
+    fake = types.ModuleType("psutil")
+    for name, value in attrs.items():
+        setattr(fake, name, value)
+    monkeypatch.setitem(sys.modules, "psutil", fake)
+    return fake
+
+
 def test_timeout_policy_defaults_false_and_parses_false_string(monkeypatch):
     monkeypatch.setattr(
         "hermes_cli.config.read_raw_config",
@@ -66,6 +83,44 @@ def test_timeout_policy_true_is_cached(monkeypatch):
     assert calls == 1
 
 
+def test_multiplexed_profiles_resolve_policy_per_call(monkeypatch):
+    """Multiplexed profile turns resolve their context-local config per call.
+
+    Regression for the profile-leak blocker: a process-global cache would let
+    profile A's ``terminate_daemon_on_timeout=true`` leak into profile B's
+    ``false`` (and back), silently enabling immediate teardown for a profile
+    that did not opt in.
+    """
+    values = iter([True, False, True])
+
+    def read_config():
+        return {"browser": {"terminate_daemon_on_timeout": next(values)}}
+
+    monkeypatch.setattr("hermes_cli.config.read_raw_config", read_config)
+    monkeypatch.setattr(bt, "get_hermes_home_override", lambda: "/profiles/b")
+
+    assert bt._should_terminate_daemon_on_timeout() is True
+    assert bt._should_terminate_daemon_on_timeout() is False
+    assert bt._should_terminate_daemon_on_timeout() is True
+
+
+def test_single_profile_policy_is_cached(monkeypatch):
+    """Single profile caches the resolved policy (reads config once)."""
+    calls = 0
+
+    def read_config():
+        nonlocal calls
+        calls += 1
+        return {"browser": {"terminate_daemon_on_timeout": True}}
+
+    monkeypatch.setattr("hermes_cli.config.read_raw_config", read_config)
+    monkeypatch.setattr(bt, "get_hermes_home_override", lambda: None)
+
+    assert bt._should_terminate_daemon_on_timeout() is True
+    assert bt._should_terminate_daemon_on_timeout() is True
+    assert calls == 1
+
+
 def test_cleanup_bare_task_includes_local_sidecar(tmp_path, monkeypatch):
     _session("task", "primary")
     _session("task::local", "sidecar")
@@ -74,6 +129,11 @@ def test_cleanup_bare_task_includes_local_sidecar(tmp_path, monkeypatch):
     _pid_file(tmp_path, "sidecar", 202)
 
     killed = []
+
+    def _kill_confirmed(pid):
+        killed.append(pid)
+        return True
+
     monkeypatch.setattr(bt, "_socket_safe_tmpdir", lambda: str(tmp_path))
     monkeypatch.setattr(bt, "_stop_cdp_supervisor", lambda _key: None)
     monkeypatch.setattr(
@@ -81,7 +141,7 @@ def test_cleanup_bare_task_includes_local_sidecar(tmp_path, monkeypatch):
     )
     monkeypatch.setattr(
         "tools.process_registry.ProcessRegistry._terminate_host_pid",
-        lambda pid: killed.append(pid),
+        _kill_confirmed,
     )
 
     bt._cleanup_local_browser_after_timeout("task", "snapshot")
@@ -109,7 +169,7 @@ def test_sidecar_timeout_does_not_destroy_live_primary_binding(tmp_path, monkeyp
     )
     monkeypatch.setattr(
         "tools.process_registry.ProcessRegistry._terminate_host_pid",
-        lambda _pid: None,
+        lambda _pid: True,
     )
 
     bt._cleanup_local_browser_after_timeout("task::local", "click")
@@ -132,7 +192,7 @@ def test_sidecar_timeout_drops_binding_when_sidecar_owned_it(tmp_path, monkeypat
     )
     monkeypatch.setattr(
         "tools.process_registry.ProcessRegistry._terminate_host_pid",
-        lambda _pid: None,
+        lambda _pid: True,
     )
 
     bt._cleanup_local_browser_after_timeout("task::local", "click")
@@ -163,6 +223,150 @@ def test_termination_failure_preserves_recovery_metadata(tmp_path, monkeypatch):
     assert "task" in bt._session_last_activity
     assert bt._last_active_session_key["task"] == "task"
     assert (tmp_path / "agent-browser-primary").exists()
+
+
+def test_unconfirmed_termination_preserves_recovery_metadata(tmp_path, monkeypatch):
+    """Termination that returns without confirmation must preserve evidence.
+
+    Regression for the review blocker: ``_terminate_host_pid`` can fail (e.g.
+    Windows ``taskkill`` returns non-zero, POSIX ``AccessDenied`` swallowed)
+    without raising, so a test that only simulates an exception misses the
+    real failure mode.  The strict timeout path must treat a ``False`` return
+    exactly like a failure: keep socket dir + session metadata.
+    """
+    _session("task", "primary")
+    bt._last_active_session_key["task"] = "task"
+    _pid_file(tmp_path, "primary", 909)
+    terminate = MagicMock(return_value=False)  # kill ran but death unconfirmed
+
+    monkeypatch.setattr(bt, "_socket_safe_tmpdir", lambda: str(tmp_path))
+    monkeypatch.setattr(bt, "_stop_cdp_supervisor", lambda _key: None)
+    monkeypatch.setattr(
+        bt, "_verify_reapable_browser_daemon", lambda *_args: True
+    )
+    monkeypatch.setattr(
+        "tools.process_registry.ProcessRegistry._terminate_host_pid", terminate
+    )
+
+    bt._cleanup_local_browser_after_timeout("task", "open")
+
+    terminate.assert_called_once_with(909)
+    assert "task" in bt._active_sessions
+    assert "task" in bt._recording_sessions
+    assert "task" in bt._session_last_activity
+    assert bt._last_active_session_key["task"] == "task"
+    assert (tmp_path / "agent-browser-primary").exists()
+
+
+def test_confirmed_termination_removes_runtime_state(tmp_path, monkeypatch):
+    """Verified ownership + confirmed termination → destructive cleanup."""
+    _session("task", "primary")
+    bt._last_active_session_key["task"] = "task"
+    _pid_file(tmp_path, "primary", 1010)
+
+    monkeypatch.setattr(bt, "_socket_safe_tmpdir", lambda: str(tmp_path))
+    monkeypatch.setattr(bt, "_stop_cdp_supervisor", lambda _key: None)
+    monkeypatch.setattr(
+        bt, "_verify_reapable_browser_daemon", lambda *_args: True
+    )
+    monkeypatch.setattr(
+        "tools.process_registry.ProcessRegistry._terminate_host_pid",
+        MagicMock(return_value=True),
+    )
+
+    bt._cleanup_local_browser_after_timeout("task", "open")
+
+    assert "task" not in bt._active_sessions
+    assert "task" not in bt._recording_sessions
+    assert "task" not in bt._session_last_activity
+    assert "task" not in bt._last_active_session_key
+    assert not (tmp_path / "agent-browser-primary").exists()
+
+
+def test_terminate_host_pid_windows_taskkill_failure_returns_false(monkeypatch):
+    """Windows taskkill returning non-zero must NOT count as success.
+
+    Covers the real termination implementation (not a mocked helper): a failed
+    ``taskkill`` with no exception must still yield ``False`` so the caller
+    preserves recovery evidence instead of deleting a still-alive daemon.
+    """
+    from tools.process_registry import ProcessRegistry
+
+    killed = []
+    monkeypatch.setattr("tools.process_registry._IS_WINDOWS", True)
+    monkeypatch.setattr(
+        "subprocess.run",
+        MagicMock(return_value=MagicMock(returncode=1)),
+    )
+    monkeypatch.setattr("os.kill", lambda pid, sig: killed.append(pid))
+    monkeypatch.setattr(
+        ProcessRegistry, "_pid_gone_within", MagicMock(return_value=False)
+    )
+
+    assert ProcessRegistry._terminate_host_pid(12345) is False
+    assert killed == [12345]  # fallback signal was attempted
+
+
+def test_terminate_host_pid_posix_confirmed_dead_returns_true(monkeypatch):
+    """POSIX: whole tree confirmed gone after terminate → True."""
+    from tools.process_registry import ProcessRegistry
+
+    class FakeProc:
+        pid = 12345
+
+        def children(self, recursive=True):
+            return []
+
+        def terminate(self):
+            pass
+
+    class _NoSuchProcess(Exception):
+        pass
+
+    _fake_psutil_module(
+        monkeypatch,
+        Process=MagicMock(return_value=FakeProc()),
+        NoSuchProcess=_NoSuchProcess,
+        AccessDenied=PermissionError,
+    )
+    monkeypatch.setattr("tools.process_registry._IS_WINDOWS", False)
+    monkeypatch.setattr(
+        ProcessRegistry, "_daemon_term_grace_seconds", lambda: 1.0
+    )
+    monkeypatch.setattr(ProcessRegistry, "_proc_alive", lambda _p: False)
+
+    assert ProcessRegistry._terminate_host_pid(12345) is True
+
+
+def test_terminate_host_pid_posix_survivor_returns_false(monkeypatch):
+    """POSIX: a surviving tree member → termination not confirmed → False."""
+    from tools.process_registry import ProcessRegistry
+
+    class FakeProc:
+        pid = 12345
+
+        def children(self, recursive=True):
+            return []
+
+        def terminate(self):
+            pass
+
+    class _NoSuchProcess(Exception):
+        pass
+
+    _fake_psutil_module(
+        monkeypatch,
+        Process=MagicMock(return_value=FakeProc()),
+        NoSuchProcess=_NoSuchProcess,
+        AccessDenied=PermissionError,
+    )
+    monkeypatch.setattr("tools.process_registry._IS_WINDOWS", False)
+    monkeypatch.setattr(
+        ProcessRegistry, "_daemon_term_grace_seconds", lambda: 0.0
+    )
+    monkeypatch.setattr(ProcessRegistry, "_proc_alive", lambda _p: True)
+
+    assert ProcessRegistry._terminate_host_pid(12345) is False
 
 
 def test_unverified_pid_preserves_recovery_metadata(tmp_path, monkeypatch):

--- a/tests/tools/test_browser_timeout_cleanup_policy.py
+++ b/tests/tools/test_browser_timeout_cleanup_policy.py
@@ -248,6 +248,40 @@ def test_cleanup_all_resets_timeout_policy_cache(monkeypatch):
     assert bt._terminate_daemon_resolved is False
 
 
+def test_cleanup_bare_task_always_drops_last_active_binding(monkeypatch):
+    """Cleaning a bare task drops its last-active binding unconditionally.
+
+    Existing hybrid-routing contract (tests/tools/test_browser_hybrid_routing.py)
+    requires ``cleanup_browser("default")`` to drop
+    ``_last_active_session_key["default"]`` even when a live session is still
+    recorded — a later click/snapshot must not resurrect a cleaned session.
+    """
+    bt._active_sessions["task"] = {"session_name": "primary"}
+    bt._active_sessions["task::local"] = {"session_name": "sidecar"}
+    bt._last_active_session_key["task"] = "task::local"
+    bt._recording_sessions.update({"task", "task::local"})
+
+    monkeypatch.setattr(bt, "_cleanup_single_browser_session", lambda _key: None)
+
+    bt.cleanup_browser("task")
+
+    assert "task" not in bt._last_active_session_key
+
+
+def test_cleanup_sidecar_keeps_live_primary_binding(monkeypatch):
+    """Cleaning a ``::local`` sidecar keeps the primary's live binding."""
+    bt._active_sessions["task"] = {"session_name": "primary"}
+    bt._active_sessions["task::local"] = {"session_name": "sidecar"}
+    bt._last_active_session_key["task"] = "task"
+    bt._recording_sessions.update({"task", "task::local"})
+
+    monkeypatch.setattr(bt, "_cleanup_single_browser_session", lambda _key: None)
+
+    bt.cleanup_browser("task::local")
+
+    assert bt._last_active_session_key["task"] == "task"
+
+
 def _timeout_result(tmp_path, monkeypatch, *, terminate: bool, cloud: bool = False):
     session_info = {
         "session_name": "timeout-session",

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -5109,7 +5109,16 @@ def cleanup_browser(task_id: Optional[str] = None) -> None:
     for session_key in session_keys:
         _cleanup_single_browser_session(session_key)
 
-    _prune_last_active_browser_binding(task_id)
+    # Drop stale last-active ownership.  Cleaning a bare task drops its
+    # binding; cleaning a sidecar drops the binding only if that sidecar was
+    # still the recorded owner.  This prevents a later click/snapshot from
+    # resurrecting a cleaned sidecar on about:blank while preserving a
+    # primary-session binding.
+    if _is_local_sidecar_key(task_id):
+        if _last_active_session_key.get(task_id[: -len(_LOCAL_SUFFIX)]) == task_id:
+            _last_active_session_key.pop(task_id[: -len(_LOCAL_SUFFIX)], None)
+    else:
+        _last_active_session_key.pop(task_id, None)
 
 
 def _cleanup_single_browser_session(task_id: str) -> None:

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -341,6 +341,46 @@ def _get_command_timeout() -> int:
     return result
 
 
+# Whether a local browser daemon should be torn down immediately when its CLI
+# command times out.  This is intentionally opt-in: current upstream already
+# has daemon-side idle expiry plus periodic orphan reaping, while some users
+# prefer to keep a live session after a single slow command.
+_cached_terminate_daemon: Optional[bool] = None
+_terminate_daemon_resolved = False
+
+
+def _should_terminate_daemon_on_timeout() -> bool:
+    """Return the config-gated immediate timeout teardown policy.
+
+    ``browser.terminate_daemon_on_timeout`` defaults to false.  Cache the
+    resolved boolean just like ``browser.command_timeout`` so the hot command
+    path does not reread config for every browser action.
+    """
+    global _cached_terminate_daemon, _terminate_daemon_resolved
+    if _terminate_daemon_resolved:
+        return bool(_cached_terminate_daemon)
+
+    result = False
+    try:
+        from hermes_cli.config import read_raw_config
+
+        cfg = read_raw_config()
+        result = is_truthy_value(
+            cfg_get(cfg, "browser", "terminate_daemon_on_timeout"),
+            default=False,
+        )
+    except Exception as exc:
+        logger.debug(
+            "Could not read terminate_daemon_on_timeout from config: %s", exc
+        )
+
+    # Publish the value before the resolved flag, matching command-timeout
+    # cache ordering so concurrent readers never observe a half-filled cache.
+    _cached_terminate_daemon = result
+    _terminate_daemon_resolved = True
+    return result
+
+
 def _safe_command_timeout() -> int:
     """Like ``_get_command_timeout`` but guaranteed non-None.
 
@@ -2765,6 +2805,59 @@ def _extract_screenshot_path_from_text(text: str) -> Optional[str]:
     return None
 
 
+def _cleanup_local_browser_after_timeout(task_id: str, command: str) -> None:
+    """Immediately tear down only browser runtimes whose ownership is proven.
+
+    Ambiguous PID ownership is recovery state, not garbage: keep both the
+    socket directory and in-memory session metadata so the normal lifecycle or
+    periodic orphan reaper can make a later decision with more evidence.
+    """
+    if _is_local_sidecar_key(task_id):
+        session_keys = [task_id]
+    else:
+        session_keys = [task_id]
+        sidecar_key = f"{task_id}{_LOCAL_SUFFIX}"
+        with _cleanup_lock:
+            if sidecar_key in _active_sessions:
+                session_keys.append(sidecar_key)
+
+    for session_key in session_keys:
+        with _cleanup_lock:
+            session_info = _active_sessions.get(session_key)
+        if not session_info:
+            continue
+
+        try:
+            cleaned = _teardown_local_browser_runtime(
+                session_info, require_verified_ownership=True
+            )
+        except Exception as exc:
+            logger.warning(
+                "browser '%s' timed out — preserving session %s after "
+                "teardown error: %s",
+                command,
+                session_key,
+                exc,
+            )
+            continue
+
+        if not cleaned:
+            logger.warning(
+                "browser '%s' timed out — ownership is ambiguous for %s; "
+                "preserving recovery metadata",
+                command,
+                session_key,
+            )
+            continue
+
+        try:
+            _stop_cdp_supervisor(session_key)
+        finally:
+            _drop_browser_session_state(session_key)
+
+    _prune_last_active_browser_binding(task_id)
+
+
 def _run_browser_command(
     task_id: str,
     command: str,
@@ -2988,6 +3081,27 @@ def _run_browser_command(
                 "success": False,
                 "error": _format_browser_timeout_error(command, timeout, stdout, stderr),
             }
+
+            # Preserve upstream's default timeout semantics unless the operator
+            # explicitly opts into immediate local teardown.  Build the timeout
+            # result first so cleanup failures (or socket removal) cannot erase
+            # captured stderr or mask the original diagnostic.
+            if (
+                _should_terminate_daemon_on_timeout()
+                and not session_info.get("cdp_url")
+            ):
+                try:
+                    _cleanup_local_browser_after_timeout(task_id, command)
+                except Exception as exc:
+                    # Defense in depth: the helper contains per-session errors,
+                    # but the timeout result must win even if a future cleanup
+                    # refactor introduces a new failure outside that boundary.
+                    logger.warning(
+                        "Error during browser timeout teardown for task %s: %s",
+                        task_id,
+                        exc,
+                    )
+
             # Fall through to fallback check below
         else:
             with open(stdout_path, "r", encoding="utf-8") as f:
@@ -4879,6 +4993,89 @@ def _cleanup_old_recordings(max_age_hours=72):
 # Cleanup and Management Functions
 # ============================================================================
 
+def _drop_browser_session_state(session_key: str) -> None:
+    """Forget one session after its runtime is known to be gone."""
+    with _cleanup_lock:
+        _recording_sessions.discard(session_key)
+        _active_sessions.pop(session_key, None)
+        _session_last_activity.pop(session_key, None)
+
+
+def _prune_last_active_browser_binding(session_key: str) -> None:
+    """Drop a last-active binding only when its concrete session is gone."""
+    task_id = _bare_task_id_for_session_key(session_key)
+    with _cleanup_lock:
+        recorded_key = _last_active_session_key.get(task_id)
+        if not recorded_key:
+            return
+        session_info = _active_sessions.get(recorded_key)
+        if session_info and _session_info_owned_by_task(
+            session_info, task_id, recorded_key
+        ):
+            return
+        _last_active_session_key.pop(task_id, None)
+
+
+def _teardown_local_browser_runtime(
+    session_info: Dict[str, Any], *, require_verified_ownership: bool = False
+) -> bool:
+    """Kill a local daemon and remove its socket directory.
+
+    Normal cleanup keeps its established best-effort semantics. Timeout cleanup
+    sets ``require_verified_ownership`` and becomes fail-closed: missing,
+    malformed, unverified, or unsuccessfully terminated PIDs leave the socket
+    directory untouched for recovery/reaping evidence.
+    """
+    session_name = session_info.get("session_name", "")
+    if not session_name:
+        return not require_verified_ownership
+
+    socket_dir = os.path.join(
+        _socket_safe_tmpdir(), f"agent-browser-{session_name}"
+    )
+    if not os.path.exists(socket_dir):
+        return not require_verified_ownership
+
+    pid_file = os.path.join(socket_dir, f"{session_name}.pid")
+    if not os.path.isfile(pid_file):
+        if require_verified_ownership:
+            return False
+        shutil.rmtree(socket_dir, ignore_errors=True)
+        return True
+
+    try:
+        daemon_pid = int(Path(pid_file).read_text(encoding="utf-8").strip())
+    except (ValueError, OSError):
+        if require_verified_ownership:
+            return False
+        shutil.rmtree(socket_dir, ignore_errors=True)
+        return True
+
+    if require_verified_ownership and not _verify_reapable_browser_daemon(
+        daemon_pid, socket_dir, session_name
+    ):
+        return False
+
+    try:
+        from tools.process_registry import ProcessRegistry
+        ProcessRegistry._terminate_host_pid(daemon_pid)
+        logger.debug("Killed daemon pid %s for %s", daemon_pid, session_name)
+    except (ProcessLookupError, PermissionError, OSError):
+        if require_verified_ownership:
+            return False
+        logger.debug(
+            "Could not kill daemon pid for %s (already dead or inaccessible)",
+            session_name,
+        )
+    except Exception:
+        if require_verified_ownership:
+            return False
+        raise
+
+    shutil.rmtree(socket_dir, ignore_errors=True)
+    return True
+
+
 def cleanup_browser(task_id: Optional[str] = None) -> None:
     """
     Clean up browser session(s) for a task.
@@ -4902,27 +5099,17 @@ def cleanup_browser(task_id: Optional[str] = None) -> None:
     # that includes the cloud/primary key + the local sidecar if one exists.
     if _is_local_sidecar_key(task_id):
         session_keys = [task_id]
-        bare_task_id = task_id[: -len(_LOCAL_SUFFIX)]
     else:
         session_keys = [task_id]
         sidecar_key = f"{task_id}{_LOCAL_SUFFIX}"
         with _cleanup_lock:
             if sidecar_key in _active_sessions:
                 session_keys.append(sidecar_key)
-        bare_task_id = task_id
 
     for session_key in session_keys:
         _cleanup_single_browser_session(session_key)
 
-    # Drop stale last-active ownership. Cleaning a bare task drops its binding;
-    # cleaning a sidecar drops the binding only if that sidecar was still the
-    # recorded owner. This prevents a later click/snapshot from resurrecting a
-    # cleaned sidecar on about:blank while preserving a primary-session binding.
-    if _is_local_sidecar_key(task_id):
-        if _last_active_session_key.get(bare_task_id) == task_id:
-            _last_active_session_key.pop(bare_task_id, None)
-    else:
-        _last_active_session_key.pop(bare_task_id, None)
+    _prune_last_active_browser_binding(task_id)
 
 
 def _cleanup_single_browser_session(task_id: str) -> None:
@@ -4976,10 +5163,8 @@ def _cleanup_single_browser_session(task_id: str) -> None:
             except Exception as e:
                 logger.warning("agent-browser close failed for task %s: %s", task_id, e)
 
-        # Now remove from tracking under lock
-        with _cleanup_lock:
-            _active_sessions.pop(task_id, None)
-            _session_last_activity.pop(task_id, None)
+        # The runtime is now on the normal cleanup path; forget its tracking.
+        _drop_browser_session_state(task_id)
 
         # Cloud mode: close the cloud browser session via provider API.
         # Local sidecars have bb_session_id=None so this no-ops for them.
@@ -4991,22 +5176,7 @@ def _cleanup_single_browser_session(task_id: str) -> None:
                 except Exception as e:
                     logger.warning("Could not close cloud browser session: %s", e)
 
-        # Kill the daemon process and clean up socket directory
-        session_name = session_info.get("session_name", "")
-        if session_name:
-            socket_dir = os.path.join(_socket_safe_tmpdir(), f"agent-browser-{session_name}")
-            if os.path.exists(socket_dir):
-                # agent-browser writes {session}.pid in the socket dir
-                pid_file = os.path.join(socket_dir, f"{session_name}.pid")
-                if os.path.isfile(pid_file):
-                    try:
-                        from tools.process_registry import ProcessRegistry
-                        daemon_pid = int(Path(pid_file).read_text(encoding="utf-8").strip())
-                        ProcessRegistry._terminate_host_pid(daemon_pid)
-                        logger.debug("Killed daemon pid %s for %s", daemon_pid, session_name)
-                    except (ProcessLookupError, ValueError, PermissionError, OSError):
-                        logger.debug("Could not kill daemon pid for %s (already dead or inaccessible)", session_name)
-                shutil.rmtree(socket_dir, ignore_errors=True)
+        _teardown_local_browser_runtime(session_info)
 
         logger.debug("Removed task %s from active sessions", task_id)
     else:
@@ -5034,6 +5204,7 @@ def cleanup_all_browsers() -> None:
     # Reset cached lookups so they are re-evaluated on next use.
     global _cached_agent_browser, _agent_browser_resolved
     global _cached_command_timeout, _command_timeout_resolved
+    global _cached_terminate_daemon, _terminate_daemon_resolved
     global _cached_chromium_installed
     global _cached_browser_engine, _browser_engine_resolved
     _cached_agent_browser = None
@@ -5043,6 +5214,8 @@ def cleanup_all_browsers() -> None:
     # reader never sees ``resolved=True`` with ``cache=None`` (#14331).
     _command_timeout_resolved = False
     _cached_command_timeout = None
+    _terminate_daemon_resolved = False
+    _cached_terminate_daemon = None
     _cached_chromium_installed = None
     global _chromium_autoinstall_attempted
     _chromium_autoinstall_attempted = False

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -352,20 +352,34 @@ _terminate_daemon_resolved = False
 def _should_terminate_daemon_on_timeout() -> bool:
     """Return the config-gated immediate timeout teardown policy.
 
-    ``browser.terminate_daemon_on_timeout`` defaults to false.  Cache the
-    resolved boolean just like ``browser.command_timeout`` so the hot command
-    path does not reread config for every browser action.
+    ``browser.terminate_daemon_on_timeout`` defaults to false.  Single-profile
+    calls cache the result for the process lifetime; multiplexed profile turns
+    resolve their context-local config on each call.
     """
     global _cached_terminate_daemon, _terminate_daemon_resolved
+
+    # The profile multiplexer scopes config with a ContextVar while sharing
+    # this module. Never reuse another profile's timeout-cleanup policy.
+    if get_hermes_home_override() is not None:
+        return _resolve_terminate_daemon_on_timeout()
+
     if _terminate_daemon_resolved:
         return bool(_cached_terminate_daemon)
 
-    result = False
+    # Publish the value before the resolved flag, matching command-timeout
+    # cache ordering so concurrent readers never observe a half-filled cache.
+    _cached_terminate_daemon = _resolve_terminate_daemon_on_timeout()
+    _terminate_daemon_resolved = True
+    return _cached_terminate_daemon
+
+
+def _resolve_terminate_daemon_on_timeout() -> bool:
+    """Read the browser timeout-teardown toggle from the active config scope."""
     try:
         from hermes_cli.config import read_raw_config
 
         cfg = read_raw_config()
-        result = is_truthy_value(
+        return is_truthy_value(
             cfg_get(cfg, "browser", "terminate_daemon_on_timeout"),
             default=False,
         )
@@ -373,12 +387,7 @@ def _should_terminate_daemon_on_timeout() -> bool:
         logger.debug(
             "Could not read terminate_daemon_on_timeout from config: %s", exc
         )
-
-    # Publish the value before the resolved flag, matching command-timeout
-    # cache ordering so concurrent readers never observe a half-filled cache.
-    _cached_terminate_daemon = result
-    _terminate_daemon_resolved = True
-    return result
+    return False
 
 
 def _safe_command_timeout() -> int:
@@ -2838,6 +2847,7 @@ def _cleanup_local_browser_after_timeout(task_id: str, command: str) -> None:
                 command,
                 session_key,
                 exc,
+                exc_info=True,
             )
             continue
 
@@ -3100,6 +3110,7 @@ def _run_browser_command(
                         "Error during browser timeout teardown for task %s: %s",
                         task_id,
                         exc,
+                        exc_info=True,
                     )
 
             # Fall through to fallback check below
@@ -5058,19 +5069,26 @@ def _teardown_local_browser_runtime(
 
     try:
         from tools.process_registry import ProcessRegistry
-        ProcessRegistry._terminate_host_pid(daemon_pid)
-        logger.debug("Killed daemon pid %s for %s", daemon_pid, session_name)
+        terminated = ProcessRegistry._terminate_host_pid(daemon_pid)
     except (ProcessLookupError, PermissionError, OSError):
-        if require_verified_ownership:
-            return False
-        logger.debug(
-            "Could not kill daemon pid for %s (already dead or inaccessible)",
-            session_name,
-        )
+        terminated = False
     except Exception:
         if require_verified_ownership:
             return False
         raise
+
+    # Verified ownership alone is not enough — the timeout contract also
+    # requires confirmed termination before recovery evidence is removed.
+    if require_verified_ownership and not terminated:
+        return False
+
+    if terminated:
+        logger.debug("Killed daemon pid %s for %s", daemon_pid, session_name)
+    else:
+        logger.debug(
+            "Could not kill daemon pid for %s (already dead or inaccessible)",
+            session_name,
+        )
 
     shutil.rmtree(socket_dir, ignore_errors=True)
     return True

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -827,8 +827,35 @@ class ProcessRegistry:
         except Exception:
             return 2.0
 
+    @staticmethod
+    def _pid_gone_within(pid: int, wait: float = 2.0) -> bool:
+        """Confirm a PID is no longer alive within a bounded window.
+
+        Termination primitives (``taskkill``, ``os.kill``) can return without
+        the process having actually died yet — or fail silently while the
+        process stays alive.  This is the positive confirmation used by the
+        timeout-cleanup contract: ``True`` only when the PID is confirmed gone
+        (or a zombie, which is already dead).  ``wait`` bounds the poll so a
+        stubborn process cannot block the caller; callers must treat ``False``
+        as "termination not confirmed" and preserve recovery evidence.
+        """
+        import psutil
+
+        deadline = time.monotonic() + wait
+        while time.monotonic() < deadline:
+            try:
+                proc = psutil.Process(pid)
+                if not proc.is_running() or proc.status() == psutil.STATUS_ZOMBIE:
+                    return True
+            except psutil.NoSuchProcess:
+                return True
+            except Exception:
+                pass  # unknown liveness — keep polling (fail closed at deadline)
+            time.sleep(0.05)
+        return False
+
     @classmethod
-    def _terminate_host_pid(cls, pid: int, expected_start: Optional[int] = None) -> None:
+    def _terminate_host_pid(cls, pid: int, expected_start: Optional[int] = None) -> bool:
         """Terminate a host-visible PID and its descendants.
 
         ``expected_start`` is the kernel start time captured when we spawned the
@@ -869,6 +896,13 @@ class ProcessRegistry:
         bare-``os.kill`` fallback covers OSError / PermissionError on
         POSIX and a missing ``taskkill.exe`` on Windows (effectively
         unreachable on real Windows installs, but cheap insurance).
+
+        Returns:
+            True when the PID is confirmed terminated (no longer alive within
+            a bounded window, or a zombie); False when termination was
+            attempted but could not be confirmed.  Callers gated on the
+            timeout-cleanup invariant must treat ``False`` as failure and
+            preserve recovery evidence rather than deleting it.
         """
         if expected_start is not None and not cls._host_pid_is_ours(pid, expected_start):
             # PID was recycled (start time changed) or is gone — never signal a
@@ -878,10 +912,10 @@ class ProcessRegistry:
                 "Refusing to terminate host pid %d: start-time mismatch — "
                 "PID was recycled onto an unrelated process.", pid,
             )
-            return
+            return False
         if _IS_WINDOWS:
             try:
-                subprocess.run(
+                result = subprocess.run(
                     ["taskkill", "/PID", str(pid), "/T", "/F"],
                     capture_output=True,
                     text=True, encoding='utf-8', errors='replace',
@@ -889,24 +923,30 @@ class ProcessRegistry:
                     creationflags=windows_hide_flags(),
                     stdin=subprocess.DEVNULL,
                 )
+                if result.returncode == 0:
+                    return cls._pid_gone_within(pid)
             except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
-                try:
-                    os.kill(pid, signal.SIGTERM)
-                except (OSError, ProcessLookupError, PermissionError):
-                    pass
-            return
+                pass
+            # taskkill failed or is unavailable — fall back to a direct signal,
+            # then confirm whether the PID actually went away.
+            try:
+                os.kill(pid, signal.SIGTERM)
+            except (OSError, ProcessLookupError, PermissionError):
+                pass
+            return cls._pid_gone_within(pid)
 
         import psutil
         try:
             parent = psutil.Process(pid)
         except psutil.NoSuchProcess:
-            return
+            # Already gone — confirmed.
+            return True
         except (OSError, PermissionError):
             try:
                 os.kill(pid, signal.SIGTERM)
             except (OSError, ProcessLookupError, PermissionError):
                 pass
-            return
+            return cls._pid_gone_within(pid)
 
         # Snapshot the whole tree (children before parent) and SIGTERM each.
         try:
@@ -927,33 +967,36 @@ class ProcessRegistry:
         # grace window — a daemon stalled in its signal handler would otherwise
         # leak indefinitely.
         grace = cls._daemon_term_grace_seconds()
-        if grace <= 0:
-            return
-        # Sleep out the grace window, then independently re-probe every target
-        # and SIGKILL any survivor.  We deliberately do NOT trust
-        # ``psutil.wait_procs``'s gone/alive partition here: it reaps via
-        # ``Process.wait()`` and can mis-partition when a target transitions
-        # through a zombie state or when reaping is racy across a parent/child
-        # tree, which left survivors un-killed.  A direct liveness re-probe is
-        # deterministic.
-        deadline = time.monotonic() + grace
-        while time.monotonic() < deadline:
-            if not any(cls._proc_alive(_p) for _p in targets):
-                break
-            time.sleep(0.05)
-        for proc in targets:
-            try:
-                if not cls._proc_alive(proc):
-                    continue
-                proc.kill()  # SIGKILL on POSIX
-                logger.info(
-                    "Escalated to SIGKILL for pid %d (ignored SIGTERM within "
-                    "%.1fs grace)", proc.pid, grace,
-                )
-            except psutil.NoSuchProcess:
-                pass
-            except (psutil.AccessDenied, OSError):
-                pass
+        if grace > 0:
+            # Sleep out the grace window, then independently re-probe every
+            # target and SIGKILL any survivor.  We deliberately do NOT trust
+            # ``psutil.wait_procs``'s gone/alive partition here: it reaps via
+            # ``Process.wait()`` and can mis-partition when a target
+            # transitions through a zombie state or when reaping is racy
+            # across a parent/child tree, which left survivors un-killed.
+            # A direct liveness re-probe is deterministic.
+            deadline = time.monotonic() + grace
+            while time.monotonic() < deadline:
+                if not any(cls._proc_alive(_p) for _p in targets):
+                    break
+                time.sleep(0.05)
+            for proc in targets:
+                try:
+                    if not cls._proc_alive(proc):
+                        continue
+                    proc.kill()  # SIGKILL on POSIX
+                    logger.info(
+                        "Escalated to SIGKILL for pid %d (ignored SIGTERM within "
+                        "%.1fs grace)", proc.pid, grace,
+                    )
+                except psutil.NoSuchProcess:
+                    pass
+                except (psutil.AccessDenied, OSError):
+                    pass
+
+        # Confirmation: destructive cleanup must only proceed when the whole
+        # tree is confirmed gone (verified identity + successful termination).
+        return not any(cls._proc_alive(_p) for _p in targets)
 
     # ----- Spawn -----
 


### PR DESCRIPTION
## Summary

Repairs Phase-2 `repair:browser-runtime` from #115 on top of refreshed `main` (`243352e7b8bddc9f33eba1b6506810f8dd88beaa`). The browser production seam is unchanged from the earlier reconstruction base (`tools/browser_tool.py` upstream blob remains `544a06d51277098472436ce4e049e293078b52f3`).

This is a bounded reconstruction of the fork's opt-in timeout cleanup policy on the current browser lifecycle, with the recovery invariant corrected after review.

## Upstream authority / prior art

- **Merged/current authority:** NousResearch/hermes-agent#86755 contains the periodic orphan reaper salvaged from #82145, including `_verify_reapable_browser_daemon()` and socket-entry-mtime based idle/recovery evidence. #115 preserves and reuses that merged substrate.
- **Closed/unmerged, superseded:** #68152 proposed immediate timeout daemon reap and was superseded by #68220.
- **Open/unmerged prior art:** #68220 covers the same timeout leak family; #50667 hardens normal cleanup PID identity; #64383 proposes broader ownership/PID-reuse recovery. These are evidence only and are not imported wholesale.
- **Residual still real:** current main still has no `browser.terminate_daemon_on_timeout` policy seam.

Pinned refs and the review correction are recorded in `docs/research/browser-runtime-issue-115.md`.

## Corrected invariant

> **verified ownership + successful termination → destructive cleanup; ambiguous ownership or failed termination → preserve recovery metadata.**

The first draft correctly refused to signal an unverified PID but incorrectly deleted the socket directory and session metadata afterward. That could erase the evidence #86755's recovery path needs while leaving the daemon alive. This revision fixes that.

### Timeout behavior

- `browser.terminate_daemon_on_timeout` remains opt-in and defaults to **false**.
- Disabled: preserve current-upstream timeout semantics; fail the CLI command and leave the browser lifecycle alone.
- Enabled, local runtime only: attempt immediate cleanup for the owned session and applicable `::local` sidecar.
- Missing PID, malformed PID, failed identity/session verification, or failed termination: **do not remove the socket directory, do not drop `_active_sessions` / `_recording_sessions` / `_session_last_activity`, and keep a still-valid last-active binding.** This leaves socket entries/mtimes and in-memory ownership available to later normal lifecycle/orphan recovery.
- Only after verified ownership and successful termination is the socket directory removed and session bookkeeping dropped.
- The CDP supervisor is stopped only for a runtime that passed destructive cleanup; an ambiguous/live runtime is left recoverable.
- Timeout stdout/stderr and the timeout result are captured before cleanup, so cleanup failures cannot mask the original diagnostic.
- Cloud/CDP timeout behavior is unchanged.

## `/ponytail`: remove the second ownership implementation

The timeout path no longer carries its own copy of PID parsing, tree-kill, socket deletion, state removal, and last-active cleanup.

Shared primitives now own those mechanics:

- `_teardown_local_browser_runtime(...)` — one PID/socket teardown implementation. Timeout supplies `require_verified_ownership=True`; normal cleanup retains its existing best-effort policy.
- `_drop_browser_session_state(...)` — one session bookkeeping removal primitive.
- `_prune_last_active_browser_binding(...)` — one ownership-aware binding cleanup primitive.

This keeps policy differences explicit while avoiding parallel security-sensitive sources of truth. It does **not** silently adopt the unmerged normal-cleanup policy from #50667/#64383.

## Regression coverage

`tests/tools/test_browser_timeout_cleanup_policy.py` now proves, among the existing timeout/sidecar/config cases:

- verified local ownership + successful termination cleans the runtime;
- termination failure preserves socket + session recovery metadata;
- unverified/reused PID is not killed and preserves recovery metadata;
- malformed PID preserves recovery metadata;
- missing PID preserves recovery metadata;
- sidecar ownership semantics remain intact;
- config false/default performs no immediate teardown;
- cloud/CDP is excluded;
- timeout diagnostics remain the observable failure;
- global cleanup invalidates the new policy cache.

The recovery-safe targeted suite, `py_compile`, and `git diff --check` passed before the temporary verification/reconstruction commits were removed. The final clean head (`97457847a7062db85901ad1d427651407e843bab`) has triggered fresh PR-wide CI/Docker checks.

## Clean merge-unit history

Final branch is exactly **2 commits ahead of current main, 0 behind**, with only 3 changed files:

1. `docs(research): refresh #115 browser-runtime preflight`
2. `fix(browser): preserve recovery metadata on ambiguous timeout ownership`

No temporary workflow, reconstruction script, or verification receipt remains in the final diff.

Closes #115
