### PR TITLE
fix(compression): close #112 review findings

### DIFF
--- a/agent/context_engine.py
+++ b/agent/context_engine.py
@@ -107,6 +107,12 @@ class ContextEngine(ABC):
     context_length: int = 0
     compression_count: int = 0
 
+    # Optional result status set by ``compress()`` for the current attempt.
+    # The host clears it before dispatch, so a plugin-reported ``"noop"``
+    # cannot suppress a later successful compression transition. Older engines
+    # may expose the same status as ``_last_compression_status``.
+    last_compression_status: str = ""
+
     # -- Compaction parameters (read by run_agent.py for preflight) --------
     #
     # These control the preflight compression check.  Subclasses may

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -3175,14 +3175,20 @@ def compress_context(
         # Check this BEFORE the semantic equality test so a plugin that
         # returns a freshly-built equal list (not the input object) is
         # still recognized as a no-op via its status flag.
-        if (
-            getattr(
-                agent.context_compressor,
-                "last_compression_status",
-                getattr(agent.context_compressor, "_last_compression_status", ""),
-            )
-            == "noop"
-        ):
+        #
+        # Resolve public then legacy status explicitly, not via a nested
+        # getattr fallback: every ContextEngine subclass now inherits the
+        # public ``last_compression_status = ""`` class attribute, so a nested
+        # ``getattr(compressor, "last_compression_status", legacy_fallback)``
+        # is masked by that empty default and never reaches a legacy-only
+        # ``_last_compression_status = "noop"``.
+        _public_status = getattr(
+            agent.context_compressor, "last_compression_status", ""
+        )
+        _legacy_status = getattr(
+            agent.context_compressor, "_last_compression_status", ""
+        )
+        if (_public_status or _legacy_status) == "noop":
             try:
                 logger.info(
                     "context compression no-op: session=%s messages=%d unchanged; skipping session boundary",

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -3029,6 +3029,17 @@ def compress_context(
                 with aux_progress_hook(_progress_hook), aux_interrupt_protection(
                     cancel_event=_hard_cancel_event
                 ):
+                    # Status belongs to this compression attempt. Clear both
+                    # the public contract and the legacy private spelling so
+                    # a prior plugin no-op cannot suppress a later success.
+                    for _status_name in (
+                        "last_compression_status",
+                        "_last_compression_status",
+                    ):
+                        try:
+                            setattr(agent.context_compressor, _status_name, "")
+                        except Exception:
+                            pass
                     compressed = compress_fn(messages, **compress_kwargs)
                     # Freeze a hard stop that arrived after the final provider
                     # attempt unwound but before this transaction can rotate

--- a/tests/run_agent/test_compression_noop_status.py
+++ b/tests/run_agent/test_compression_noop_status.py
@@ -133,5 +133,10 @@ def test_stale_noop_status_does_not_suppress_successful_transition():
                 approx_tokens=10_000,
             )
 
-            assert compressed == [{"role": "user", "content": "summary"}]
+            # The successful transition is the contract under test, not
+            # byte-equality of the payload: rotation + persistence may attach
+            # internal message metadata (e.g. ``_row_id``), so compare only the
+            # fields that prove the summary was adopted and the session rotated.
+            assert compressed[0]["role"] == "user"
+            assert compressed[0]["content"] == "summary"
             assert agent.session_id != original_sid

--- a/tests/run_agent/test_compression_noop_status.py
+++ b/tests/run_agent/test_compression_noop_status.py
@@ -140,3 +140,65 @@ def test_stale_noop_status_does_not_suppress_successful_transition():
             assert compressed[0]["role"] == "user"
             assert compressed[0]["content"] == "summary"
             assert agent.session_id != original_sid
+
+
+def test_legacy_engine_private_noop_status_skips_boundary():
+    """A legacy ContextEngine subclass writing only the private flag still
+    skips the session boundary.
+
+    Regression for #112 review: the public ``last_compression_status`` class
+    attribute is inherited by every ``ContextEngine`` subclass, so a nested
+    ``getattr(compressor, "last_compression_status", legacy_fallback)`` is
+    masked by that empty default and never sees a legacy-only
+    ``_last_compression_status = "noop"``. Status resolution must treat the
+    public value as precedence with the private spelling as fallback.
+    """
+    from hermes_state import SessionDB
+    from agent.context_engine import ContextEngine
+
+    class _LegacyEngine(ContextEngine):
+        @property
+        def name(self) -> str:
+            return "legacy"
+
+        def update_from_response(self, usage) -> None:
+            pass
+
+        def should_compress(self, prompt_tokens=None) -> bool:
+            return True
+
+        def compress(
+            self,
+            messages,
+            current_tokens=None,
+            focus_topic=None,
+            force=False,
+            memory_context="",
+        ):
+            # Legacy contract: only the private spelling is written. The
+            # inherited public ``last_compression_status = ""`` stays empty.
+            self._last_compression_status = "noop"
+            return [{"role": "assistant", "content": "cleaned tail"}]
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "test.db"
+        with SessionDB(db_path=db_path) as db:
+            agent = _BoundaryHarness()._make_agent(db)
+            agent.context_compressor = _LegacyEngine()
+            agent._cached_system_prompt = "cached-system-prompt"
+            original_sid = agent.session_id
+
+            compressed, prompt = agent._compress_context(
+                [
+                    {"role": "user", "content": "replayed scaffold"},
+                    {"role": "assistant", "content": "fresh tail"},
+                ],
+                "sys",
+                approx_tokens=10_000,
+            )
+
+            assert compressed == [
+                {"role": "assistant", "content": "cleaned tail"}
+            ]
+            assert prompt == "cached-system-prompt"
+            assert agent.session_id == original_sid

--- a/tests/run_agent/test_compression_noop_status.py
+++ b/tests/run_agent/test_compression_noop_status.py
@@ -43,45 +43,95 @@ def test_plugin_noop_adopts_cleanup_without_session_boundary():
 
     with tempfile.TemporaryDirectory() as tmpdir:
         db_path = Path(tmpdir) / "test.db"
-        db = SessionDB(db_path=db_path)
-        agent = _BoundaryHarness()._make_agent(db)
+        with SessionDB(db_path=db_path) as db:
+            agent = _BoundaryHarness()._make_agent(db)
 
-        messages = [
-            {"role": "user", "content": "replayed scaffold"},
-            {"role": "assistant", "content": "fresh tail"},
-        ]
-        cleaned = [{"role": "assistant", "content": "fresh tail"}]
-        compressor = _noop_compressor(cleaned)
-        agent.context_compressor = compressor
-        agent._cached_system_prompt = "cached-system-prompt"
+            messages = [
+                {"role": "user", "content": "replayed scaffold"},
+                {"role": "assistant", "content": "fresh tail"},
+            ]
+            cleaned = [{"role": "assistant", "content": "fresh tail"}]
+            compressor = _noop_compressor(cleaned)
+            agent.context_compressor = compressor
+            agent._cached_system_prompt = "cached-system-prompt"
 
-        original_sid = agent.session_id
-        compressed, prompt = agent._compress_context(
-            messages,
-            "sys",
-            approx_tokens=10_000,
-        )
+            original_sid = agent.session_id
+            compressed, prompt = agent._compress_context(
+                messages,
+                "sys",
+                approx_tokens=10_000,
+            )
 
-        # This must exercise the explicit status seam, not #67938's equality
-        # guard: cleanup changed the active context.
-        assert compressed == cleaned
-        assert compressed != messages
-        assert prompt == "cached-system-prompt"
-        assert agent.session_id == original_sid
+            # This must exercise the explicit status seam, not #67938's equality
+            # guard: cleanup changed the active context.
+            assert compressed == cleaned
+            assert compressed != messages
+            assert prompt == "cached-system-prompt"
+            assert agent.session_id == original_sid
 
-        compression_boundary_calls = [
-            call
-            for call in compressor.on_session_start.call_args_list
-            if call.kwargs.get("boundary_reason") == "compression"
-        ]
-        assert not compression_boundary_calls
+            compression_boundary_calls = [
+                call
+                for call in compressor.on_session_start.call_args_list
+                if call.kwargs.get("boundary_reason") == "compression"
+            ]
+            assert not compression_boundary_calls
 
-        conn = sqlite3.connect(str(db_path))
-        try:
-            child_count = conn.execute(
-                "SELECT COUNT(*) FROM sessions WHERE parent_session_id = ?",
-                (original_sid,),
-            ).fetchone()[0]
-        finally:
-            conn.close()
-        assert child_count == 0
+            conn = sqlite3.connect(str(db_path))
+            try:
+                child_count = conn.execute(
+                    "SELECT COUNT(*) FROM sessions WHERE parent_session_id = ?",
+                    (original_sid,),
+                ).fetchone()[0]
+            finally:
+                conn.close()
+            assert child_count == 0
+
+
+def test_stale_noop_status_does_not_suppress_successful_transition():
+    """A later successful result must not inherit a previous no-op status."""
+    from hermes_state import SessionDB
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "test.db"
+        with SessionDB(db_path=db_path) as db:
+            agent = _BoundaryHarness()._make_agent(db)
+            compressor = _noop_compressor(
+                [{"role": "assistant", "content": "cleaned tail"}]
+            )
+            calls = 0
+
+            def _compress(_messages, **_kwargs):
+                nonlocal calls
+                calls += 1
+                if calls == 1:
+                    compressor.last_compression_status = "noop"
+                    return [{"role": "assistant", "content": "cleaned tail"}]
+                # Deliberately leave the previous public status untouched.
+                return [{"role": "user", "content": "summary"}]
+
+            compressor.compress.side_effect = _compress
+            agent.context_compressor = compressor
+            original_sid = agent.session_id
+
+            messages = [
+                {"role": "user", "content": "replayed scaffold"},
+                {"role": "assistant", "content": "fresh tail"},
+            ]
+            compressed, _ = agent._compress_context(
+                messages,
+                "sys",
+                approx_tokens=10_000,
+            )
+            assert compressed == [
+                {"role": "assistant", "content": "cleaned tail"}
+            ]
+            assert agent.session_id == original_sid
+
+            compressed, _ = agent._compress_context(
+                compressed,
+                "sys",
+                approx_tokens=10_000,
+            )
+
+            assert compressed == [{"role": "user", "content": "summary"}]
+            assert agent.session_id != original_sid


### PR DESCRIPTION
Addresses review findings on PR #118 / issue #112.\n\n- Clears public and legacy private no-op status before each compression attempt, preventing stale noop from suppressing a later successful transition.\n- Documents the ContextEngine status contract.\n- Uses SessionDB as a context manager in the regression and adds stale-status coverage.\n\nFocused test: scripts/run_tests.sh tests/run_agent/test_compression_noop_status.py -q