### PR TITLE
fix(tests): increase lease-timeout test safety net from 1s to 5s

### DIFF
--- a/tests/gateway/test_turn_lease.py
+++ b/tests/gateway/test_turn_lease.py
@@ -200,7 +200,7 @@ async def test_full_dispatch_rejects_lease_timeout_without_running_goal_hook(
     runner._post_turn_goal_continuation = AsyncMock()
 
     try:
-        response = await asyncio.wait_for(runner._handle_message(_event()), timeout=1)
+        response = await asyncio.wait_for(runner._handle_message(_event()), timeout=5)
     finally:
         assert runner._turn_leases.release(holder) is True
 


### PR DESCRIPTION
## Problem

`test_full_dispatch_rejects_lease_timeout_without_running_goal_hook` fails intermittently on CI with `TimeoutError`. The test wraps `_handle_message` in `asyncio.wait_for(..., timeout=1)` — but `_handle_message` internally calls `asyncio.to_thread(_recover_telegram_topic_thread_id)`, which can exceed 1 second under CI resource constraints.

The actual lease timeout under test (`HERMES_TURN_LEASE_TIMEOUT=0.02s`) is unchanged — the 1s wrapper is just a safety net to prevent test hangs.

## Fix

Increase the `asyncio.wait_for` safety-net timeout from 1s to 5s. The test's real assertion (lease timeout rejects promptly) is unaffected.

## Verification

Test passes locally: `1 passed in 3.55s` (previously `FAILED` in 12.35s due to TimeoutError).