### PR TITLE
feat(observability): add bounded residual runtime diagnostics

### DIFF
--- a/agent/monitoring/emitter.py
+++ b/agent/monitoring/emitter.py
@@ -14,9 +14,12 @@ Mechanism:
   * A daemon thread drains the queue and fans each batch out to subscribers
     (the OTLP metric/span/log streamers). Each subscriber is fail-isolated —
     a slow or raising subscriber never affects the hot path or its peers.
+  * A process-lifetime producer whose event predates its exporter may use
+    ``emit_buffered(event)``. That one event enters the same bounded queue even
+    before the first subscriber exists; it does not enable unrelated producers
+    or create a second queue/store.
 
-Nothing is persisted here. Monitoring is an egress path, not a local store;
-if no subscriber is attached, events simply age out of the ring buffer.
+Nothing is persisted here. Monitoring is an egress path, not a local store.
 """
 
 from __future__ import annotations
@@ -50,17 +53,11 @@ class MonitoringEmitter:
         self._subscribers: list = []
 
     # ── public API (hot path) ───────────────────────────────────────────────
-    def emit(self, event: Any) -> None:
-        """Enqueue an event. Never blocks, never raises.
-
-        ``event`` may be a dataclass with ``to_dict()`` or a plain dict.
-        """
-        if not self._enabled:
-            return
+    def _enqueue(self, event: Any) -> None:
+        """Put one event into the bounded queue. Never blocks, never raises."""
         try:
             payload = event.to_dict() if hasattr(event, "to_dict") else dict(event)
             payload.setdefault("ts_ns", time.time_ns())
-            self._ensure_started()
             try:
                 self._q.put_nowait(payload)
             except queue.Full:
@@ -72,8 +69,31 @@ class MonitoringEmitter:
                     self._q.put_nowait(payload)
                 except Exception:
                     self._dropped += 1
-        except Exception:  # the hot-path invariant: never propagate
+            if self._subscribers:
+                self._ensure_started()
+        except Exception:
             logger.debug("monitoring emit failed", exc_info=True)
+
+    def emit(self, event: Any) -> None:
+        """Enqueue an event when the monitoring plane is enabled.
+
+        ``event`` may be a dataclass with ``to_dict()`` or a plain dict.
+        Never blocks and never raises.
+        """
+        if not self._enabled:
+            return
+        self._enqueue(event)
+
+    def emit_buffered(self, event: Any) -> None:
+        """Enqueue one opt-in event even before a subscriber is attached.
+
+        This deliberately does *not* set ``_enabled``. It exists for an
+        already-opted-in producer whose observation lifetime begins before its
+        exporter/subscriber is constructed. Unrelated producers still see the
+        normal disabled ``emit()`` behavior. If no subscriber ever attaches,
+        only explicitly buffered events occupy the existing bounded queue.
+        """
+        self._enqueue(event)
 
     # ── lifecycle ───────────────────────────────────────────────────────────
     def _ensure_started(self) -> None:
@@ -90,6 +110,12 @@ class MonitoringEmitter:
 
     def _run(self) -> None:
         while not self._stop.is_set():
+            # A subscriber may detach after the dispatcher has started. Leave
+            # explicitly buffered events queued until another subscriber
+            # attaches rather than consuming them into an empty fan-out set.
+            if not self._subscribers:
+                self._stop.wait(0.1)
+                continue
             try:
                 first = self._q.get(timeout=0.5)
             except queue.Empty:
@@ -120,6 +146,13 @@ class MonitoringEmitter:
         if callback not in self._subscribers:
             self._subscribers.append(callback)
         self._enabled = True
+        # Never start dispatch from subscribe(). A residual event buffered
+        # before any subscriber may sit in the queue while the gateway attaches
+        # subscribers one at a time (span streamer first, diagnostic streamer
+        # second); an early dispatcher would dequeue it into a partial fan-out
+        # and lose it. The first ordinary emit() after the full subscriber set
+        # attaches starts dispatch and drains buffered events through the
+        # complete fan-out.
 
     def unsubscribe(self, callback) -> None:
         try:
@@ -131,8 +164,18 @@ class MonitoringEmitter:
 
     # ── introspection / shutdown (tests, CLI) ───────────────────────────────
     def flush(self, timeout: float = 2.0) -> None:
-        """Wait boundedly for queued and in-flight batches to finish dispatch."""
-        if timeout <= 0:
+        """Wait boundedly for queued and in-flight batches to finish dispatch.
+
+        With no subscriber there is no sink that can make queued explicitly
+        buffered events complete, so flushing is a no-op rather than a timeout
+        delay. Those events remain bounded in memory for a later subscriber.
+
+        The same holds before the dispatcher has started: a subscriber may be
+        attached while nothing can drain the queue (the startup snapshot was
+        never emitted), so waiting would only add an artificial shutdown delay.
+        Fail-open: no-op unless dispatch is actually running.
+        """
+        if timeout <= 0 or not self._subscribers or not self._started:
             return
 
         finished = threading.Event()
@@ -177,7 +220,8 @@ def get_emitter() -> MonitoringEmitter:
     with _EMITTER_LOCK:
         if _EMITTER is None:
             # Collection is opt-in. A plane exporter enables the singleton by
-            # attaching its first subscriber; until then producers are no-ops.
+            # attaching its first subscriber; until then ordinary producers
+            # are no-ops. Explicit pre-subscriber events use emit_buffered().
             _EMITTER = MonitoringEmitter(enabled=False)
     return _EMITTER
 

--- a/docs/observability/runtime-observability.md
+++ b/docs/observability/runtime-observability.md
@@ -1,0 +1,207 @@
+# Runtime observability
+
+Runtime observability is an **optional residual diagnostic extension** rebuilt
+from the historical fork capability after refreshing current upstream ownership.
+It does not restore the old telemetry stack wholesale.
+
+The important reconstruction result is that the five historical domains no
+longer all belong to one fork implementation:
+
+| Domain | Current authority | #114 action |
+| --- | --- | --- |
+| lifecycle | merged gateway monitoring + merged Relay shared metrics | reuse; do not duplicate |
+| tool | merged Relay shared metrics | reuse; do not duplicate |
+| stream | no equivalent bounded operator event | add residual diagnostic |
+| SQLite/session persistence | current runtime policy/logging, no equivalent bounded operator event | add residual diagnostic only; do not change retry policy |
+| delivery | current retry/fallback runtime, no equivalent bounded operator event | add residual diagnostic only |
+
+This split matters because `agent.monitoring` explicitly excludes run/model/tool
+trajectory capture; that plane belongs to Relay. Re-emitting session and tool
+trajectories through gateway monitoring would create a second owner rather than
+preserve the current architecture.
+
+## Enablement, lifetime, and sink
+
+The residual producer is off by default:
+
+```yaml
+monitoring:
+  runtime_observability:
+    enabled: true
+```
+
+**Lifetime contract:** once the Hermes process imports `hermes_cli`, the residual
+observation boundary is installed for the rest of that process lifetime. It is
+installed as a dormant logging handler: installation performs no configuration
+I/O, network I/O, disk I/O, or event emission. Exact matched runtime facts check
+`monitoring.runtime_observability.enabled` at emission time.
+
+This deliberately does **not** wait for `on_session_start`. Both the gateway
+(`hermes_cli.config`) and SessionDB (`hermes_cli.sqlite_runtime`) enter through
+the `hermes_cli` package before the residual runtime boundaries are constructed,
+so startup SQLite/reconnect, stream, and delivery facts are observable before
+the first session exists.
+
+That switch only enables the residual producer. Export remains controlled by
+the existing gateway monitoring configuration. For OTLP export, operators use
+the existing sink, for example:
+
+```yaml
+monitoring:
+  runtime_observability:
+    enabled: true
+  gateway_health_export:
+    enabled: true
+  export:
+    otlp:
+      enabled: true
+      endpoint: http://collector-host:4318/v1/traces
+      headers_env: {}
+```
+
+The producer can become active before the OTLP subscriber is attached during
+gateway startup. In that interval an already-opted-in residual fact uses the
+existing monitoring emitter's explicit `emit_buffered()` path. That one event is
+retained in the same bounded queue without turning on ordinary `emit()` calls
+from unrelated monitoring producers. The dispatcher does not start while the subscriber set is empty, and
+`subscribe()` never starts it either: a pre-buffered residual must survive the
+gateway's two-sink assembly (span streamer attaches first, diagnostic streamer
+second) rather than being dequeued into a partial fan-out and lost. The
+ordinary initial snapshot emitted after the full fan-out attaches starts
+dispatch, which drains the buffered residual through every subscriber. The
+queue keeps its existing 10,000-event bound and oldest-drop policy. There is no
+second queue, local telemetry database, or persistence layer. A flush is a
+no-op whenever nothing can drain the queue — no subscriber, or a subscriber
+attached before the dispatcher started — so it never adds an artificial
+shutdown delay.
+
+There is no built-in destination and no new local telemetry store. If runtime
+observability is disabled, its installed handler is dormant. If the queue is
+full or an exporter/collector fails, the observed Hermes operation keeps its
+normal result. Diagnostics are never a runtime dependency.
+
+## Stable event subset
+
+Only the **residual** domains add event names here. Events use the existing
+`GatewayDiagnosticEvent` envelope.
+
+| Domain | Stable residual facts |
+| --- | --- |
+| stream | `runtime.stream.failed` |
+| SQLite/session persistence | `runtime.sqlite.persistence_failed`, `runtime.sqlite.connection_recovered`, `runtime.sqlite.connection_recovery_failed` |
+| delivery | `runtime.delivery.retry_succeeded`, `runtime.delivery.retries_exhausted`, `runtime.delivery.fallback_failed` |
+
+For `runtime.sqlite.persistence_failed`, the optional `error_code` is restricted
+to the current coarse persistence vocabulary:
+
+`locked`, `compression`, `compression_closed`, `turn_lease`, `corrupt`, `disk`,
+or `unknown`.
+
+Those values reuse the runtime's existing `classify_persistence_error()`
+semantics. The set is frozen in this feature: a future upstream classifier
+bucket maps to `unknown` until the telemetry contract is deliberately reviewed.
+
+The omission of high-volume success events is intentional. This extension is
+not an execution trace. Stream success, every SQLite write, each retry attempt,
+and every ordinary delivery are implementation noise for this contract.
+
+Lifecycle and tool remain deliberately absent from this residual event list:
+current upstream already owns those signals. Residual diagnostics no longer
+consume any lifecycle hook merely to bootstrap themselves.
+
+## Why a static-log adapter is acceptable here
+
+Stream, persistence, and delivery do not currently expose a stable lifecycle
+hook at the exact residual failure/terminal boundaries. Adding new hooks to
+three large hot paths solely for #114 would create a wider behavioral surface.
+
+Instead, the residual adapter recognizes only exact, code-owned **static log
+templates** that already represent those domain facts, then projects the fixed
+fact name. It matches `LogRecord.msg`, never fuzzy-matches rendered text, and
+never calls `LogRecord.getMessage()`.
+
+For stream and delivery it does not inspect interpolation arguments at all. For
+the one SQLite persistence-failure template, it passes only the exception
+object to the existing bounded persistence classifier and exports only the
+closed cause bucket above; the stage, exception text, and other arguments are
+never exported.
+
+This is deliberately fail-closed but carries a maintenance cost: an upstream
+wording-only change to one mapped log template will silently remove that
+structured fact until the explicit table is refreshed. The table is therefore
+a reviewed compatibility surface, not a fuzzy parser. This trade-off is kept
+narrow here rather than pretending the current runtime already exposes stable
+structured hooks at those three boundaries.
+
+## Redaction / privacy contract
+
+Residual runtime events may contain only the existing diagnostic envelope plus
+the closed event name, subsystem, fixed error class, optional bounded SQLite
+error code, and fixed severity. They must not contain:
+
+- prompts, responses, streamed text, message content, or previews;
+- tool names, tool arguments, tool results, or raw tool/provider errors;
+- session, chat, message, turn, task, request, span, or tool-call identifiers;
+- filesystem paths;
+- provider raw responses;
+- arbitrary exception class names or exception strings.
+
+Values substituted into stream/delivery log `%s` / `%d` placeholders remain on
+the local runtime log path and never enter the structured event. SQLite failure
+text is used only inside the already-existing coarse classifier; only its
+allowlisted bucket can cross the event boundary. Tests include sensitive paths,
+provider text, platform identifiers, and objects that raise from `__str__` on
+stream/delivery paths to pin this boundary.
+
+The existing OTLP monitoring exporter applies its own fixed allowlist/redaction
+policy again at the sink boundary. Producer-side tests remain mandatory so
+privacy does not depend on one downstream filter.
+
+## Failure isolation
+
+There are four fail-open boundaries:
+
+1. `hermes_cli` process bootstrap catches installation/import failures;
+2. the dormant log handler catches normalization/producer failures;
+3. the monitoring emitter remains non-blocking and bounded, including the explicit pre-subscriber residual path;
+4. monitoring subscribers/exporters remain fail-isolated from the runtime.
+
+Telemetry must never change a tool outcome, session result, stream/delivery
+result, SQLite retry policy, startup result, or exception propagation that the
+runtime already owns.
+
+## Explicit non-goals
+
+This feature does **not** restore the historical fork telemetry implementation
+wholesale. In particular it does not add:
+
+- `/proc`, cgroup, disk, kernel, RSS/PSS, or resource-probe telemetry;
+- SQLite progress-handler/native-owner instrumentation or per-write counters;
+- per-token/per-delta stream telemetry;
+- raw lifecycle correlation IDs;
+- a local telemetry SQLite store;
+- another OpenTelemetry shim/exporter;
+- duplicate lifecycle/tool trajectories already owned upstream;
+- compression no-op/session-boundary behavior;
+- SQLite write-contention retry/backoff behavior.
+
+Compression boundary semantics and SQLite contention policy remain owned by
+their separate feature lines. Runtime observability may report residual facts
+from persistence but cannot gate or alter those policies.
+
+## Prior-art disposition used for this reconstruction
+
+The implementation is reconstructed against current upstream behavior rather
+than replaying historical code:
+
+- **merged/current sink authority:** gateway monitoring / OTLP diagnostics;
+- **merged/current lifecycle and tool authority:** Relay shared metrics,
+  including bounded tool aggregation;
+- **merged after revert/rework:** the current Relay landing is the restored
+  implementation, not its reverted first landing;
+- **closed/unmerged evidence only:** monolithic OpenTelemetry and local-SQLite
+  telemetry proposals;
+- **open/unmerged evidence only:** local timeline/delivery proposals;
+- **historical fork evidence only:** the old telemetry commit identifies useful
+  diagnostic domains, but its resource probes, raw identifiers, SQLite native
+  instrumentation, and unrelated compression behavior are not restored.

--- a/hermes_cli/__init__.py
+++ b/hermes_cli/__init__.py
@@ -90,3 +90,25 @@ def _ensure_utf8():
 
 
 _ensure_utf8()
+
+
+def _install_runtime_observability_boundary() -> None:
+    """Install dormant process-lifetime residual diagnostics, fail-open.
+
+    ``hermes_cli`` is imported before the runtime components that #114
+    observes: the gateway imports ``hermes_cli.config`` during module startup,
+    and ``hermes_state`` imports ``hermes_cli.sqlite_runtime`` before SessionDB
+    construction. Installing the dormant handler here therefore closes the
+    pre-first-session startup gap without making observability a runtime
+    dependency or forcing configuration I/O at package import time.
+    """
+    try:
+        from .observability.runtime_observability import install
+
+        install()
+    except Exception:
+        # Import/bootstrap diagnostics can never decide whether Hermes starts.
+        pass
+
+
+_install_runtime_observability_boundary()

--- a/hermes_cli/observability/runtime_observability.py
+++ b/hermes_cli/observability/runtime_observability.py
@@ -1,0 +1,263 @@
+"""Residual runtime diagnostics on top of current upstream observability.
+
+Current upstream already owns two parts of the historical fork capability:
+
+* lifecycle/service-health signals live in ``agent.monitoring`` and bounded
+  task lifecycle metrics live in Relay shared metrics;
+* bounded tool outcome/latency/retry metrics live in Relay shared metrics.
+
+This module therefore does *not* create a second lifecycle/tool trajectory.
+It fills only the residual operator-diagnostic gap for stream, SQLite/session
+persistence, and delivery failures by projecting a tiny content-free fact set
+onto the existing ``agent.monitoring`` diagnostic sink.
+
+The process-lifetime log adapter is installed when ``hermes_cli`` is imported,
+not on the first session. Installation itself is dormant and does not read
+configuration or emit anything. Exact matched facts consult the opt-in config;
+when enabled they use the monitoring emitter's explicit pre-subscriber event
+path so startup diagnostics survive until the exporter attaches without
+turning on unrelated monitoring producers.
+
+The contract is intentionally closed: no prompts/messages/streamed text, tool
+arguments/results, raw errors, IDs, filesystem paths, provider responses,
+per-token stream events, or SQLite implementation counters.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+
+logger = logging.getLogger(__name__)
+
+# Public stable residual event contract. These are diagnosable domain facts,
+# not an inventory of implementation branches.
+STABLE_FACTS: dict[str, frozenset[str]] = {
+    "stream": frozenset({"failed"}),
+    "sqlite": frozenset({
+        "persistence_failed",
+        "connection_recovered",
+        "connection_recovery_failed",
+    }),
+    "delivery": frozenset({
+        "retry_succeeded",
+        "retries_exhausted",
+        "fallback_failed",
+    }),
+}
+
+# Freeze the current public persistence buckets into this telemetry contract.
+# If upstream adds a new classifier result it degrades to "unknown" until this
+# contract is deliberately reviewed; observability must not widen silently.
+_SQLITE_ERROR_CODES = frozenset({
+    "locked",
+    "compression",
+    "compression_closed",
+    "turn_lease",
+    "corrupt",
+    "disk",
+    "unknown",
+})
+
+# Fixed error classes only. Never use exception class names or exception text
+# here: those can contain provider strings, paths, or user-controlled content.
+_ERROR_CLASS = {
+    ("stream", "failed"): "stream_failure",
+    ("sqlite", "persistence_failed"): "persistence_failure",
+    ("sqlite", "connection_recovered"): "none",
+    ("sqlite", "connection_recovery_failed"): "connection_recovery_failure",
+    ("delivery", "retry_succeeded"): "none",
+    ("delivery", "retries_exhausted"): "delivery_failure",
+    ("delivery", "fallback_failed"): "delivery_failure",
+}
+
+_SEVERITY = {
+    ("stream", "failed"): "error",
+    ("sqlite", "persistence_failed"): "error",
+    ("sqlite", "connection_recovered"): "info",
+    ("sqlite", "connection_recovery_failed"): "error",
+    ("delivery", "retry_succeeded"): "info",
+    ("delivery", "retries_exhausted"): "error",
+    ("delivery", "fallback_failed"): "error",
+}
+
+
+def enabled() -> bool:
+    """Return whether the optional residual runtime diagnostics are enabled."""
+    try:
+        from hermes_cli.config import read_raw_config_readonly
+
+        config = read_raw_config_readonly()
+        monitoring = config.get("monitoring") if isinstance(config, dict) else None
+        runtime = (
+            monitoring.get("runtime_observability")
+            if isinstance(monitoring, dict)
+            else None
+        )
+        return bool(runtime.get("enabled", False)) if isinstance(runtime, dict) else False
+    except Exception:
+        # Configuration/telemetry failures can never change runtime behavior.
+        return False
+
+
+def _emit_fact(
+    subsystem: str,
+    fact: str,
+    *,
+    error_code: str | None = None,
+) -> None:
+    """Emit one validated, content-free residual runtime fact. Never raises."""
+    try:
+        if fact not in STABLE_FACTS.get(subsystem, frozenset()):
+            return
+        if error_code is not None:
+            if subsystem != "sqlite" or error_code not in _SQLITE_ERROR_CODES:
+                error_code = "unknown" if subsystem == "sqlite" else None
+
+        from agent.monitoring.emitter import get_emitter
+        from agent.monitoring.events import GatewayDiagnosticEvent
+
+        event = GatewayDiagnosticEvent(
+            name=f"runtime.{subsystem}.{fact}",
+            subsystem=subsystem,
+            error_class=_ERROR_CLASS[(subsystem, fact)],
+            error_code=error_code,
+            severity=_SEVERITY[(subsystem, fact)],
+        )
+        # The producer is process-lifetime, while the exporter subscribes later
+        # during gateway startup. Queue THIS already-opted-in residual event in
+        # the existing bounded emitter even before that subscriber exists.
+        # Unlike ordinary emit(), this does not enable unrelated producers.
+        get_emitter().emit_buffered(event)
+    except Exception:
+        # The observed operation always wins over observability.
+        logger.debug("runtime observability emit failed", exc_info=True)
+
+
+def _classify_persistence_record(record: logging.LogRecord) -> str:
+    """Return one frozen coarse persistence bucket without exporting the error."""
+    try:
+        args = record.args
+        if not isinstance(args, tuple) or len(args) < 2:
+            return "unknown"
+        from hermes_state import classify_persistence_error
+
+        cause = classify_persistence_error(args[1])
+        return cause if cause in _SQLITE_ERROR_CODES else "unknown"
+    except Exception:
+        return "unknown"
+
+
+# These residual domains currently expose stable, code-owned terminal/failure
+# log templates rather than lifecycle hooks. Normalize only the STATIC
+# template in LogRecord.msg. Stream/delivery never inspect interpolation args.
+# The one SQLite persistence mapping passes only its exception object through
+# the existing bounded classifier and exports only the frozen cause bucket.
+#
+# Maintenance warning: these templates are intentionally fail-closed. Wording
+# drift drops a structured fact rather than widening the schema by fuzzy
+# parsing. When an upstream log template changes, this explicit table must be
+# reviewed and updated with the emitting runtime boundary.
+_LOG_FACTS: dict[tuple[str, str], tuple[str, str]] = {
+    (
+        "gateway.stream_consumer",
+        "Stream consumer error: %s",
+    ): ("stream", "failed"),
+    (
+        "agent.tool_executor",
+        "Incremental tool-call persistence failed after %s: %s",
+    ): ("sqlite", "persistence_failed"),
+    (
+        "hermes_state",
+        "state.db connection reopened successfully; retrying the failed write.",
+    ): ("sqlite", "connection_recovered"),
+    (
+        "hermes_state",
+        "state.db reconnect after 'file is not a database' failed (%s); the database may need the full offline repair path.",
+    ): ("sqlite", "connection_recovery_failed"),
+    (
+        "gateway.platforms.base",
+        "[%s] Send succeeded on retry %d",
+    ): ("delivery", "retry_succeeded"),
+    (
+        "gateway.platforms.base",
+        "[%s] Failed to deliver response after %d retries: %s",
+    ): ("delivery", "retries_exhausted"),
+    (
+        "gateway.platforms.base",
+        "[%s] Fallback send also failed: %s",
+    ): ("delivery", "fallback_failed"),
+}
+_PERSISTENCE_LOG_KEY = (
+    "agent.tool_executor",
+    "Incremental tool-call persistence failed after %s: %s",
+)
+_LOGGER_NAMES = frozenset(name for name, _template in _LOG_FACTS)
+_LOG_HANDLER_MARKER = "_hermes_runtime_observability_handler"
+_log_observer_lock = threading.Lock()
+
+
+class _RuntimeDiagnosticLogHandler(logging.Handler):
+    """Normalize selected static runtime log templates into bounded facts."""
+
+    def emit(self, record: logging.LogRecord) -> None:  # noqa: D401 - logging API
+        try:
+            if not isinstance(record.msg, str):
+                return
+            key = (record.name, record.msg)
+            mapped = _LOG_FACTS.get(key)
+            if mapped is None:
+                return
+            # Installation is process-lifetime and intentionally dormant when
+            # disabled. Check enablement only after an exact template match so
+            # unrelated logs pay no config-read cost.
+            if not enabled():
+                return
+            if key == _PERSISTENCE_LOG_KEY:
+                _emit_fact(*mapped, error_code=_classify_persistence_record(record))
+            else:
+                _emit_fact(*mapped)
+        except Exception:
+            # logging.Handler.handle() does not protect callers from arbitrary
+            # handler exceptions; fail-open explicitly at this boundary.
+            return
+
+
+def install() -> None:
+    """Attach the dormant residual log normalizer for the process lifetime.
+
+    Called from ``hermes_cli.__init__`` so the boundary exists before SessionDB,
+    stream, or delivery runtime construction. This function deliberately does
+    not consult configuration: disabled installs are inert, and exact matched
+    records perform the opt-in check at emit time.
+    """
+    with _log_observer_lock:
+        for name in _LOGGER_NAMES:
+            target = logging.getLogger(name)
+            if any(getattr(h, _LOG_HANDLER_MARKER, False) for h in target.handlers):
+                continue
+            handler = _RuntimeDiagnosticLogHandler()
+            setattr(handler, _LOG_HANDLER_MARKER, True)
+            target.addHandler(handler)
+
+
+def reset_for_tests() -> None:
+    """Remove installed handlers. Test-only helper."""
+    with _log_observer_lock:
+        for name in _LOGGER_NAMES:
+            target = logging.getLogger(name)
+            for handler in list(target.handlers):
+                if getattr(handler, _LOG_HANDLER_MARKER, False):
+                    target.removeHandler(handler)
+                    try:
+                        handler.close()
+                    except Exception:
+                        pass
+
+
+__all__ = [
+    "STABLE_FACTS",
+    "enabled",
+    "install",
+    "reset_for_tests",
+]

--- a/tests/hermes_cli/test_runtime_observability.py
+++ b/tests/hermes_cli/test_runtime_observability.py
@@ -1,0 +1,467 @@
+from __future__ import annotations
+
+import ast
+import importlib
+import json
+import logging
+from pathlib import Path
+
+import pytest
+
+from hermes_cli.observability import runtime_observability as runtime_obs
+
+
+@pytest.fixture(autouse=True)
+def _clean_runtime_observability():
+    from agent.monitoring.emitter import reset_emitter_for_tests
+
+    runtime_obs.reset_for_tests()
+    reset_emitter_for_tests()
+    yield
+    runtime_obs.reset_for_tests()
+    reset_emitter_for_tests()
+
+
+def _capture_events(monkeypatch):
+    captured = []
+    monkeypatch.setattr(runtime_obs, "enabled", lambda: True)
+
+    import agent.monitoring.emitter as emitter_module
+
+    class _CaptureEmitter:
+        def emit_buffered(self, event):
+            captured.append(event)
+
+    monkeypatch.setattr(emitter_module, "get_emitter", lambda: _CaptureEmitter())
+    return captured
+
+
+def _event_dicts(events):
+    return [event.to_dict() for event in events]
+
+
+def _literal_log_templates(path: Path) -> set[str]:
+    """Return literal first arguments of logger calls in one source file."""
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    templates: set[str] = set()
+    log_methods = {"debug", "info", "warning", "error", "critical", "exception"}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not node.args:
+            continue
+        if not isinstance(node.func, ast.Attribute) or node.func.attr not in log_methods:
+            continue
+        try:
+            value = ast.literal_eval(node.args[0])
+        except (ValueError, TypeError):
+            continue
+        if isinstance(value, str):
+            templates.add(value)
+    return templates
+
+
+def test_stable_facts_cover_residual_domains_only():
+    assert set(runtime_obs.STABLE_FACTS) == {"stream", "sqlite", "delivery"}
+    assert all(runtime_obs.STABLE_FACTS.values())
+
+
+def test_upstream_relay_remains_the_tool_lifecycle_owner():
+    from hermes_cli.observability import relay_shared_metrics
+
+    assert "on_session_start" in relay_shared_metrics.HANDLED_HOOKS
+    assert "post_tool_call" in relay_shared_metrics.HANDLED_HOOKS
+    assert not hasattr(runtime_obs, "HANDLED_HOOKS")
+
+
+def test_mapped_static_templates_are_anchored_to_current_emit_sites():
+    """Turn exact-log wording drift into a reviewable CI failure.
+
+    Runtime matching stays fail-closed: it never fuzzy-parses rendered logs.
+    This test makes the maintenance liability explicit by proving every mapped
+    literal still exists at the code-owned logger call that defines the fact.
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    source_for_logger = {
+        "gateway.stream_consumer": repo_root / "gateway" / "stream_consumer.py",
+        "agent.tool_executor": repo_root / "agent" / "tool_executor.py",
+        "hermes_state": repo_root / "hermes_state.py",
+        "gateway.platforms.base": repo_root / "gateway" / "platforms" / "base.py",
+    }
+    templates_by_logger = {
+        logger_name: _literal_log_templates(path)
+        for logger_name, path in source_for_logger.items()
+    }
+
+    for (logger_name, template), _fact in runtime_obs._LOG_FACTS.items():
+        assert template in templates_by_logger[logger_name], (
+            f"runtime observability mapping drifted from {source_for_logger[logger_name]}: "
+            f"{template!r}"
+        )
+
+
+def test_hermes_cli_import_installs_process_lifetime_boundary(monkeypatch):
+    import hermes_cli
+
+    runtime_obs.reset_for_tests()
+
+    # Installation must not depend on feature enablement or config I/O. The
+    # handler exists for the process lifetime and remains dormant when disabled.
+    monkeypatch.setattr(
+        runtime_obs,
+        "enabled",
+        lambda: (_ for _ in ()).throw(AssertionError("install must not read config")),
+    )
+    importlib.reload(hermes_cli)
+
+    for name in runtime_obs._LOGGER_NAMES:
+        assert any(
+            getattr(handler, runtime_obs._LOG_HANDLER_MARKER, False)
+            for handler in logging.getLogger(name).handlers
+        )
+
+
+def test_disabled_process_lifetime_observer_is_dormant(monkeypatch):
+    runtime_obs.install()
+    monkeypatch.setattr(runtime_obs, "enabled", lambda: False)
+
+    logging.getLogger("gateway.stream_consumer").handle(logging.LogRecord(
+        "gateway.stream_consumer",
+        logging.ERROR,
+        __file__,
+        1,
+        "Stream consumer error: %s",
+        ("secret streamed text",),
+        None,
+    ))
+
+    from agent.monitoring.emitter import get_emitter
+
+    assert get_emitter().stats()["queued"] == 0
+    # Disabled means dormant, not absent: the observation boundary is already
+    # installed and can become active without waiting for a session hook.
+    for name in runtime_obs._LOGGER_NAMES:
+        assert any(
+            getattr(handler, runtime_obs._LOG_HANDLER_MARKER, False)
+            for handler in logging.getLogger(name).handlers
+        )
+
+
+def test_startup_fact_survives_multi_sink_subscribe_order(monkeypatch):
+    """Regression for #114 review: no bootstrap lifetime hole across sinks.
+
+    Gateway startup attaches the span streamer (filter: gateway_health /
+    cron_execution) before the diagnostic-log streamer. A residual diagnostic
+    buffered before either subscriber must survive that gap and reach the
+    diagnostic sink after the full fan-out attaches — subscribe() must not
+    start dispatch into a partial subscriber set.
+    """
+    from agent.monitoring.emitter import MonitoringEmitter, reset_emitter_for_tests
+
+    emitter = MonitoringEmitter(enabled=False)
+    reset_emitter_for_tests(emitter)
+    monkeypatch.setattr(runtime_obs, "enabled", lambda: True)
+    runtime_obs.install()
+
+    # Model a startup SQLite reconnect failure before gateway OTLP setup has
+    # attached any subscriber. Use the installed logger path, not the handler
+    # directly, so this exercises the process-lifetime bootstrap contract.
+    logging.getLogger("hermes_state").handle(logging.LogRecord(
+        "hermes_state",
+        logging.ERROR,
+        __file__,
+        1,
+        "state.db reconnect after 'file is not a database' failed (%s); the database may need the full offline repair path.",
+        ("private /home/user/state.db detail",),
+        None,
+    ))
+
+    assert emitter.stats() == {
+        "queued": 1,
+        "dispatched": 0,
+        "dropped": 0,
+        "subscribers": 0,
+    }
+
+    span_received: list[dict] = []
+    diag_received: list[dict] = []
+
+    def _span_subscriber(batch):
+        # Mirrors otlp_exporter.start_streaming(event_filter=_gateway_health_event).
+        for ev in batch:
+            if ev.get("event") in {"gateway_health", "cron_execution"}:
+                span_received.append(ev)
+
+    def _diag_subscriber(batch):
+        # Mirrors GatewayDiagnosticLogStreamer.__call__.
+        for ev in batch:
+            if ev.get("event") == "gateway_diagnostic":
+                diag_received.append(ev)
+
+    # Span streamer attaches first with a non-empty queue. subscribe() must not
+    # start dispatch here — the residual must survive until the full fan-out.
+    emitter.subscribe(_span_subscriber)
+    assert emitter._started is False
+    assert emitter.stats()["queued"] == 1
+
+    # Diagnostic streamer attaches; the full fan-out is now in place.
+    emitter.subscribe(_diag_subscriber)
+
+    # The ordinary initial snapshot emitted after both subscribers attach
+    # starts dispatch and drains the buffered residual through both sinks.
+    emitter.emit({"event": "gateway_health", "name": "gateway.health_snapshot"})
+    emitter.flush(timeout=1.0)
+
+    assert [ev["name"] for ev in diag_received] == [
+        "runtime.sqlite.connection_recovery_failed"
+    ]
+    assert [ev["name"] for ev in span_received] == ["gateway.health_snapshot"]
+    # Sensitive startup detail never crosses the event boundary.
+    assert "private /home/user/state.db detail" not in json.dumps(diag_received)
+    assert emitter.stats()["queued"] == 0
+    assert emitter.stats()["dispatched"] == 2
+    emitter.close()
+
+
+def test_pre_subscriber_buffer_does_not_enable_unrelated_producers():
+    from agent.monitoring.emitter import MonitoringEmitter
+
+    emitter = MonitoringEmitter(enabled=False)
+    try:
+        # Normal monitoring semantics stay untouched while no exporter exists.
+        emitter.emit({"event": "gateway_diagnostic", "name": "ordinary"})
+        assert emitter.stats()["queued"] == 0
+
+        # Only an explicitly buffered, already-opted-in producer can cross the
+        # pre-subscriber lifetime boundary.
+        emitter.emit_buffered({"event": "gateway_diagnostic", "name": "early"})
+        assert emitter.stats()["queued"] == 1
+        assert emitter.stats()["dispatched"] == 0
+        assert emitter._started is False
+
+        # Another ordinary producer is still disabled; emit_buffered did not
+        # mutate global plane enablement.
+        emitter.emit({"event": "gateway_diagnostic", "name": "ordinary-2"})
+        assert emitter.stats()["queued"] == 1
+
+        delivered = []
+        emitter.subscribe(delivered.extend)
+        # subscribe() must not start dispatch on buffered events; the first
+        # ordinary emit after the full subscriber set attaches does (mirrors
+        # the gateway snapshot emit after both streamers attach).
+        assert emitter._started is False
+        emitter.emit({"event": "gateway_health", "name": "snapshot"})
+        emitter.flush(timeout=1.0)
+
+        assert [item["name"] for item in delivered] == ["early", "snapshot"]
+        assert "ordinary-2" not in [item["name"] for item in delivered]
+        assert emitter.stats()["queued"] == 0
+        assert emitter.stats()["dispatched"] == 2
+    finally:
+        emitter.close()
+
+
+def test_static_log_normalizer_covers_stream_sqlite_and_delivery(monkeypatch):
+    captured = _capture_events(monkeypatch)
+    handler = runtime_obs._RuntimeDiagnosticLogHandler()
+
+    records = [
+        logging.LogRecord(
+            "gateway.stream_consumer",
+            logging.ERROR,
+            __file__,
+            1,
+            "Stream consumer error: %s",
+            ("secret streamed text",),
+            None,
+        ),
+        logging.LogRecord(
+            "agent.tool_executor",
+            logging.WARNING,
+            __file__,
+            1,
+            "Incremental tool-call persistence failed after %s: %s",
+            ("secret-stage", "database is locked at /secret/state.db"),
+            None,
+        ),
+        logging.LogRecord(
+            "gateway.platforms.base",
+            logging.ERROR,
+            __file__,
+            1,
+            "[%s] Failed to deliver response after %d retries: %s",
+            ("telegram-secret-chat", 2, "secret provider response"),
+            None,
+        ),
+    ]
+    for record in records:
+        handler.emit(record)
+
+    assert [event.name for event in captured] == [
+        "runtime.stream.failed",
+        "runtime.sqlite.persistence_failed",
+        "runtime.delivery.retries_exhausted",
+    ]
+    assert captured[1].error_code == "locked"
+    payload = json.dumps(_event_dicts(captured), sort_keys=True)
+    for secret in (
+        "secret streamed text",
+        "secret-stage",
+        "/secret/state.db",
+        "telegram-secret-chat",
+        "secret provider response",
+    ):
+        assert secret not in payload
+
+
+def test_persistence_classifier_is_closed_to_frozen_codes(monkeypatch):
+    captured = _capture_events(monkeypatch)
+    monkeypatch.setattr(
+        runtime_obs,
+        "_classify_persistence_record",
+        lambda _record: "future_unreviewed_bucket",
+    )
+    handler = runtime_obs._RuntimeDiagnosticLogHandler()
+
+    handler.emit(logging.LogRecord(
+        "agent.tool_executor",
+        logging.WARNING,
+        __file__,
+        1,
+        "Incremental tool-call persistence failed after %s: %s",
+        ("stage", RuntimeError("private")),
+        None,
+    ))
+
+    assert len(captured) == 1
+    assert captured[0].error_code == "unknown"
+
+
+def test_recovery_and_retry_success_are_bounded_facts(monkeypatch):
+    captured = _capture_events(monkeypatch)
+    handler = runtime_obs._RuntimeDiagnosticLogHandler()
+
+    handler.emit(logging.LogRecord(
+        "hermes_state",
+        logging.WARNING,
+        __file__,
+        1,
+        "state.db connection reopened successfully; retrying the failed write.",
+        (),
+        None,
+    ))
+    handler.emit(logging.LogRecord(
+        "gateway.platforms.base",
+        logging.INFO,
+        __file__,
+        1,
+        "[%s] Send succeeded on retry %d",
+        ("private-platform-instance", 1),
+        None,
+    ))
+
+    assert [event.name for event in captured] == [
+        "runtime.sqlite.connection_recovered",
+        "runtime.delivery.retry_succeeded",
+    ]
+    payload = json.dumps(_event_dicts(captured), sort_keys=True)
+    assert "private-platform-instance" not in payload
+
+
+def test_static_log_normalizer_ignores_interpolated_or_unknown_messages(monkeypatch):
+    captured = _capture_events(monkeypatch)
+    handler = runtime_obs._RuntimeDiagnosticLogHandler()
+
+    # Same human-readable idea, but not the exact code-owned template. The
+    # adapter must not fuzzy-match arbitrary application/user-controlled text.
+    record = logging.LogRecord(
+        "gateway.stream_consumer",
+        logging.ERROR,
+        __file__,
+        1,
+        "Stream consumer error: already interpolated secret",
+        (),
+        None,
+    )
+    handler.emit(record)
+
+    assert captured == []
+
+
+def test_stream_and_delivery_paths_never_format_record_args(monkeypatch):
+    captured = _capture_events(monkeypatch)
+    handler = runtime_obs._RuntimeDiagnosticLogHandler()
+
+    class _MustNotStringify:
+        def __str__(self):
+            raise AssertionError("record args must never be formatted")
+
+    handler.emit(logging.LogRecord(
+        "gateway.stream_consumer",
+        logging.ERROR,
+        __file__,
+        1,
+        "Stream consumer error: %s",
+        (_MustNotStringify(),),
+        None,
+    ))
+    handler.emit(logging.LogRecord(
+        "gateway.platforms.base",
+        logging.ERROR,
+        __file__,
+        1,
+        "[%s] Fallback send also failed: %s",
+        (_MustNotStringify(), _MustNotStringify()),
+        None,
+    ))
+
+    assert [event.name for event in captured] == [
+        "runtime.stream.failed",
+        "runtime.delivery.fallback_failed",
+    ]
+
+
+def test_log_observer_installs_once():
+    runtime_obs.install()
+    runtime_obs.install()
+
+    for name in runtime_obs._LOGGER_NAMES:
+        handlers = [
+            handler
+            for handler in logging.getLogger(name).handlers
+            if getattr(handler, runtime_obs._LOG_HANDLER_MARKER, False)
+        ]
+        assert len(handlers) == 1
+
+
+def test_telemetry_failure_cannot_escape_into_runtime(monkeypatch):
+    monkeypatch.setattr(runtime_obs, "enabled", lambda: True)
+
+    import agent.monitoring.emitter as emitter_module
+
+    class _BoomEmitter:
+        def emit_buffered(self, _event):
+            raise RuntimeError("collector is unavailable")
+
+    monkeypatch.setattr(emitter_module, "get_emitter", lambda: _BoomEmitter())
+
+    handler = runtime_obs._RuntimeDiagnosticLogHandler()
+    # No exception escapes even when the sink raises.
+    handler.emit(logging.LogRecord(
+        "gateway.stream_consumer",
+        logging.ERROR,
+        __file__,
+        1,
+        "Stream consumer error: %s",
+        ("private failure detail",),
+        None,
+    ))
+
+
+def test_builtin_lifecycle_dispatcher_remains_relay_only(monkeypatch):
+    from hermes_cli import observability
+    from hermes_cli.observability import relay_shared_metrics
+
+    monkeypatch.setattr(relay_shared_metrics, "handles_hook", lambda _hook: False)
+
+    # Residual diagnostics no longer use lifecycle hooks as a bootstrap seam.
+    assert observability.handles_hook("on_session_start") is False
+    assert observability.handles_hook("post_tool_call") is False

--- a/tests/monitoring/test_emitter.py
+++ b/tests/monitoring/test_emitter.py
@@ -35,10 +35,58 @@ def test_process_singleton_stays_dormant_until_subscribed():
         emitter.reset_emitter_for_tests()
 
 
+def test_subscribe_never_starts_dispatch_on_buffered_events():
+    """subscribe() must not start dispatch just because the queue is non-empty.
+
+    Regression for #114: a residual event buffered before any subscriber must
+    survive while gateway subscribers attach one at a time (span streamer
+    first, diagnostic streamer second). Starting dispatch from subscribe()
+    would dequeue it into a partial fan-out set and lose it.
+    """
+    em = MonitoringEmitter(enabled=False)
+    try:
+        em.emit_buffered({"event": "gateway_diagnostic", "name": "early"})
+        assert em.stats()["queued"] == 1
+        assert em._started is False
+
+        # First subscriber attaches with a non-empty queue — still no dispatch.
+        em.subscribe(lambda _batch: None)
+        assert em._started is False
+        assert em.stats()["queued"] == 1
+
+        # The first ordinary emit after subscribe starts dispatch and drains.
+        em.emit({"event": "gateway_health", "name": "snapshot"})
+        em.flush(timeout=1.0)
+        assert em.stats()["queued"] == 0
+    finally:
+        em.close()
 
 
+def test_flush_is_noop_before_dispatcher_starts():
+    """flush() must not wait when a subscriber exists but dispatch never ran.
 
+    Regression for #114: a partial startup path (buffered residual → subscriber
+    attached → initial snapshot never emitted) leaves the dispatcher unstarted.
+    flush() with a subscriber but no dispatcher would block on queue.join()
+    until the timeout, adding an artificial shutdown delay — fail-open requires
+    an instant no-op instead.
+    """
+    em = MonitoringEmitter(enabled=False)
+    try:
+        em.emit_buffered({"event": "gateway_diagnostic", "name": "early"})
+        em.subscribe(lambda _batch: None)
+        assert em._started is False
 
+        start = time.monotonic()
+        em.flush(timeout=2.0)
+        elapsed = time.monotonic() - start
+
+        # Buggy behavior blocks the full 2s timeout; a no-op returns instantly.
+        assert elapsed < 1.0
+        assert em.stats()["queued"] == 1
+        assert em._started is False
+    finally:
+        em.close()
 
 
 def test_unsubscribe_stops_delivery():


### PR DESCRIPTION
Closes #114.

## Completion claim

Reconstructs the Phase-1 runtime-observability capability as a bounded residual diagnostic extension on current fork `main`, without replaying the historical telemetry stack.

## Intent-readable history

The branch no longer carries a single mega-squash. The final tree is split into two intent commits (code + tests + docs travel together per intent):

1. `feat(observability): process-lifetime bounded delivery boundary` (`07581832b`)
   - `MonitoringEmitter.emit_buffered()` — an already-opted-in producer whose observation lifetime predates its exporter enqueues into the existing bounded queue without enabling unrelated producers or creating a second store.
   - `subscribe()` never starts dispatch on a non-empty queue — the buffered residual survives the gateway's two-sink assembly (span streamer first, diagnostic-log streamer second) and is drained by the ordinary post-assembly snapshot emit.
   - Dispatcher leaves buffered events queued when the subscriber set is empty.
   - `hermes_cli` installs the dormant observation boundary for the process lifetime (fail-open, no config/network/disk I/O).
2. `feat(observability): residual runtime fact vocabulary` (`8a69bebad`)
   - `STABLE_FACTS` closed residual subset (stream / SQLite-persistence / delivery); lifecycle and tool remain upstream-owned (Relay).
   - Dormant static-log normalizer over exact code-owned templates; never fuzzy-matches or stringifies args.
   - SQLite persistence exports only the frozen coarse bucket; producer-side redaction contract.
   - Single enablement gate; telemetry stays fail-open.

## Review fix (blocking, folded in)

PR #122 review found `subscribe()` could start dispatch on the first (span-filtered) subscriber and lose a pre-buffered `gateway_diagnostic` before the diagnostic-log streamer attached. Fixed: subscribe only enables the plane; the initial gateway-health snapshot starts dispatch after the full fan-out is assembled. Regression `test_startup_fact_survives_multi_sink_subscribe_order` exercises the real order: buffered residual → span subscriber → diagnostic subscriber → initial snapshot, asserting the residual reaches only its owning sink. Over-engineering cleanup folded in: dropped runtime-unused `DOMAIN_OWNERSHIP` + its exact-snapshot test (YAGNI; Relay behavioral test already proves non-duplication) and the duplicate `enabled()` gate.

## Verification

- `tests/hermes_cli/test_runtime_observability.py` — fact vocabulary, redaction, fail-open, template anchoring, multi-sink ordering.
- `tests/monitoring/test_emitter.py` — subscribe-never-starts-dispatch, hot path, unsubscribe.
- `tests/monitoring/test_otlp_exporter.py` — sink/filter compatibility.
- Local: 20 passed, 1 skipped (otlp extra).