### PR TITLE
line:memory-trim-diagnostics: restore fail-open runtime diagnostics

### DIFF
--- a/hermes_cli/mem_trim.py
+++ b/hermes_cli/mem_trim.py
@@ -15,10 +15,12 @@ from __future__ import annotations
 import ctypes
 import gc
 import logging
+import os
 import platform
 import sys
 import threading
 import time
+import xml.etree.ElementTree as ET
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
@@ -135,8 +137,9 @@ def _read_proc_status() -> str | None:
 def collect_memory_snapshot(history_bytes: int | None = None) -> dict[str, int | None]:
     """Return lightweight process-memory telemetry for trim logs and canaries.
 
-    ``VmRSS`` and ``RssAnon`` are Linux-only best effort fields. The helper is
-    intentionally dependency-free so allocation recovery never requires psutil.
+    ``VmRSS``, ``RssAnon``, and ``VmSwap`` are Linux-only best-effort fields.
+    The helper is intentionally dependency-free so allocation recovery never
+    requires psutil.
     """
     snapshot: dict[str, int | None] = {
         "rss_kib": None,
@@ -145,18 +148,104 @@ def collect_memory_snapshot(history_bytes: int | None = None) -> dict[str, int |
     }
     status = _read_proc_status()
     if status:
+        field_names = {
+            "VmRSS": "rss_kib",
+            "RssAnon": "rss_anon_kib",
+            "VmSwap": "vm_swap_kib",
+        }
         for line in status.splitlines():
             key, separator, raw_value = line.partition(":")
-            if not separator or key not in {"VmRSS", "RssAnon"}:
+            if not separator or key not in field_names:
                 continue
             value = raw_value.strip().split(maxsplit=1)
             if value and value[0].isdigit():
-                snapshot["rss_kib" if key == "VmRSS" else "rss_anon_kib"] = int(
-                    value[0]
-                )
+                snapshot[field_names[key]] = int(value[0])
     if isinstance(history_bytes, int) and history_bytes >= 0:
         snapshot["history_bytes"] = history_bytes
     return snapshot
+
+
+def _parse_malloc_info(xml_text: str) -> dict[str, float | int | None] | None:
+    """Parse glibc malloc_info(3) top-level totals into fragmentation evidence.
+
+    ``malloc_info`` repeats per-heap totals inside ``<heap>`` elements and then
+    emits process-wide totals at the root. Only root-level values are summed so
+    multi-arena processes are not double-counted.
+    """
+    try:
+        root = ET.fromstring(xml_text)
+        system_bytes = sum(
+            int(node.attrib["size"])
+            for node in root.findall("system")
+            if node.attrib.get("type") == "current" and "size" in node.attrib
+        )
+        free_bytes = sum(
+            int(node.attrib["size"])
+            for node in root.findall("total")
+            if node.attrib.get("type") in {"fast", "rest"}
+            and "size" in node.attrib
+        )
+    except (ET.ParseError, KeyError, TypeError, ValueError):
+        return None
+
+    frag_pct = (
+        round(free_bytes * 100.0 / system_bytes, 1) if system_bytes > 0 else None
+    )
+    return {
+        "system_bytes": system_bytes,
+        "free_bytes": free_bytes,
+        "frag_pct": frag_pct,
+    }
+
+
+def _malloc_info_stats() -> dict[str, float | int | None] | None:
+    """Return best-effort glibc heap fragmentation diagnostics.
+
+    Use libc ``tmpfile()`` instead of a predictable path under /tmp. The stream
+    is process-local/temporary and always closed. Any platform, libc, stdio,
+    parser, or filesystem failure degrades to ``None`` and cannot veto recovery.
+    """
+    if sys.platform != "linux":
+        return None
+    try:
+        libc = ctypes.CDLL(None)
+
+        libc.malloc_info.argtypes = [ctypes.c_int, ctypes.c_void_p]
+        libc.malloc_info.restype = ctypes.c_int
+        libc.tmpfile.argtypes = []
+        libc.tmpfile.restype = ctypes.c_void_p
+        libc.fflush.argtypes = [ctypes.c_void_p]
+        libc.fflush.restype = ctypes.c_int
+        libc.fileno.argtypes = [ctypes.c_void_p]
+        libc.fileno.restype = ctypes.c_int
+        libc.fclose.argtypes = [ctypes.c_void_p]
+        libc.fclose.restype = ctypes.c_int
+
+        stream = libc.tmpfile()
+        if not stream:
+            return None
+        try:
+            if libc.malloc_info(0, stream) != 0:
+                return None
+            if libc.fflush(stream) != 0:
+                return None
+            fd = libc.fileno(stream)
+            if fd < 0:
+                return None
+            os.lseek(fd, 0, os.SEEK_SET)
+            chunks: list[bytes] = []
+            while True:
+                chunk = os.read(fd, 65536)
+                if not chunk:
+                    break
+                chunks.append(chunk)
+            return _parse_malloc_info(
+                b"".join(chunks).decode("utf-8", errors="replace")
+            )
+        finally:
+            libc.fclose(stream)
+    except Exception:
+        return None
 
 
 def _should_log_trim(
@@ -172,7 +261,7 @@ def _should_log_trim(
     # successful trim is an explicit observability event, regardless of RSS.
     if force:
         return True
-    if not force and call_count % log_every_n:
+    if call_count % log_every_n:
         return False
     before_rss = before.get("rss_kib")
     after_rss = after.get("rss_kib")
@@ -212,7 +301,7 @@ def trim_memory(
 
     Returns ``True`` only when ``malloc_trim(0)`` ran and reported success.
     Unsupported allocators, the config kill switch, cooldown suppression, the
-    RSS low-water gate, and all runtime errors return ``False`` without
+    configured RSS low-water mark, and runtime errors return ``False`` without
     affecting the caller.
     """
     (
@@ -283,14 +372,29 @@ def trim_memory(
                 or not _last_gc_monotonic
                 or now - _last_gc_monotonic >= gc_cooldown
             )
-            started = time.perf_counter()
+
+            # Diagnostics extend policy: even an unexpected diagnostics failure
+            # must not suppress gc/trim. Collect fragmentation before recovery so
+            # it describes the heap state that motivated this attempt.
+            try:
+                heap = _malloc_info_stats()
+            except Exception as exc:
+                logger.debug("malloc_info diagnostics failed: %s", exc)
+                heap = None
+
+            gc_ms = 0.0
             if should_gc:
+                gc_started = time.perf_counter()
                 gc.collect()
+                gc_ms = (time.perf_counter() - gc_started) * 1000
                 _last_gc_monotonic = time.monotonic()
+
+            trim_started = time.perf_counter()
             trim_result = trim(0)
+            trim_ms = (time.perf_counter() - trim_started) * 1000
             released = bool(trim_result)
             after = collect_memory_snapshot()
-            duration_ms = (time.perf_counter() - started) * 1000
+            duration_ms = gc_ms + trim_ms
             _trim_call_count += 1
             if released and _should_log_trim(
                 force=force,
@@ -300,17 +404,31 @@ def trim_memory(
                 after=after,
                 info_log_min_delta_mb=info_log_min_delta_mb,
             ):
+                heap_system_mb = (
+                    heap["system_bytes"] / (1024 * 1024) if heap else None
+                )
+                heap_free_mb = heap["free_bytes"] / (1024 * 1024) if heap else None
                 logger.info(
                     "memory trim: reason=%s malloc_trim=%s rss_kib=%s->%s "
-                    "rss_anon_kib=%s->%s threads=%s duration_ms=%.1f",
+                    "rss_anon_kib=%s->%s swap_kib=%s->%s threads=%s "
+                    "duration_ms=%.1f gc_ran=%s gc_ms=%.1f trim_ms=%.1f "
+                    "heap_system_mb=%s heap_free_mb=%s frag_pct=%s",
                     reason or "cleanup",
                     trim_result,
                     before.get("rss_kib"),
                     after.get("rss_kib"),
                     before.get("rss_anon_kib"),
                     after.get("rss_anon_kib"),
+                    before.get("vm_swap_kib"),
+                    after.get("vm_swap_kib"),
                     after.get("thread_count"),
                     duration_ms,
+                    should_gc,
+                    gc_ms,
+                    trim_ms,
+                    heap_system_mb,
+                    heap_free_mb,
+                    heap.get("frag_pct") if heap else None,
                 )
             return released
         except Exception as exc:

--- a/tests/hermes_cli/test_mem_trim_diagnostics.py
+++ b/tests/hermes_cli/test_mem_trim_diagnostics.py
@@ -1,0 +1,146 @@
+"""Diagnostics extension tests for memory-runtime reconstruction (#110)."""
+
+from unittest.mock import Mock
+
+import pytest
+
+import hermes_cli.mem_trim as mem_trim
+
+
+@pytest.fixture(autouse=True)
+def _reset_trim_state(monkeypatch):
+    monkeypatch.setattr(mem_trim, "_last_trim_monotonic", 0.0)
+    monkeypatch.setattr(mem_trim, "_last_gc_monotonic", 0.0)
+    monkeypatch.setattr(mem_trim, "_probe_done", True)
+    monkeypatch.setattr(mem_trim, "_malloc_trim", None)
+    monkeypatch.setattr(mem_trim, "_trim_call_count", 0)
+
+
+def _snapshot(rss_kib=4096, rss_anon_kib=3072, vm_swap_kib=None):
+    snapshot = {
+        "rss_kib": rss_kib,
+        "rss_anon_kib": rss_anon_kib,
+        "thread_count": 3,
+    }
+    if vm_swap_kib is not None:
+        snapshot["vm_swap_kib"] = vm_swap_kib
+    return snapshot
+
+
+def test_memory_snapshot_parses_vmswap_when_available(monkeypatch):
+    monkeypatch.setattr(
+        mem_trim,
+        "_read_proc_status",
+        lambda: (
+            "Name:\tpython\nVmRSS:\t1234 kB\n"
+            "RssAnon:\t567 kB\nVmSwap:\t89 kB\n"
+        ),
+    )
+    monkeypatch.setattr(mem_trim.threading, "active_count", lambda: 9)
+
+    assert mem_trim.collect_memory_snapshot() == {
+        "rss_kib": 1234,
+        "rss_anon_kib": 567,
+        "vm_swap_kib": 89,
+        "thread_count": 9,
+    }
+
+
+def test_malloc_info_parser_uses_process_totals_without_double_counting():
+    xml = """<malloc version="1">
+      <heap nr="0">
+        <total type="fast" count="1" size="50"/>
+        <total type="rest" count="1" size="350"/>
+        <system type="current" size="1000"/>
+      </heap>
+      <total type="fast" count="2" size="100"/>
+      <total type="rest" count="3" size="400"/>
+      <system type="current" size="2000"/>
+    </malloc>"""
+
+    assert mem_trim._parse_malloc_info(xml) == {
+        "system_bytes": 2000,
+        "free_bytes": 500,
+        "frag_pct": 25.0,
+    }
+
+
+def test_malformed_malloc_info_is_best_effort():
+    assert mem_trim._parse_malloc_info("<malloc>") is None
+
+
+def test_diagnostics_failure_does_not_block_recovery(monkeypatch):
+    collect = Mock()
+    trim = Mock(return_value=1)
+    monkeypatch.setattr(mem_trim.gc, "collect", collect)
+    monkeypatch.setattr(mem_trim, "_malloc_trim", trim)
+    monkeypatch.setattr(
+        mem_trim,
+        "_malloc_info_stats",
+        Mock(side_effect=RuntimeError("diagnostics unavailable")),
+    )
+    monkeypatch.setattr(mem_trim.time, "monotonic", lambda: 100.0)
+    monkeypatch.setattr(mem_trim, "collect_memory_snapshot", lambda: _snapshot())
+
+    assert mem_trim.trim_memory(reason="diagnostics-fail") is True
+    collect.assert_called_once_with()
+    trim.assert_called_once_with(0)
+
+
+def test_log_attributes_gc_trim_fragmentation_and_swap(monkeypatch, caplog):
+    monkeypatch.setattr(mem_trim.gc, "collect", lambda: None)
+    monkeypatch.setattr(mem_trim, "_malloc_trim", lambda _pad: 1)
+    monkeypatch.setattr(
+        mem_trim,
+        "_malloc_info_stats",
+        lambda: {
+            "system_bytes": 4 * 1024 * 1024,
+            "free_bytes": 1 * 1024 * 1024,
+            "frag_pct": 25.0,
+        },
+    )
+    monkeypatch.setattr(
+        mem_trim, "_config_settings", lambda: (True, 0.0, 300.0, 1, 0.0, None)
+    )
+    monkeypatch.setattr(mem_trim.time, "monotonic", lambda: 100.0)
+    perf_ticks = iter([10.0, 10.003, 20.0, 20.007])
+    monkeypatch.setattr(mem_trim.time, "perf_counter", lambda: next(perf_ticks))
+    snapshots = iter(
+        (
+            _snapshot(4096, 3072, 128),
+            _snapshot(2048, 1024, 64),
+        )
+    )
+    monkeypatch.setattr(mem_trim, "collect_memory_snapshot", lambda: next(snapshots))
+
+    with caplog.at_level("INFO", logger="hermes_cli.mem_trim"):
+        assert mem_trim.trim_memory(reason="diagnostic-test") is True
+
+    assert "gc_ran=True" in caplog.text
+    assert "gc_ms=3.0" in caplog.text
+    assert "trim_ms=7.0" in caplog.text
+    assert "swap_kib=128->64" in caplog.text
+    assert "frag_pct=25.0" in caplog.text
+
+
+def test_log_marks_gc_cooldown_without_suppressing_trim(monkeypatch, caplog):
+    collect = Mock()
+    monkeypatch.setattr(mem_trim.gc, "collect", collect)
+    monkeypatch.setattr(mem_trim, "_malloc_trim", lambda _pad: 1)
+    monkeypatch.setattr(mem_trim, "_malloc_info_stats", lambda: None)
+    monkeypatch.setattr(mem_trim, "_last_gc_monotonic", 90.0)
+    monkeypatch.setattr(
+        mem_trim, "_config_settings", lambda: (True, 0.0, 300.0, 1, 0.0, None)
+    )
+    monkeypatch.setattr(mem_trim.time, "monotonic", lambda: 100.0)
+    perf_ticks = iter([20.0, 20.004])
+    monkeypatch.setattr(mem_trim.time, "perf_counter", lambda: next(perf_ticks))
+    monkeypatch.setattr(mem_trim, "collect_memory_snapshot", lambda: _snapshot())
+
+    with caplog.at_level("INFO", logger="hermes_cli.mem_trim"):
+        assert mem_trim.trim_memory(reason="gc-cooling") is True
+
+    collect.assert_not_called()
+    assert "gc_ran=False" in caplog.text
+    assert "gc_ms=0.0" in caplog.text
+    assert "trim_ms=4.0" in caplog.text


### PR DESCRIPTION
## Work line: \line:memory-trim-diagnostics\

Part of merge unit \epair:memory-runtime\ (#110).

Depends on: PR #131 (\line:memory-trim-policy\).

## Commits

1. \eat(mem-trim): restore fail-open runtime diagnostics\ — GC/trim timing split + fragmentation + VmSwap

## Behavior

- Separate \gc_ms\ and \	rim_ms\ timing attribution
- Best-effort \malloc_info(3)\ fragmentation stats (process totals, no double-count)
- \VmSwap\ evidence from \/proc/self/status\
- Diagnostic failures degrade gracefully, never block recovery

## Coverage

6 diagnostics tests in \	ests/hermes_cli/test_mem_trim_diagnostics.py\.

Composed into integration PR #120 (\epair:memory-runtime\).