### PR TITLE
feat(display): configurable reasoning display line limit

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -1332,6 +1332,71 @@ def _trim_error(msg: str) -> str:
     return msg
 
 
+def resolve_reasoning_max_lines(config: dict | None, surface_default: int) -> int:
+    """Resolve the effective reasoning display line cap.
+
+    Reads ``display.reasoning_max_lines`` from *config* (a resolved config
+    dict — CLI_CONFIG or gateway config) and returns the cap to use.
+
+    Semantics:
+      - key absent → *surface_default* (5/10/15 per surface)
+      - explicit ``0`` → unlimited (returns ``sys.maxsize``)
+      - positive int → that cap
+      - missing / invalid / negative / boolean → *surface_default*
+
+    This is the single production seam for reasoning_max_lines resolution.
+    Both CLI and gateway callers must use this function rather than
+    re-implementing the parsing logic.
+    """
+    if not config:
+        return surface_default
+    display = config.get("display", {}) if isinstance(config, dict) else {}
+    if not isinstance(display, dict):
+        return surface_default
+    raw = display.get("reasoning_max_lines")
+    if raw is None:
+        return surface_default
+    # bool is subclass of int — reject it explicitly
+    if isinstance(raw, bool):
+        return surface_default
+    # Accept int or integer-like string
+    if isinstance(raw, str):
+        try:
+            raw = int(raw)
+        except (ValueError, TypeError):
+            return surface_default
+    if not isinstance(raw, int):
+        return surface_default
+    if raw < 0:
+        return surface_default
+    if raw == 0:
+        return sys.maxsize
+    return raw
+
+
+def _truncate_reasoning_lines(text: str, max_lines: int, suffix_template: str) -> str:
+    """Truncate reasoning text to max_lines, appending a formatted suffix.
+
+    Pure formatting helper — does not escape code fences or apply any
+    other transformation. Callers compose this with escape_code_fences_for_display
+    as needed (truncate first, then escape).
+
+    Args:
+        text: Reasoning text (will be stripped).
+        max_lines: Maximum number of lines to keep.
+        suffix_template: Format string with {n} placeholder for remaining line count.
+
+    Returns:
+        Truncated text with suffix appended if truncation occurred, otherwise
+        the stripped input unchanged.
+    """
+    lines = text.strip().splitlines()
+    if len(lines) <= max_lines:
+        return text.strip()
+    kept = "\n".join(lines[:max_lines])
+    return kept + suffix_template.format(n=len(lines) - max_lines)
+
+
 def _detect_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str]:
     """Inspect a tool result string for signs of failure.
 

--- a/cli.py
+++ b/cli.py
@@ -4739,6 +4739,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # reasoning_full: when reasoning display is on, print the post-response
         # recap box uncollapsed instead of clamping to the first 10 lines.
         self.reasoning_full = CLI_CONFIG["display"].get("reasoning_full", False)
+        # reasoning_max_lines: optional global cap override for all reasoning
+        # display surfaces (preview=5, recap=10). Resolved once at init from
+        # the already-loaded CLI_CONFIG — no hot-path config reload.
+        from agent.display import resolve_reasoning_max_lines
+        self.reasoning_max_lines_preview = resolve_reasoning_max_lines(CLI_CONFIG, 5)
+        self.reasoning_max_lines_recap = resolve_reasoning_max_lines(CLI_CONFIG, 10)
         _configure_output_history(
             enabled=CLI_CONFIG["display"].get("persistent_output", True),
             max_lines=CLI_CONFIG["display"].get("persistent_output_max_lines", 200),
@@ -7210,13 +7216,34 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             _cprint(f"  {_DIM}[thinking] {preview_text}{_RST}")
             return
 
-        lines = preview_text.splitlines()
-        if len(lines) > 5:
-            preview = "\n".join(lines[:5])
-            preview += f"\n  ... ({len(lines) - 5} more lines)"
-        else:
-            preview = preview_text
+        from agent.display import _truncate_reasoning_lines
+        preview = _truncate_reasoning_lines(
+            preview_text,
+            self.reasoning_max_lines_preview,
+            "\n  ... ({n} more lines)"
+        )
         _cprint(f"  {_DIM}[thinking] {preview}{_RST}")
+
+    def _build_reasoning_recap(self, reasoning: str) -> str:
+        """Format the post-response reasoning recap box content.
+
+        Precedence: ``reasoning_full`` > ``reasoning_max_lines`` > legacy
+        10-line default.  ``reasoning_full`` prints the thinking uncollapsed;
+        otherwise the reasoning is truncated to ``self.reasoning_max_lines_recap``
+        (resolved once from CLI_CONFIG at init — no hot-path reload) with the
+        existing /reasoning full hint suffix.
+
+        This is the production seam for the CLI recap; tests must exercise it
+        rather than reimplementing the precedence locally.
+        """
+        from agent.display import _truncate_reasoning_lines
+        if self.reasoning_full:
+            return reasoning.strip()
+        return _truncate_reasoning_lines(
+            reasoning,
+            self.reasoning_max_lines_recap,
+            f"\n{_DIM}  ... ({{n}} more lines — /reasoning full to show){_RST}",
+        )
 
     def _flush_reasoning_preview(self, *, force: bool = False) -> None:
         """Flush buffered reasoning text at natural boundaries.
@@ -15841,14 +15868,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     r_fill = w - 2 - len(r_label)
                     r_top = f"{_DIM}┌─{r_label}{'─' * max(r_fill - 1, 0)}┐{_RST}"
                     r_bot = f"{_DIM}└{'─' * (w - 2)}┘{_RST}"
-                    # Collapse long reasoning to the first 10 lines unless the
+                    # Collapse long reasoning to the first N lines unless the
                     # user opted into full display via /reasoning full.
-                    lines = reasoning.strip().splitlines()
-                    if len(lines) > 10 and not getattr(self, "reasoning_full", False):
-                        display_reasoning = "\n".join(lines[:10])
-                        display_reasoning += f"\n{_DIM}  ... ({len(lines) - 10} more lines — /reasoning full to show){_RST}"
-                    else:
-                        display_reasoning = reasoning.strip()
+                    # Precedence: reasoning_full > reasoning_max_lines > legacy 10.
+                    display_reasoning = self._build_reasoning_recap(reasoning)
                     _cprint(f"\n{r_top}\n{_DIM}{display_reasoning}{_RST}\n{r_bot}")
 
             if response and not response_previewed:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -19864,13 +19864,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 last_reasoning = agent_result.get("last_reasoning")
                 if last_reasoning:
                     from gateway.stream_consumer import escape_code_fences_for_display
+                    from agent.display import resolve_reasoning_max_lines, _truncate_reasoning_lines
                     # Collapse long reasoning to keep messages readable
-                    lines = last_reasoning.strip().splitlines()
-                    if len(lines) > 15:
-                        display_reasoning = "\n".join(lines[:15])
-                        display_reasoning += f"\n_... ({len(lines) - 15} more lines)_"
-                    else:
-                        display_reasoning = last_reasoning.strip()
+                    max_lines = resolve_reasoning_max_lines(_load_gateway_config(), 15)
+                    display_reasoning = _truncate_reasoning_lines(
+                        last_reasoning, max_lines, "\n_... ({n} more lines)_"
+                    )
                     # Render style is per-platform: Discord defaults to "-# "
                     # subtext (native small grey metadata text); other
                     # platforms keep the fenced code block.

--- a/tests/agent/test_resolve_reasoning_max_lines.py
+++ b/tests/agent/test_resolve_reasoning_max_lines.py
@@ -1,0 +1,287 @@
+"""Tests for resolve_reasoning_max_lines and _truncate_reasoning_lines production helpers.
+
+This exercises the production seams in agent/display.py that both
+CLI and gateway callers must use for reasoning_max_lines resolution.
+Tests cover: unset defaults, invalid fallback, positive override,
+0 = unlimited, boolean rejection, negative fallback, reasoning_full
+precedence, and code-fence/backtick regression.
+"""
+
+import sys
+
+import pytest
+
+from agent.display import resolve_reasoning_max_lines, _truncate_reasoning_lines
+from gateway.stream_consumer import escape_code_fences_for_display
+
+
+class TestResolveReasoningMaxLines:
+    """Test the production helper for reasoning_max_lines resolution."""
+
+    def test_unset_returns_surface_default(self):
+        """Key absent → surface_default (5/10/15 per surface)."""
+        config = {"display": {}}
+        assert resolve_reasoning_max_lines(config, 5) == 5
+        assert resolve_reasoning_max_lines(config, 10) == 10
+        assert resolve_reasoning_max_lines(config, 15) == 15
+
+    def test_none_config_returns_surface_default(self):
+        """None config → surface_default."""
+        assert resolve_reasoning_max_lines(None, 5) == 5
+        assert resolve_reasoning_max_lines(None, 10) == 10
+
+    def test_empty_config_returns_surface_default(self):
+        """Empty dict → surface_default."""
+        assert resolve_reasoning_max_lines({}, 5) == 5
+
+    def test_missing_display_key_returns_surface_default(self):
+        """display key missing → surface_default."""
+        config = {"other": "value"}
+        assert resolve_reasoning_max_lines(config, 10) == 10
+
+    def test_none_value_returns_surface_default(self):
+        """reasoning_max_lines: null → surface_default."""
+        config = {"display": {"reasoning_max_lines": None}}
+        assert resolve_reasoning_max_lines(config, 5) == 5
+
+    def test_positive_int_override(self):
+        """Positive integer → that cap."""
+        config = {"display": {"reasoning_max_lines": 20}}
+        assert resolve_reasoning_max_lines(config, 5) == 20
+        assert resolve_reasoning_max_lines(config, 10) == 20
+        assert resolve_reasoning_max_lines(config, 15) == 20
+
+    def test_zero_means_unlimited(self):
+        """Explicit 0 → unlimited (sys.maxsize)."""
+        config = {"display": {"reasoning_max_lines": 0}}
+        assert resolve_reasoning_max_lines(config, 5) == sys.maxsize
+        assert resolve_reasoning_max_lines(config, 10) == sys.maxsize
+        assert resolve_reasoning_max_lines(config, 15) == sys.maxsize
+
+    def test_negative_falls_back_to_surface_default(self):
+        """Negative value → surface_default."""
+        config = {"display": {"reasoning_max_lines": -5}}
+        assert resolve_reasoning_max_lines(config, 5) == 5
+        assert resolve_reasoning_max_lines(config, 10) == 10
+
+    def test_boolean_true_falls_back_to_surface_default(self):
+        """Boolean True → surface_default (bool is subclass of int)."""
+        config = {"display": {"reasoning_max_lines": True}}
+        assert resolve_reasoning_max_lines(config, 5) == 5
+        assert resolve_reasoning_max_lines(config, 10) == 10
+
+    def test_boolean_false_falls_back_to_surface_default(self):
+        """Boolean False → surface_default."""
+        config = {"display": {"reasoning_max_lines": False}}
+        assert resolve_reasoning_max_lines(config, 5) == 5
+
+    def test_string_integer_accepted(self):
+        """Integer-like string → that cap."""
+        config = {"display": {"reasoning_max_lines": "25"}}
+        assert resolve_reasoning_max_lines(config, 5) == 25
+
+    def test_string_zero_means_unlimited(self):
+        """String "0" → unlimited."""
+        config = {"display": {"reasoning_max_lines": "0"}}
+        assert resolve_reasoning_max_lines(config, 10) == sys.maxsize
+
+    def test_invalid_string_falls_back_to_surface_default(self):
+        """Non-numeric string → surface_default."""
+        config = {"display": {"reasoning_max_lines": "unlimited"}}
+        assert resolve_reasoning_max_lines(config, 5) == 5
+
+    def test_float_falls_back_to_surface_default(self):
+        """Float → surface_default (not int)."""
+        config = {"display": {"reasoning_max_lines": 5.5}}
+        assert resolve_reasoning_max_lines(config, 5) == 5
+
+    def test_list_falls_back_to_surface_default(self):
+        """List → surface_default."""
+        config = {"display": {"reasoning_max_lines": [10]}}
+        assert resolve_reasoning_max_lines(config, 5) == 5
+
+    def test_display_not_dict_falls_back_to_surface_default(self):
+        """display key is not a dict → surface_default."""
+        config = {"display": "invalid"}
+        assert resolve_reasoning_max_lines(config, 5) == 5
+
+    def test_config_not_dict_falls_back_to_surface_default(self):
+        """Config is not a dict → surface_default."""
+        assert resolve_reasoning_max_lines("invalid", 5) == 5
+        assert resolve_reasoning_max_lines(123, 5) == 5
+
+    def test_one_is_valid_cap(self):
+        """Positive integer 1 → 1."""
+        config = {"display": {"reasoning_max_lines": 1}}
+        assert resolve_reasoning_max_lines(config, 5) == 1
+
+    def test_large_positive_cap(self):
+        """Large positive integer → that cap."""
+        config = {"display": {"reasoning_max_lines": 1000}}
+        assert resolve_reasoning_max_lines(config, 5) == 1000
+
+
+class TestTruncateReasoningLines:
+    """Test the _truncate_reasoning_lines production helper."""
+
+    def test_short_text_unchanged(self):
+        """Text within limit → returned unchanged."""
+        text = "line1\nline2\nline3"
+        result = _truncate_reasoning_lines(text, 5, "\n... ({n} more lines)")
+        assert result == text
+
+    def test_exact_limit_unchanged(self):
+        """Text exactly at limit → returned unchanged."""
+        text = "line1\nline2\nline3\nline4\nline5"
+        result = _truncate_reasoning_lines(text, 5, "\n... ({n} more lines)")
+        assert result == text
+
+    def test_long_text_truncated(self):
+        """Text exceeding limit → truncated with suffix."""
+        text = "\n".join(f"line{i}" for i in range(10))
+        result = _truncate_reasoning_lines(text, 5, "\n... ({n} more lines)")
+        assert result == "line0\nline1\nline2\nline3\nline4\n... (5 more lines)"
+
+    def test_whitespace_stripped(self):
+        """Leading/trailing whitespace → stripped."""
+        text = "  line1\nline2  \n"
+        result = _truncate_reasoning_lines(text, 5, "\n... ({n} more lines)")
+        assert result == "line1\nline2"
+
+    def test_empty_text(self):
+        """Empty text → returned as empty string."""
+        result = _truncate_reasoning_lines("", 5, "\n... ({n} more lines)")
+        assert result == ""
+
+    def test_custom_suffix_template(self):
+        """Custom suffix template → used correctly."""
+        text = "\n".join(f"line{i}" for i in range(10))
+        result = _truncate_reasoning_lines(text, 3, " [showing 3 of {n} more]")
+        assert result == "line0\nline1\nline2 [showing 3 of 7 more]"
+
+
+class _RecapStub:
+    """Minimal carrier for the CLI recap production seam.
+
+    Attributes are resolved through the production path (CLI init resolves
+    ``reasoning_max_lines_recap`` from config via ``resolve_reasoning_max_lines``
+    with the legacy 10-line default), and the recap decision is the real
+    ``HermesCLI._build_reasoning_recap`` method — so these tests exercise the
+    actual CLI renderer decision, not a local reimplementation.
+    """
+
+    def __init__(self, config, reasoning_full=False):
+        self.reasoning_full = reasoning_full
+        self.reasoning_max_lines_recap = resolve_reasoning_max_lines(config, 10)
+        import cli
+        self._build_reasoning_recap = cli.HermesCLI._build_reasoning_recap.__get__(self)
+
+
+class TestReasoningFullPrecedence:
+    """Test reasoning_full precedence over reasoning_max_lines via the CLI seam."""
+
+    def test_reasoning_full_overrides_max_lines(self):
+        """reasoning_full=True → reasoning_max_lines ignored (full recap)."""
+        reasoning = "\n".join(f"line{i}" for i in range(20))
+        stub = _RecapStub(
+            {"display": {"reasoning_max_lines": 10}}, reasoning_full=True
+        )
+        display_reasoning = stub._build_reasoning_recap(reasoning)
+        # With reasoning_full=True, all 20 lines are shown uncollapsed.
+        assert len(display_reasoning.splitlines()) == 20
+
+    def test_reasoning_max_lines_when_full_false(self):
+        """reasoning_full=False → reasoning_max_lines applied to recap."""
+        reasoning = "\n".join(f"line{i}" for i in range(20))
+        stub = _RecapStub(
+            {"display": {"reasoning_max_lines": 10}}, reasoning_full=False
+        )
+        display_reasoning = stub._build_reasoning_recap(reasoning)
+        # Truncated to 10 content lines + 1 suffix line (with /reasoning full hint).
+        lines = display_reasoning.splitlines()
+        assert len(lines) == 11
+        assert "... (10 more lines — /reasoning full to show)" in lines[-1]
+
+    def test_recap_defaults_to_10_when_unset(self):
+        """Key absent → CLI recap keeps the legacy 10-line default."""
+        reasoning = "\n".join(f"line{i}" for i in range(20))
+        stub = _RecapStub({}, reasoning_full=False)
+        display_reasoning = stub._build_reasoning_recap(reasoning)
+        lines = display_reasoning.splitlines()
+        assert len(lines) == 11  # 10 content lines + suffix
+        assert "... (10 more lines — /reasoning full to show)" in lines[-1]
+
+    def test_recap_unlimited_when_explicit_zero(self):
+        """Explicit 0 → recap is unlimited even with reasoning_full=False."""
+        reasoning = "\n".join(f"line{i}" for i in range(20))
+        stub = _RecapStub(
+            {"display": {"reasoning_max_lines": 0}}, reasoning_full=False
+        )
+        display_reasoning = stub._build_reasoning_recap(reasoning)
+        assert len(display_reasoning.splitlines()) == 20
+
+
+class TestCodeFenceRegression:
+    """Test code-fence/backtick escaping after truncation."""
+
+    def test_truncation_then_escape(self):
+        """Truncate first, then escape code fences."""
+        # Reasoning with code fences
+        reasoning = "\n".join([
+            "Thinking about code:",
+            "```python",
+            "def foo():",
+            "    pass",
+            "```",
+            "More thinking:",
+            "```javascript",
+            "function bar() {}",
+            "```",
+            "Final thoughts",
+        ])
+
+        # Truncate to 8 lines (includes both code blocks)
+        truncated = _truncate_reasoning_lines(reasoning, 8, "\n... ({n} more lines)")
+
+        # Then escape for display
+        escaped = escape_code_fences_for_display(truncated)
+
+        # Verify truncation happened
+        assert len(truncated.splitlines()) == 9  # 8 + suffix
+
+        # Verify code fences were escaped
+        assert "\\`\\`\\`python" in escaped
+        assert "\\`\\`\\`javascript" in escaped
+
+    def test_truncation_preserves_fence_balance(self):
+        """Truncation doesn't break fence balance in unexpected ways."""
+        reasoning = "\n".join([
+            "```",
+            "code block",
+            "```",
+            "more text",
+            "```",
+            "another block",
+            "```",
+        ])
+
+        truncated = _truncate_reasoning_lines(reasoning, 4, "\n... ({n} more lines)")
+        escaped = escape_code_fences_for_display(truncated)
+
+        # Should have escaped all fences in the truncated output
+        # First 4 lines: ```, code block, ```, more text
+        # So 2 fences should be escaped
+        assert escaped.count("\\`\\`\\`") == 2
+
+    def test_backtick_not_escaped(self):
+        """Single backticks are not escaped (only triple backticks)."""
+        reasoning = "Use `code` inline and ```block``` for code"
+        escaped = escape_code_fences_for_display(reasoning)
+
+        # Single backticks preserved
+        assert "`code`" in escaped
+        # Triple backticks escaped
+        assert "\\`\\`\\`block\\`\\`\\`" in escaped
+
+
+


### PR DESCRIPTION
## Configurable Reasoning Display — feature line

Implements #116 as one small coherent feature line (`feature:reasoning-display`), per the Wayfinder topology update: PR itself is the complete feature intent; no wrapper/child `line:` PR is needed.

One optional `display.reasoning_max_lines` setting controls the maintained reasoning-display caps across CLI/gateway while preserving each surface's legacy default, explicit `0 = unlimited`, `reasoning_full` precedence, and the existing escaping pipeline.

### Commit intents

1. `feat(display): make reasoning display line cap configurable` — production semantics
   - `agent/display.py`: `resolve_reasoning_max_lines()` production seam (absent/invalid/negative/bool → surface default; explicit `0` → unlimited; positive int → cap) + shared `_truncate_reasoning_lines()` (truncate before existing fence-escape pipeline).
   - `cli.py`: resolve preview/recap caps once at init from already-resolved `CLI_CONFIG` (no hot-path reload); apply to 5-line preview + 10-line recap with `reasoning_full` precedence via `_build_reasoning_recap()`.
   - `gateway/run.py`: apply cap at 15-line recap seam via shared helper.
2. `test(display): prove reasoning_max_lines behavior through production seams` — acceptance/evidence
   - Resolver/truncation edge cases; `reasoning_full` precedence through the real `HermesCLI._build_reasoning_recap()` seam; fence/backtick regression.

### Semantics (accepted behavior contract)

- Key absent → surface-specific legacy default (CLI preview 5, CLI recap 10, gateway recap 15)
- Missing/invalid/negative/boolean → safe fallback to surface default
- Explicit `0` → unlimited
- Positive integer / integer-like string → configured cap
- CLI final recap precedence: `reasoning_full` > `reasoning_max_lines` > legacy 10
- Truncate first, then existing `escape_code_fences_for_display()` — pipeline untouched
- `reasoning_max_lines` intentionally NOT in `DEFAULT_CONFIG` (preserves absent-vs-explicit-0 distinction per spec)

### Verification

- 70/70 reasoning tests pass (32 new + 38 existing, no regressions)
- Tests exercise production seams, not local reimplementations
- No hot-path config reload (avoids #48478 defect 1)
- Tests exercise production helpers/callers (avoids #48478 defect 2)

Closes #116
